### PR TITLE
fix(Networking): keep requests when status code from an HTTP response…

### DIFF
--- a/AndroidSDK/src/com/leanplum/internal/Request.java
+++ b/AndroidSDK/src/com/leanplum/internal/Request.java
@@ -524,7 +524,7 @@ public class Request {
           }
         } else {
           errorException = new Exception("HTTP error " + statusCode);
-          if (statusCode != 408 && !(statusCode >= 500 && statusCode <= 599)) {
+          if (statusCode != -1 && statusCode != 408 && !(statusCode >= 500 && statusCode <= 599)) {
             deleteSentRequests(unsentRequests.size());
             parseResponseBody(responseBody, requestsToSend, errorException, unsentRequests.size());
           }


### PR DESCRIPTION
… message equals -1.
getResponseCode  returns -1 if no status code from an HTTP response can be discerned, at this time we should keep requests too.