### PR TITLE
Addedded ability to define custom PushListenerService and PushReceiver

### DIFF
--- a/AndroidSDK/src/com/leanplum/LeanplumGcmProvider.java
+++ b/AndroidSDK/src/com/leanplum/LeanplumGcmProvider.java
@@ -128,15 +128,28 @@ class LeanplumGcmProvider extends LeanplumCloudMessagingProvider {
           LeanplumManifestHelper.ApplicationComponent.RECEIVER, LeanplumManifestHelper.GCM_RECEIVER,
           true, LeanplumManifestHelper.GCM_SEND_PERMISSION, Arrays.asList(LeanplumManifestHelper.GCM_RECEIVE_ACTION,
               LeanplumManifestHelper.GCM_REGISTRATION_ACTION), context.getPackageName());
+
+      String pushReceiverClassName = LeanplumManifestHelper.getStringMetadata(context, LeanplumManifestHelper.LP_PUSH_RECEIVER_KEY);
+      if(pushReceiverClassName == null || pushReceiverClassName.isEmpty())
+      {
+        pushReceiverClassName = LeanplumManifestHelper.LP_PUSH_RECEIVER;
+      }
+
+      String pushListenerServiceClassName = LeanplumManifestHelper.getStringMetadata(context, LeanplumManifestHelper.LP_PUSH_LISTENER_SERVICE_KEY);
+      if(pushListenerServiceClassName == null || pushListenerServiceClassName.isEmpty())
+      {
+        pushListenerServiceClassName = LeanplumManifestHelper.LP_PUSH_LISTENER_SERVICE;
+      }
+
       boolean hasPushReceiver = LeanplumManifestHelper.checkComponent(LeanplumManifestHelper.ApplicationComponent.RECEIVER,
-          LeanplumManifestHelper.LP_PUSH_RECEIVER, false, null,
-          Collections.singletonList(LeanplumManifestHelper.LP_PUSH_LISTENER_SERVICE), context.getPackageName());
+              pushReceiverClassName, false, null,
+          Collections.singletonList(pushListenerServiceClassName), context.getPackageName());
 
       boolean hasReceivers = hasGcmReceiver && hasPushReceiver;
 
       boolean hasPushListenerService = LeanplumManifestHelper.checkComponent(
           LeanplumManifestHelper.ApplicationComponent.SERVICE,
-          LeanplumManifestHelper.LP_PUSH_LISTENER_SERVICE, false, null,
+              pushListenerServiceClassName, false, null,
           Collections.singletonList(LeanplumManifestHelper.GCM_RECEIVE_ACTION), context.getPackageName());
       boolean hasInstanceIdService = LeanplumManifestHelper.checkComponent(
           LeanplumManifestHelper.ApplicationComponent.SERVICE,

--- a/AndroidSDK/src/com/leanplum/LeanplumPushService.java
+++ b/AndroidSDK/src/com/leanplum/LeanplumPushService.java
@@ -326,7 +326,14 @@ public class LeanplumPushService {
     final NotificationManager notificationManager = (NotificationManager)
         context.getSystemService(Context.NOTIFICATION_SERVICE);
 
-    Intent intent = new Intent(context, LeanplumPushReceiver.class);
+    String pushReceiverClassName = LeanplumManifestHelper.getStringMetadata(context, LeanplumManifestHelper.LP_PUSH_RECEIVER_KEY);
+    if(pushReceiverClassName == null || pushReceiverClassName.isEmpty())
+    {
+      pushReceiverClassName = LeanplumManifestHelper.LP_PUSH_RECEIVER;
+    }
+    Class pushReceiverClass = LeanplumManifestHelper.getClassForName(pushReceiverClassName);
+
+    Intent intent = new Intent(context, pushReceiverClass);
     intent.addCategory("lpAction");
     intent.putExtras(message);
     PendingIntent contentIntent = PendingIntent.getBroadcast(
@@ -822,7 +829,14 @@ public class LeanplumPushService {
       if (gcmReceiver != null) {
         LeanplumManifestHelper.enableComponent(context, packageManager, gcmReceiver);
       }
-      Class pushListener = LeanplumManifestHelper.getClassForName(LEANPLUM_PUSH_LISTENER_SERVICE_CLASS);
+
+      String pushListenerServiceClassName = LeanplumManifestHelper.getStringMetadata(context, LeanplumManifestHelper.LP_PUSH_LISTENER_SERVICE_KEY);
+      if(pushListenerServiceClassName == null || pushListenerServiceClassName.isEmpty())
+      {
+        pushListenerServiceClassName = LeanplumManifestHelper.LP_PUSH_LISTENER_SERVICE;
+      }
+
+      Class pushListener = LeanplumManifestHelper.getClassForName(pushListenerServiceClassName);
       if (pushListener != null) {
         LeanplumManifestHelper.enableComponent(context, packageManager, pushListener);
       }
@@ -864,12 +878,18 @@ public class LeanplumPushService {
       return;
     }
 
+    String pushListenerServiceClassName = LeanplumManifestHelper.getStringMetadata(context, LeanplumManifestHelper.LP_PUSH_LISTENER_SERVICE_KEY);
+    if(pushListenerServiceClassName == null || pushListenerServiceClassName.isEmpty())
+    {
+      pushListenerServiceClassName = LeanplumManifestHelper.LP_PUSH_LISTENER_SERVICE;
+    }
+
     LeanplumManifestHelper.disableComponent(context, packageManager,
         LEANPLUM_PUSH_INSTANCE_ID_SERVICE_CLASS);
     LeanplumManifestHelper.disableComponent(context, packageManager,
         GCM_RECEIVER_CLASS);
     LeanplumManifestHelper.disableComponent(context, packageManager,
-        LEANPLUM_PUSH_LISTENER_SERVICE_CLASS);
+            pushListenerServiceClassName);
   }
 
   /**

--- a/AndroidSDK/src/com/leanplum/internal/LeanplumManifestHelper.java
+++ b/AndroidSDK/src/com/leanplum/internal/LeanplumManifestHelper.java
@@ -61,6 +61,10 @@ public class LeanplumManifestHelper {
   public static final String LP_PUSH_REGISTRATION_SERVICE = "com.leanplum.LeanplumPushRegistrationService";
   public static final String LP_PUSH_RECEIVER = "com.leanplum.LeanplumPushReceiver";
 
+  //Metadata
+  public static final String LP_PUSH_RECEIVER_KEY = "LeanplumPushReceiver";
+  public static final String LP_PUSH_LISTENER_SERVICE_KEY = "LeanplumPushListenerService";
+
   /**
    * Gets Class for name.
    *
@@ -310,4 +314,19 @@ public class LeanplumManifestHelper {
   }
 
   public enum ApplicationComponent {SERVICE, RECEIVER}
+
+  public static String getStringMetadata(Context context, String key)
+  {
+    try {
+      ApplicationInfo app = context.getPackageManager().getApplicationInfo(context.getPackageName(),PackageManager.GET_META_DATA);
+      Bundle bundle = app.metaData;
+      String metaData = bundle.getString(key);
+      return bundle.getString(key);
+    } catch (PackageManager.NameNotFoundException e) {
+      e.printStackTrace();
+    } catch (NullPointerException e) {
+      e.printStackTrace();
+    }
+    return "";
+  }
 }


### PR DESCRIPTION
Addedded ability to define custom PushListenerService and PushReceiver using metadata:
<meta-data android:name="LeanplumPushReceiver" android:value="com.leanplum.LeanplumPushReceiver" />
<meta-data android:name="LeanplumPushListenerService" android:value="com.leanplum.LeanplumPushListenerService" />

User can override class, than define it in AndroidManifest and all ready!
<meta-data android:name="LeanplumPushReceiver" android:value="com.somecompany.MyCustomLeanplumPushReceiver" />