### PR TITLE
fix(AndroidO/AdaptiveIcons): Fix for System crash when the client receive…

### DIFF
--- a/AndroidSDK/src/com/leanplum/LeanplumNotificationHelper.java
+++ b/AndroidSDK/src/com/leanplum/LeanplumNotificationHelper.java
@@ -291,8 +291,8 @@ class LeanplumNotificationHelper {
       return false;
     }
 
-    //TODO: Potentially there should be checked for Build.VERSION.SDK_INT != 26, but we need to
-    //TODO: confirm that adaptive icon works well on 27, before to change it.
+    // TODO: Potentially there should be checked for Build.VERSION.SDK_INT != 26, but we need to
+    // TODO: confirm that adaptive icon works well on 27, before to change it.
     if (Build.VERSION.SDK_INT < 26) {
       return true;
     }

--- a/AndroidSDK/src/com/leanplum/LeanplumNotificationHelper.java
+++ b/AndroidSDK/src/com/leanplum/LeanplumNotificationHelper.java
@@ -25,6 +25,8 @@ import android.app.PendingIntent;
 import android.content.Context;
 import android.content.res.Resources;
 import android.graphics.Bitmap;
+import android.graphics.drawable.AdaptiveIconDrawable;
+import android.graphics.drawable.Drawable;
 import android.os.Build;
 import android.os.Bundle;
 import android.support.v4.app.NotificationCompat;
@@ -48,6 +50,7 @@ class LeanplumNotificationHelper {
 
   private static final int BIGPICTURE_TEXT_TOP_PADDING = -14;
   private static final int BIGPICTURE_TEXT_SIZE = 14;
+  private static final String LEANPLUM_DEFAULT_PUSH_ICON = "leanplum_default_push_icon";
 
   /**
    * If notification channels are supported this method will try to create
@@ -192,17 +195,23 @@ class LeanplumNotificationHelper {
    * @param title String with title for push notification.
    * @param messageText String with text for push notification.
    * @param bigPicture Bitmap for BigPictureStyle notification.
+   * @param defaultNotificationIconResourceId int Resource id for default push notification.
    * @return Notification.Builder or null.
    */
   static Notification.Builder getNotificationBuilder(Context context, Bundle message,
-      PendingIntent contentIntent, String title, final String messageText, Bitmap bigPicture) {
+      PendingIntent contentIntent, String title, final String messageText, Bitmap bigPicture,
+      int defaultNotificationIconResourceId) {
     if (Build.VERSION.SDK_INT < 16) {
       return null;
     }
     Notification.Builder notificationBuilder =
         getNotificationBuilder(context, message);
-    notificationBuilder.setSmallIcon(context.getApplicationInfo().icon)
-        .setContentTitle(title)
+    if (defaultNotificationIconResourceId == 0) {
+      notificationBuilder.setSmallIcon(context.getApplicationInfo().icon);
+    } else {
+      notificationBuilder.setSmallIcon(defaultNotificationIconResourceId);
+    }
+    notificationBuilder.setContentTitle(title)
         .setContentText(messageText);
     Notification.BigPictureStyle bigPictureStyle = new Notification.BigPictureStyle() {
       @Override
@@ -248,5 +257,65 @@ class LeanplumNotificationHelper {
     notificationBuilder.setAutoCancel(true);
     notificationBuilder.setContentIntent(contentIntent);
     return notificationBuilder;
+  }
+
+  /**
+   * Checks a possibility to create icon drawable from current app icon.
+   *
+   * @param context Current application context.
+   * @return boolean True if it is possible to create a drawable from current app icon.
+   */
+  private static boolean canCreateIconDrawable(Context context) {
+    try {
+      // Try to create icon drawable.
+      Drawable drawable = AdaptiveIconDrawable.createFromStream(
+          context.getResources().openRawResource(context.getApplicationInfo().icon),
+          "applicationInfo.icon");
+      // If there was no crash, we still need to check for null.
+      if (drawable != null) {
+        return true;
+      }
+    } catch (Throwable ignored) {
+    }
+    return false;
+  }
+
+  /**
+   * Validation of Application icon for small icon on push notification.
+   *
+   * @param context Current application context.
+   * @return boolean True if application icon can be used for small icon on push notification.
+   */
+  static boolean isApplicationIconValid(Context context) {
+    if (context == null) {
+      return false;
+    }
+
+    //TODO Potentially there should be checked for Build.VERSION.SDK_INT != 26, but we need to
+    //TODO confirm that adaptive icon works well on 27, before to change it.
+    // Checks current version of device. If current version less than 26, we can skip next step.
+    if (Build.VERSION.SDK_INT < 26) {
+      return true;
+    }
+
+    //If there is Android Oreo and app, we need to check for a possibility to create icon drawable
+    // from current app icon.
+    return canCreateIconDrawable(context);
+  }
+
+  /**
+   * Gets default push notification resource id for LEANPLUM_DEFAULT_PUSH_ICON in drawable.
+   *
+   * @param context Current application context.
+   * @return int Resource id.
+   */
+  static int getDefaultPushNotificationIconResourceId(Context context) {
+    try {
+      Resources resources = context.getResources();
+      return resources.getIdentifier(LEANPLUM_DEFAULT_PUSH_ICON, "drawable",
+          context.getPackageName());
+    } catch (Throwable ignored) {
+      return 0;
+    }
   }
 }

--- a/AndroidSDK/src/com/leanplum/LeanplumNotificationHelper.java
+++ b/AndroidSDK/src/com/leanplum/LeanplumNotificationHelper.java
@@ -195,7 +195,7 @@ class LeanplumNotificationHelper {
    * @param title String with title for push notification.
    * @param messageText String with text for push notification.
    * @param bigPicture Bitmap for BigPictureStyle notification.
-   * @param defaultNotificationIconResourceId int Resource id for default push notification.
+   * @param defaultNotificationIconResourceId int Resource id for default push notification icon.
    * @return Notification.Builder or null.
    */
   static Notification.Builder getNotificationBuilder(Context context, Bundle message,
@@ -291,15 +291,12 @@ class LeanplumNotificationHelper {
       return false;
     }
 
-    //TODO Potentially there should be checked for Build.VERSION.SDK_INT != 26, but we need to
-    //TODO confirm that adaptive icon works well on 27, before to change it.
-    // Checks current version of device. If current version less than 26, we can skip next step.
+    //TODO: Potentially there should be checked for Build.VERSION.SDK_INT != 26, but we need to
+    //TODO: confirm that adaptive icon works well on 27, before to change it.
     if (Build.VERSION.SDK_INT < 26) {
       return true;
     }
 
-    //If there is Android Oreo and app, we need to check for a possibility to create icon drawable
-    // from current app icon.
     return canCreateIconDrawable(context);
   }
 

--- a/AndroidSDK/src/com/leanplum/LeanplumPushService.java
+++ b/AndroidSDK/src/com/leanplum/LeanplumPushService.java
@@ -307,13 +307,13 @@ public class LeanplumPushService {
     }
 
     int defaultIconId = 0;
-    // If client will start to use Adaptive icon, there can be a problem
+    // If client will start to use adaptive icon, there can be a problem
     // https://issuetracker.google.com/issues/68716460 that can cause a factory reset of the device
     // on Android Version 26.
     if (!LeanplumNotificationHelper.isApplicationIconValid(context)) {
       defaultIconId = LeanplumNotificationHelper.getDefaultPushNotificationIconResourceId(context);
       if (defaultIconId == 0) {
-        Log.e("You are using Adaptive icons without having a fallback icon for push" +
+        Log.e("You are using adaptive icons without having a fallback icon for push" +
             " notifications on Android Oreo. \n" + "This can cause a factory reset of the device" +
             " on Android Version 26. Please add regular icon with name " +
             "\"leanplum_default_push_icon.png\" to your \"drawable\" folder.\n" + "Google issue: " +

--- a/AndroidSDK/src/com/leanplum/LeanplumPushService.java
+++ b/AndroidSDK/src/com/leanplum/LeanplumPushService.java
@@ -306,6 +306,23 @@ public class LeanplumPushService {
       return;
     }
 
+    int defaultIconId = 0;
+    // If client will start to use Adaptive icon, there can be a problem
+    // https://issuetracker.google.com/issues/68716460 that can cause a factory reset of the device
+    // on Android Version 26.
+    if (!LeanplumNotificationHelper.isApplicationIconValid(context)) {
+      defaultIconId = LeanplumNotificationHelper.getDefaultPushNotificationIconResourceId(context);
+      if (defaultIconId == 0) {
+        Log.e("You are using Adaptive icons without having a fallback icon for push" +
+            " notifications on Android Oreo. \n" + "This can cause a factory reset of the device" +
+            " on Android Version 26. Please add regular icon with name " +
+            "\"leanplum_default_push_icon.png\" to your \"drawable\" folder.\n" + "Google issue: " +
+            "https://issuetracker.google.com/issues/68716460"
+        );
+        return;
+      }
+    }
+
     final NotificationManager notificationManager = (NotificationManager)
         context.getSystemService(Context.NOTIFICATION_SERVICE);
 
@@ -327,8 +344,14 @@ public class LeanplumPushService {
       return;
     }
     final String messageText = message.getString(Keys.PUSH_MESSAGE_TEXT);
-    notificationCompatBuilder.setSmallIcon(context.getApplicationInfo().icon)
-        .setContentTitle(title)
+
+    if (defaultIconId == 0) {
+      notificationCompatBuilder.setSmallIcon(context.getApplicationInfo().icon);
+    } else {
+      notificationCompatBuilder.setSmallIcon(defaultIconId);
+    }
+
+    notificationCompatBuilder.setContentTitle(title)
         .setStyle(new NotificationCompat.BigTextStyle()
             .bigText(messageText))
         .setContentText(messageText);
@@ -346,8 +369,8 @@ public class LeanplumPushService {
               .setBigContentTitle(title)
               .setSummaryText(messageText));
         } else {
-          notificationBuilder = LeanplumNotificationHelper.getNotificationBuilder(context, message, contentIntent, title,
-              messageText, bigPicture);
+          notificationBuilder = LeanplumNotificationHelper.getNotificationBuilder(context, message,
+              contentIntent, title, messageText, bigPicture, defaultIconId);
         }
       } else {
         Log.w(String.format("Image download failed for push notification with big picture. " +


### PR DESCRIPTION
fix(AndroidO/AdaptiveIcons): Fix for System crash when the client receives a push notification and using an Adaptive icon on Android O.

On Android O if the client will start using an Adaptive icon that can cause a factory reset of the device. We need to ask the client to add a regular icon with name "leanplum_default_push_icon.png" to"drawable" folder to avoid this. There is a Google issue: [https://issuetracker.google.com/issues/68716460](https://issuetracker.google.com/issues/68716460)