### PR TITLE
fix(Geofencing): change logging type from error to warning for Geofen…

### DIFF
--- a/AndroidSDK/src/com/leanplum/internal/ActionManager.java
+++ b/AndroidSDK/src/com/leanplum/internal/ActionManager.java
@@ -87,7 +87,7 @@ public class ActionManager {
         }
       } catch (Throwable e) {
         if (!loggedLocationManagerFailure) {
-          Log.e("Geofencing support requires Google Play Services v8.1 and higher.\n" +
+          Log.w("Geofencing support requires Google Play Services v8.1 and higher.\n" +
               "Add this to your build.gradle file:\n" +
               "compile ('com.google.android.gms:play-services-location:8.3.0+')");
           loggedLocationManagerFailure = true;


### PR DESCRIPTION
fix(Geofencing): change logging type from error to warning for Geofencing support message.

Some clients won't use Location services and they don't want to see an error message in the log.