### PR TITLE
fix: Retrieve chained message if it doesn't exist locally yet.

### DIFF
--- a/AndroidSDK/src/com/leanplum/ActionContext.java
+++ b/AndroidSDK/src/com/leanplum/ActionContext.java
@@ -374,8 +374,8 @@ public class ActionContext extends BaseActionContext implements Comparable<Actio
   /**
    * Return true if here was an action for this message and we started it.
    */
-  private boolean createActionContextForMessageId(String messageAction, Map<String, Object>
-      messageArgs, String messageId, String name, Boolean chained) {
+  private boolean createActionContextForMessageId(String messageAction,
+      Map<String, Object> messageArgs, String messageId, String name, Boolean chained) {
     try {
       final ActionContext actionContext = new ActionContext(messageAction,
           messageArgs, messageId);
@@ -406,27 +406,68 @@ public class ActionContext extends BaseActionContext implements Comparable<Actio
   }
 
   /**
-   * Return true if here was action "Chain to Existing Message" and we started it.
+   * Return true if there was action "Chain to Existing Message" and we started it.
    */
-  private boolean isChainToExistingMessageStarted(Map<String, Object> args, String name) {
+  private boolean isChainToExistingMessageStarted(Map<String, Object> args, final String name) {
     if (args == null) {
       return false;
     }
 
-    String messageId = (String) args.get(Constants.Values.CHAIN_MESSAGE_ARG);
-    Object actionType = args.get(Constants.Values.ACTION_ARG);
-    if (messageId != null && Constants.Values.CHAIN_MESSAGE_ACTION_NAME.equals(actionType)) {
-      Map<String, Object> messages = VarCache.messages();
-      if (messages != null && messages.containsKey(messageId)) {
-        Map<String, Object> message = CollectionUtil.uncheckedCast(messages.get(messageId));
-        if (message != null) {
-          Map<String, Object> messageArgs = CollectionUtil.uncheckedCast(
-              message.get(Constants.Keys.VARS));
-          Object messageAction = message.get("action");
-          return messageAction != null && createActionContextForMessageId(messageAction.toString(),
-              messageArgs, messageId, name, true);
+    final String messageId = getChainedMessageId(args);
+    if (!shouldForceContentUpdateForChainedMessage(args)) {
+      return executeChainedMessage(messageId, VarCache.messages(), name);
+    } else {
+      // message may not on the device yet, so we need to fetch it.
+      Leanplum.forceContentUpdate(new VariablesChangedCallback() {
+        @Override
+        public void variablesChanged() {
+          executeChainedMessage(messageId, VarCache.messages(), name);
         }
+      });
+    }
+    return false;
+  }
+
+  /**
+   * Return true if there is a chained message in the actionMap that is not yet loaded onto the device.
+   */
+  static boolean shouldForceContentUpdateForChainedMessage(Map<String, Object> actionMap) {
+    if (actionMap == null) {
+      return false;
+    }
+    String chainedMessageId = getChainedMessageId(actionMap);
+    if (chainedMessageId != null
+            && (VarCache.messages() == null || !VarCache.messages().containsKey(chainedMessageId))) {
+        return true;
+    }
+    return false;
+  }
+
+  /**
+   * Extract chained messageId from parent message's actionMap.  If it doesn't exist then return null.
+   */
+  static String getChainedMessageId(Map<String, Object> actionMap) {
+    if (actionMap != null) {
+      if (Constants.Values.CHAIN_MESSAGE_ACTION_NAME.equals(actionMap.get(Constants.Values.ACTION_ARG))) {
+        return (String) actionMap.get(Constants.Values.CHAIN_MESSAGE_ARG);
       }
+    }
+    return null;
+  }
+
+
+  private boolean executeChainedMessage(String messageId, Map<String, Object> messages,
+                                        String name) {
+    if (messages == null) {
+      return false;
+    }
+    Map<String, Object> message = CollectionUtil.uncheckedCast(messages.get(messageId));
+    if (message != null) {
+      Map<String, Object> messageArgs = CollectionUtil.uncheckedCast(
+              message.get(Constants.Keys.VARS));
+      Object messageAction = message.get("action");
+      return messageAction != null && createActionContextForMessageId(messageAction.toString(),
+              messageArgs, messageId, name, true);
     }
     return false;
   }


### PR DESCRIPTION
https://leanplum.atlassian.net/browse/LP-6124?filter=-1

Tested in staging by setting up a case where:

  * App is already running.
  * On dashboard I create a new In-App message that is active.
  * Create a push message with open existing message pointing to the just created in-app message.
  * Send out Push as preview, and have the test app display in-app message after i open the push notification.