### PR TITLE
Add applyVars endpoint to Websocket client.

### DIFF
--- a/AndroidSDK/src/com/leanplum/internal/Socket.java
+++ b/AndroidSDK/src/com/leanplum/internal/Socket.java
@@ -60,6 +60,7 @@ public class Socket {
   private static final String EVENT_GET_VARIABLES = "getVariables";
   private static final String EVENT_GET_ACTIONS = "getActions";
   private static final String EVENT_REGISTER_DEVICE = "registerDevice";
+  private static final String EVENT_APPLY_VARS = "applyVars";
 
   private static Socket instance = new Socket();
   private SocketIOClient sio;
@@ -137,6 +138,9 @@ public class Socket {
               break;
             case EVENT_REGISTER_DEVICE:
               handleRegisterDeviceEvent(arguments);
+              break;
+            case EVENT_APPLY_VARS:
+              handleApplyVarsEvent(arguments);
               break;
             default:
               break;
@@ -287,6 +291,24 @@ public class Socket {
         });
       }
     });
+  }
+
+  /**
+   * Apply variables passed in from applyVars endpoint.
+   */
+  static void handleApplyVarsEvent(JSONArray args) {
+    try {
+      JSONObject object = args.getJSONObject(0);
+      if (object == null) {
+        return;
+      }
+      VarCache.applyVariableDiffs(
+          JsonConverter.mapFromJson(object), null, null, null, null, null);
+    } catch (JSONException e) {
+      Log.e("Couldn't applyVars for preview.", e);
+    } catch (Throwable e) {
+      Util.handleException(e);
+    }
   }
 
   void previewUpdateRules(JSONArray arguments) {

--- a/AndroidSDKTests/src/test/java/com/leanplum/internal/SocketTest.java
+++ b/AndroidSDKTests/src/test/java/com/leanplum/internal/SocketTest.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2017, Leanplum, Inc. All rights reserved.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.leanplum.internal;
+
+import com.leanplum.Var;
+import com.leanplum.__setup.LeanplumTestApp;
+import com.leanplum.__setup.LeanplumTestRunner;
+import org.json.JSONArray;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
+import org.robolectric.annotation.Config;
+
+/**
+ * Tests for {@link Socket} class.
+ *
+ * @author Lev Neiman
+ */
+@RunWith(LeanplumTestRunner.class)
+@Config(
+    constants = com.leanplum.BuildConfig.class,
+    sdk = 16,
+    application = LeanplumTestApp.class
+)
+@PowerMockIgnore({
+    "org.mockito.*",
+    "org.robolectric.*",
+    "org.json.*",
+    "org.powermock.*",
+    "android.*"
+})
+public class SocketTest {
+  @Test
+  public void testApplyVars() throws Exception {
+    // Given:  We have a string variable foo -> baz
+    VarCache.registerVariable(Var.define("foo", "baz"));
+    Var<String> val =  VarCache.<String>getVariable("foo");
+    Assert.assertEquals("baz", val.stringValue);
+
+    String jsonString = "[{\"foo\":\"bar\"}]";
+
+    // When:  Socket calls handleApplyVarsEvent with JSON array of foo -> bar
+    Socket.handleApplyVarsEvent(new JSONArray(jsonString));
+
+    // Then:  VarCache now contains new mapping of foo -> bar
+    val = VarCache.<String>getVariable("foo");
+    Assert.assertNotNull(val);
+    Assert.assertEquals("bar", val.stringValue);
+  }
+}


### PR DESCRIPTION
Support `applyVars` endpoint in WebSocket client in order to support variable previews via sending of variable values directly to the test device.

Tested via local node-server instance and test device.