### PR TITLE
fix(HtmlTemplate):  Now event parameter value can be used in the HTML…

### DIFF
--- a/AndroidSDK/src/com/leanplum/ActionContext.java
+++ b/AndroidSDK/src/com/leanplum/ActionContext.java
@@ -226,7 +226,7 @@ public class ActionContext extends BaseActionContext implements Comparable<Actio
     }
   }
 
-  private String fillTemplate(String value) {
+  public String fillTemplate(String value) {
     if (contextualValues == null || value == null || !value.contains("##")) {
       return value;
     }

--- a/AndroidSDK/src/com/leanplum/messagetemplates/HTMLOptions.java
+++ b/AndroidSDK/src/com/leanplum/messagetemplates/HTMLOptions.java
@@ -170,8 +170,14 @@ class HTMLOptions {
     try {
       htmlString = (htmlTemplate.replace("##Vars##",
           ActionContext.mapToJsonObject(htmlArgs).toString()));
+      try {
+        htmlString = context.fillTemplate(htmlString);
+      } catch (Throwable ignored) {
+      }
     } catch (JSONException e) {
       Log.e("Leanplum", "Cannot convert map of arguments to JSON object.");
+    } catch (Throwable t) {
+      Log.e("Leanplum", "Cannot get html template.", t);
     }
     return htmlString.replace("\\/", "/");
   }


### PR DESCRIPTION
fix(HtmlTemplate):  Now event parameter value can be used in the HTML template.

We need to replace "##Parameter" before sending HTML to webview.