### PR TITLE
fix(NPE) wrapping creation notification in try{}catch block to avoid …

### DIFF
--- a/AndroidSDK/src/com/leanplum/LeanplumPushService.java
+++ b/AndroidSDK/src/com/leanplum/LeanplumPushService.java
@@ -366,7 +366,15 @@ public class LeanplumPushService {
         notificationId = value.hashCode();
       }
     }
-    notificationManager.notify(notificationId, builder.build());
+
+    try {
+      notificationManager.notify(notificationId, builder.build());
+    } catch (NullPointerException e) {
+      Log.e("Unable to show push notification.", e);
+    } catch (Throwable t) {
+      Log.e("Unable to show push notification.", t);
+      Util.handleException(t);
+    }
   }
 
   static void openNotification(Context context, Intent intent) {


### PR DESCRIPTION
…NPE.

getProfiles at this line
https://github.com/android/platform_frameworks_base/blob/d7b1f41109abee60ec8529369a85d84300b1d678/core/java/android/app/ApplicationPackageManager.java#L2306 can return null and it will crash with NPE at next line.
