### PR TITLE
fix(LocalPush):  fix for locally triggered notifications appear after…

### DIFF
--- a/AndroidSDK/src/com/leanplum/internal/ActionManager.java
+++ b/AndroidSDK/src/com/leanplum/internal/ActionManager.java
@@ -233,7 +233,7 @@ public class ActionManager {
           SharedPreferencesUtil.commitChanges(editor);
 
           // Cancel notification.
-          Intent intentAlarm = new Intent(context, LeanplumPushService.class);
+          Intent intentAlarm = new Intent(context, LeanplumLocalPushListenerService.class);
           AlarmManager alarmManager = (AlarmManager) context.getSystemService(Context.ALARM_SERVICE);
           PendingIntent existingIntent = PendingIntent.getService(
               context, messageId.hashCode(), intentAlarm, PendingIntent.FLAG_UPDATE_CURRENT);


### PR DESCRIPTION
… notification was canceled.

We tried to cancel intent to LeanplumPushService.class but we should cancel intent to LeanplumLocalPushListenerService.class because the original intent was created for LeanplumLocalPushListenerService.class.