### PR TITLE
feat(deprecation): removing deprecated methods toArgs and register fr…

### DIFF
--- a/AndroidSDK/src/com/leanplum/messagetemplates/WebInterstitial.java
+++ b/AndroidSDK/src/com/leanplum/messagetemplates/WebInterstitial.java
@@ -43,15 +43,6 @@ public class WebInterstitial extends BaseMessageDialog {
     this.webOptions = options;
   }
 
-  /**
-   * Deprecated: Use {@link WebInterstitial#register()}.
-   */
-  @Deprecated
-  @SuppressWarnings("unused")
-  public static void register(Context currentContext) {
-    register();
-  }
-
   public static void register() {
     Leanplum.defineAction(NAME, Leanplum.ACTION_KIND_MESSAGE | Leanplum.ACTION_KIND_ACTION,
         WebInterstitialOptions.toArgs(), new ActionCallback() {

--- a/AndroidSDK/src/com/leanplum/messagetemplates/WebInterstitialOptions.java
+++ b/AndroidSDK/src/com/leanplum/messagetemplates/WebInterstitialOptions.java
@@ -69,15 +69,6 @@ public class WebInterstitialOptions {
     this.closeUrl = closeUrl;
   }
 
-  /**
-   * Deprecated: Use {@link WebInterstitialOptions#toArgs()}.
-   */
-  @Deprecated
-  @SuppressWarnings("unused")
-  public static ActionArgs toArgs(Context currentContext) {
-    return toArgs();
-  }
-
   public static ActionArgs toArgs() {
     return new ActionArgs()
         .with(Args.URL, Values.DEFAULT_URL)


### PR DESCRIPTION
Removing deprecated methods toArgs(Context currentContext) and register(Context currentContext) from WebInterstitial and WebInterstitialOptions. Please use methods toArgs() and register().