### PR TITLE
fix(banner) Reverse for https://github.com/Leanplum/Leanplum-Android-SDK/pull/16

### DIFF
--- a/AndroidSDK/src/com/leanplum/messagetemplates/BaseMessageDialog.java
+++ b/AndroidSDK/src/com/leanplum/messagetemplates/BaseMessageDialog.java
@@ -488,7 +488,7 @@ public class BaseMessageDialog extends Dialog {
           if (!TextUtils.isEmpty(queryComponentsFromUrl)) {
             Leanplum.track(queryComponentsFromUrl);
           }
-          return false;
+          return true;
         }
 
         // Track URL event.


### PR DESCRIPTION
We fixed banner issue in html template.

Returning true - javascript in Webview is allowed to do more work after the close button is clicked.
Returning false - javascript in Webview is NOT allowed to do more work after the close button is clicked.