### PR TITLE
Custom locale configuration in start process and runtime

### DIFF
--- a/AndroidSDKCore/src/main/java/com/leanplum/Leanplum.java
+++ b/AndroidSDKCore/src/main/java/com/leanplum/Leanplum.java
@@ -25,6 +25,7 @@ import android.app.Activity;
 import android.content.Context;
 import android.location.Location;
 import android.os.AsyncTask;
+import android.support.annotation.Nullable;
 import android.text.TextUtils;
 
 import com.leanplum.ActionContext.ContextualValues;
@@ -102,6 +103,80 @@ public class Leanplum {
   private static Runnable pushStartCallback;
 
   private Leanplum() {
+  }
+
+  /**
+   * Custom builder to support multiple start parameters
+   */
+  public static class LeanplumStartParamsBuilder {
+
+    // initialization according existing start methods
+    private Context context;
+    private String userId = null;
+    private Map<String, ?> attributes = null;
+    private StartCallback response = null;
+    private Boolean isBackground = null;
+    private String locale = null;
+
+    /**
+     * Constructor with the minimum information for the start process
+     * @param _context for initialization
+     */
+    public LeanplumStartParamsBuilder(final Context _context) {
+      this.context = _context;
+    }
+
+    /**
+     * Set the custom user identifier for the Leanplum initialization
+     * @param _userId custom user identifier
+     * @return builder
+     */
+    public LeanplumStartParamsBuilder setUserId(final String _userId) {
+      this.userId = _userId;
+      return this;
+    }
+
+    /**
+     * Set the custom attributes for the Leanplum initialization
+     * @param _attributes custom attributes
+     * @return builder
+     */
+    public LeanplumStartParamsBuilder setAttributes(final Map<String, ?> _attributes) {
+      this.attributes = _attributes;
+      return this;
+    }
+
+    /**
+     * Set a custom start callback for the Leanplum initialization
+     * @param _response custom callback
+     * @return builder
+     */
+    public LeanplumStartParamsBuilder setStartCallback(final StartCallback _response) {
+      this.response = _response;
+      return this;
+    }
+
+    /**
+     * Set a custom background execution for the Leanplum initialization
+     * @param _isBackground custom background exectuion
+     * @return builder
+     */
+    public LeanplumStartParamsBuilder setBackground(final Boolean _isBackground) {
+      this.isBackground = _isBackground;
+      return this;
+    }
+
+    /**
+     * Set the custom locale information for the Leanplum initialization
+     * @param _locale custom locale
+     * @return builder
+     */
+    public LeanplumStartParamsBuilder setLocale(final String _locale) {
+      this.locale = _locale;
+      return this;
+    }
+
+
   }
 
   /**
@@ -417,7 +492,7 @@ public class Leanplum {
    * the values of the variables used in your app.
    */
   public static void start(Context context) {
-    start(context, null, null, null, null);
+    start(context, null, null, null, null, null);
   }
 
   /**
@@ -425,7 +500,7 @@ public class Leanplum {
    * the values of the variables used in your app.
    */
   public static void start(Context context, StartCallback callback) {
-    start(context, null, null, callback, null);
+    start(context, null, null, callback, null, null);
   }
 
   /**
@@ -433,7 +508,7 @@ public class Leanplum {
    * the values of the variables used in your app.
    */
   public static void start(Context context, Map<String, ?> userAttributes) {
-    start(context, null, userAttributes, null, null);
+    start(context, null, userAttributes, null, null, null);
   }
 
   /**
@@ -441,7 +516,7 @@ public class Leanplum {
    * the values of the variables used in your app.
    */
   public static void start(Context context, String userId) {
-    start(context, userId, null, null, null);
+    start(context, userId, null, null, null, null);
   }
 
   /**
@@ -449,7 +524,7 @@ public class Leanplum {
    * the values of the variables used in your app.
    */
   public static void start(Context context, String userId, StartCallback callback) {
-    start(context, userId, null, callback, null);
+    start(context, userId, null, callback, null, null);
   }
 
   /**
@@ -457,7 +532,7 @@ public class Leanplum {
    * the values of the variables used in your app.
    */
   public static void start(Context context, String userId, Map<String, ?> userAttributes) {
-    start(context, userId, userAttributes, null, null);
+    start(context, userId, userAttributes, null, null, null);
   }
 
   /**
@@ -466,11 +541,38 @@ public class Leanplum {
    */
   public static synchronized void start(final Context context, String userId,
       Map<String, ?> attributes, StartCallback response) {
-    start(context, userId, attributes, response, null);
+    start(context, userId, attributes, response, null, null);
   }
 
-  static synchronized void start(final Context context, final String userId,
-      final Map<String, ?> attributes, StartCallback response, final Boolean isBackground) {
+  /**
+   * Call this when your application starts. This will initiate a call to Leamplum's servers to get
+   * the values of the variables used in yout app.
+   * @param builder custom configuration for the initialization
+   */
+  public static void start(final LeanplumStartParamsBuilder builder) {
+    start(builder.context,
+            builder.userId,
+            builder.attributes,
+            builder.response,
+            builder.isBackground,
+            builder.locale);
+  }
+
+  static synchronized void start(final Context context,
+                                 final String userId,
+                                 final Map<String, ?> attributes,
+                                 StartCallback response,
+                                 final Boolean isBackground) {
+    start(context, userId, attributes, response, isBackground, null);
+
+  }
+
+  static synchronized void start(final Context context,
+                                 final String userId,
+                                 final Map<String, ?> attributes,
+                                 StartCallback response,
+                                 final Boolean isBackground,
+                                 @Nullable final String locale) {
     try {
       OsHandler.getInstance();
 
@@ -564,7 +666,7 @@ public class Leanplum {
         @Override
         protected Void doInBackground(Void... params) {
           try {
-            startHelper(userId, validAttributes, actuallyInBackground);
+            startHelper(userId, validAttributes, actuallyInBackground, locale);
           } catch (Throwable t) {
             Util.handleException(t);
           }
@@ -592,7 +694,10 @@ public class Leanplum {
   }
 
   private static void startHelper(
-      String userId, final Map<String, ?> attributes, final boolean isBackground) {
+      String userId,
+      final Map<String, ?> attributes,
+      final boolean isBackground,
+      @Nullable final String locale) {
     LeanplumEventDataManager.init(context);
     checkAndStartNotificationsModules();
     Boolean limitAdTracking = null;
@@ -646,7 +751,7 @@ public class Leanplum {
     }
     params.put(Constants.Keys.TIMEZONE, localTimeZone.getID());
     params.put(Constants.Keys.TIMEZONE_OFFSET_SECONDS, Integer.toString(timezoneOffsetSeconds));
-    params.put(Constants.Keys.LOCALE, Util.getLocale());
+    params.put(Constants.Keys.LOCALE, (locale != null) ? locale : Util.getLocale());
     params.put(Constants.Keys.COUNTRY, Constants.Values.DETECT);
     params.put(Constants.Keys.REGION, Constants.Values.DETECT);
     params.put(Constants.Keys.CITY, Constants.Values.DETECT);
@@ -1438,6 +1543,37 @@ public class Leanplum {
     }
 
     setUserAttributes(null, userAttributes);
+  }
+
+  /**
+   * Update the locale information for the current user
+   * @param locale new locale information
+   */
+  public static void setLocale(final String locale) {
+    if (TextUtils.isEmpty(locale)) {
+      Log.e("setLocale - Invalid locale parameter provided.");
+      return;
+    }
+
+    if (Constants.isNoop()) {
+      return;
+    }
+    pushStartCallback = new Runnable() {
+      @Override
+      public void run() {
+        if (Constants.isNoop()) {
+          return;
+        }
+        try {
+          HashMap<String, Object> params = new HashMap<>();
+          params.put(Constants.Keys.LOCALE, locale);
+          Request.post(Constants.Methods.START, params).send();
+        } catch (Throwable t) {
+          Util.handleException(t);
+        }
+      }
+    };
+    LeanplumInternal.addStartIssuedHandler(pushStartCallback);
   }
 
   /**

--- a/AndroidSDKTests/src/test/java/com/leanplum/LeanplumTest.java
+++ b/AndroidSDKTests/src/test/java/com/leanplum/LeanplumTest.java
@@ -359,6 +359,297 @@ public class LeanplumTest extends AbstractTest {
     assertTrue(Request.userId().equals(userId));
   }
 
+  @Test
+  public void testStartBuilderWithCallback() throws Exception {
+    final Semaphore semaphore = new Semaphore(1);
+    semaphore.acquire();
+
+    // Seed response from the file.
+    ResponseHelper.seedResponse("/responses/simple_start_response.json");
+
+    // Expected request params.
+    final HashMap<String, Object> expectedRequestParams = CollectionUtil.newHashMap(
+            "city", "(detect)",
+            "country", "(detect)",
+            "location", "(detect)",
+            "region", "(detect)",
+            "locale", "en_US"
+    );
+
+    // Validate request.
+    RequestHelper.addRequestHandler(new RequestHelper.RequestHandler() {
+      @Override
+      public void onRequest(String httpMethod, String apiMethod, Map<String, Object> params) {
+        assertEquals(Constants.Methods.START, apiMethod);
+        assertTrue(params.keySet().containsAll(expectedRequestParams.keySet()));
+        assertTrue(params.values().containsAll(expectedRequestParams.values()));
+      }
+    });
+
+    Leanplum.LeanplumStartParamsBuilder builder =
+            new Leanplum.LeanplumStartParamsBuilder(mContext)
+            .setStartCallback(new StartCallback() {
+              @Override
+              public void onResponse(boolean success) {
+                assertTrue(success);
+                semaphore.release();
+              }
+            });
+
+    Leanplum.start(builder);
+    assertTrue(Leanplum.hasStarted());
+  }
+
+  public void testStartBuilderWithUserAttributes() {
+    ResponseHelper.seedResponse("/responses/simple_start_response.json");
+
+    // Expected request params.
+    final HashMap<String, Object> expectedRequestParams = CollectionUtil.newHashMap(
+            "city", "(detect)",
+            "country", "(detect)",
+            "location", "(detect)",
+            "region", "(detect)",
+            "locale", "en_US"
+    );
+
+    // Setup user attributes.
+    final HashMap<String, Object> userAttributes = CollectionUtil.newHashMap(
+            "name", "John Smith",
+            "age", 42,
+            "address", "New York"
+    );
+
+    // Validate request.
+    RequestHelper.addRequestHandler(new RequestHelper.RequestHandler() {
+      @Override
+      public void onRequest(String httpMethod, String apiMethod, Map<String, Object> params) {
+        assertEquals(Constants.Methods.START, apiMethod);
+
+        assertTrue(params.keySet().containsAll(expectedRequestParams.keySet()));
+        assertTrue(params.values().containsAll(expectedRequestParams.values()));
+
+        String requestUserAttributes = (String) params.get("userAttributes");
+
+        assertTrue(userAttributes.keySet()
+                .containsAll(JsonConverter.fromJson(requestUserAttributes).keySet()));
+        assertTrue(userAttributes.values()
+                .containsAll(JsonConverter.fromJson(requestUserAttributes).values()));
+      }
+    });
+
+    Leanplum.start(new Leanplum.LeanplumStartParamsBuilder(mContext)
+            .setAttributes(userAttributes));
+    assertTrue(Leanplum.hasStarted());
+  }
+
+  public void testStartBuilderWithUserId() {
+    ResponseHelper.seedResponse("/responses/simple_start_response.json");
+
+    // Expected request params.
+    final HashMap<String, Object> expectedRequestParams = CollectionUtil.newHashMap(
+            "city", "(detect)",
+            "country", "(detect)",
+            "location", "(detect)",
+            "region", "(detect)",
+            "locale", "en_US"
+    );
+
+    String userId = "user_id";
+
+    // Validate request.
+    RequestHelper.addRequestHandler(new RequestHelper.RequestHandler() {
+      @Override
+      public void onRequest(String httpMethod, String apiMethod, Map<String, Object> params) {
+        assertEquals(Constants.Methods.START, apiMethod);
+
+        assertTrue(params.keySet().containsAll(expectedRequestParams.keySet()));
+        assertTrue(params.values().containsAll(expectedRequestParams.values()));
+      }
+    });
+
+    Leanplum.start(new Leanplum.LeanplumStartParamsBuilder(mContext)
+            .setUserId(userId));
+    assertTrue(Leanplum.hasStarted());
+    assertTrue(Request.userId().equals(userId));
+  }
+
+  @Test
+  public void testStartBuilderWithUserIdAndAttributes() {
+    ResponseHelper.seedResponse("/responses/simple_start_response.json");
+
+    // Expected request params.
+    final HashMap<String, Object> expectedRequestParams = CollectionUtil.newHashMap(
+            "city", "(detect)",
+            "country", "(detect)",
+            "location", "(detect)",
+            "region", "(detect)",
+            "locale", "en_US"
+    );
+
+    // Setup user attributes.
+    final HashMap<String, Object> userAttributes = CollectionUtil.newHashMap(
+            "name", "John Smith",
+            "age", 42,
+            "address", "New York"
+    );
+
+    String userId = "user_id";
+
+    // Validate request.
+    RequestHelper.addRequestHandler(new RequestHelper.RequestHandler() {
+      @Override
+      public void onRequest(String httpMethod, String apiMethod, Map<String, Object> params) {
+        assertEquals(Constants.Methods.START, apiMethod);
+
+        assertTrue(params.keySet().containsAll(expectedRequestParams.keySet()));
+        assertTrue(params.values().containsAll(expectedRequestParams.values()));
+
+        String requestUserAttributes = (String) params.get("userAttributes");
+
+        assertTrue(userAttributes.keySet()
+                .containsAll(JsonConverter.fromJson(requestUserAttributes).keySet()));
+        assertTrue(userAttributes.values()
+                .containsAll(JsonConverter.fromJson(requestUserAttributes).values()));
+      }
+    });
+
+    Leanplum.start(new Leanplum.LeanplumStartParamsBuilder(mContext)
+            .setUserId(userId)
+            .setAttributes(userAttributes));
+    assertTrue(Leanplum.hasStarted());
+    assertTrue(Request.userId().equals(userId));
+  }
+
+  @Test
+  public void testStartBuilderWithUserIdAndCallback() {
+    // Seed response from the file.
+    ResponseHelper.seedResponse("/responses/simple_start_response.json");
+
+    // Expected request params.
+    final HashMap<String, Object> expectedRequestParams = CollectionUtil.newHashMap(
+            "city", "(detect)",
+            "country", "(detect)",
+            "location", "(detect)",
+            "region", "(detect)",
+            "locale", "en_US"
+    );
+
+    String userId = "user_id";
+
+    // Validate request.
+    RequestHelper.addRequestHandler(new RequestHelper.RequestHandler() {
+      @Override
+      public void onRequest(String httpMethod, String apiMethod, Map<String, Object> params) {
+        assertEquals(Constants.Methods.START, apiMethod);
+
+        assertTrue(params.keySet().containsAll(expectedRequestParams.keySet()));
+        assertTrue(params.values().containsAll(expectedRequestParams.values()));
+      }
+    });
+
+    Leanplum.start(new Leanplum.LeanplumStartParamsBuilder(mContext)
+            .setUserId(userId)
+            .setStartCallback(new StartCallback() {
+              @Override
+              public void onResponse(boolean success) {
+                assertTrue(success);
+              }
+            }));
+    assertTrue(Leanplum.hasStarted());
+    assertTrue(Request.userId().equals(userId));
+  }
+
+  @Test
+  public void testStartBuilderWithUserIdAttributesAndCallback() throws Exception {
+    ResponseHelper.seedResponse("/responses/simple_start_response.json");
+
+    // Expected request params.
+    final HashMap<String, Object> expectedRequestParams = CollectionUtil.newHashMap(
+            "city", "(detect)",
+            "country", "(detect)",
+            "location", "(detect)",
+            "region", "(detect)",
+            "locale", "en_US"
+    );
+
+    // Setup user attributes.
+    final HashMap<String, Object> userAttributes = CollectionUtil.newHashMap(
+            "name", "John Smith",
+            "age", 42,
+            "address", "New York"
+    );
+
+    String userId = "user_id";
+
+    final CountDownLatch countDownLatch = new CountDownLatch(1);
+
+    // Validate request.
+    RequestHelper.addRequestHandler(new RequestHelper.RequestHandler() {
+      @Override
+      public void onRequest(String httpMethod, String apiMethod, Map<String, Object> params) {
+        assertEquals(Constants.Methods.START, apiMethod);
+
+        assertTrue(params.keySet().containsAll(expectedRequestParams.keySet()));
+        assertTrue(params.values().containsAll(expectedRequestParams.values()));
+
+        String requestUserAttributes = (String) params.get("userAttributes");
+
+        assertTrue(userAttributes.keySet()
+                .containsAll(JsonConverter.fromJson(requestUserAttributes).keySet()));
+        assertTrue(userAttributes.values()
+                .containsAll(JsonConverter.fromJson(requestUserAttributes).values()));
+      }
+    });
+
+    Leanplum.start(new Leanplum.LeanplumStartParamsBuilder(RuntimeEnvironment.application)
+            .setUserId(userId)
+            .setAttributes(userAttributes)
+            .setStartCallback(new StartCallback() {
+              @Override
+              public void onResponse(boolean success) {
+                assertTrue(success);
+                countDownLatch.countDown();
+              }
+            }));
+    countDownLatch.await(10, TimeUnit.SECONDS);
+    assertTrue(Leanplum.hasStarted());
+    assertTrue(Request.userId().equals(userId));
+  }
+
+  @Test
+  public void testStartBuilderLocale() throws Exception {
+    ResponseHelper.seedResponse("/responses/simple_start_response.json");
+
+    // Expected request params.
+    final HashMap<String, Object> expectedRequestParams = CollectionUtil.newHashMap(
+            "city", "(detect)",
+            "country", "(detect)",
+            "location", "(detect)",
+            "region", "(detect)",
+            "locale", "nl_NL"
+    );
+
+    // Validate request.
+    RequestHelper.addRequestHandler(new RequestHelper.RequestHandler() {
+      @Override
+      public void onRequest(String httpMethod, String apiMethod, Map<String, Object> params) {
+        assertEquals(Constants.Methods.START, apiMethod);
+
+        // Validate request.
+        assertTrue(params.keySet().containsAll(expectedRequestParams.keySet()));
+        assertTrue(params.values().containsAll(expectedRequestParams.values()));
+      }
+    });
+
+    Leanplum.LeanplumStartParamsBuilder builder =
+            (new Leanplum.LeanplumStartParamsBuilder(mContext))
+                    .setLocale("nl_NL");
+
+    Leanplum.start(builder);
+    assertTrue(Leanplum.hasStarted());
+
+  }
+
   /**
    * Tests Metadata.
    */
@@ -970,6 +1261,26 @@ public class LeanplumTest extends AbstractTest {
     });
     // Register for push notification.
     Leanplum.setRegistrationId(LeanplumPushService.LEANPLUM_SENDER_ID);
+  }
+
+  /**
+   * Test custom locale update
+   */
+  @Test
+  public void testLocalUpdate() throws Exception {
+    setupSDK(mContext, "/responses/simple_start_response.json");
+
+    // Verify request.
+    RequestHelper.addRequestHandler(new RequestHelper.RequestHandler() {
+      @Override
+      public void onRequest(String httpMethod, String apiMethod, Map<String, Object> params) {
+        assertEquals(Constants.Methods.START, apiMethod);
+        assertNotNull(params);
+        assertEquals("nl_NL", params.get(Constants.Keys.LOCALE));
+      }
+    });
+    // Register for push notification.
+    Leanplum.setLocale("nl_NL");
   }
 
   /**


### PR DESCRIPTION
## Proposed Changes

- added new builder to simplify start parameters (including new locale configuration)
- added new custom locale parameter for the start process
- added new start method to support the new parameter builder
- generic start supports custom locale (null value for locale has the previous behaviour)
- add setter for the locale and propagate the changes to the server (via START call)
- added unit test for the builder and the new locale parameter
- added unit test for the locale setter

