### PR TITLE
Allow users to access VariantDebugInfo by setting a flag

### DIFF
--- a/AndroidSDKCore/build.gradle
+++ b/AndroidSDKCore/build.gradle
@@ -30,6 +30,7 @@ dependencies {
     // Compile dependencies will be added as dependency in pom file.
     api "com.android.support:support-v4:[22.0.0,${SUPPORT_LIBRARY_VERSION}]"
     api "com.android.support:appcompat-v7:[22.0.0,${SUPPORT_LIBRARY_VERSION}]"
+    compile 'com.google.code.gson:gson:2.8.5'
 }
 
 task generateJavadoc(type: Javadoc) {

--- a/AndroidSDKCore/build.gradle
+++ b/AndroidSDKCore/build.gradle
@@ -30,7 +30,6 @@ dependencies {
     // Compile dependencies will be added as dependency in pom file.
     api "com.android.support:support-v4:[22.0.0,${SUPPORT_LIBRARY_VERSION}]"
     api "com.android.support:appcompat-v7:[22.0.0,${SUPPORT_LIBRARY_VERSION}]"
-    compile 'com.google.code.gson:gson:2.8.5'
 }
 
 task generateJavadoc(type: Javadoc) {

--- a/AndroidSDKCore/src/main/java/com/leanplum/Leanplum.java
+++ b/AndroidSDKCore/src/main/java/com/leanplum/Leanplum.java
@@ -27,8 +27,6 @@ import android.location.Location;
 import android.os.AsyncTask;
 import android.text.TextUtils;
 
-import com.google.gson.Gson;
-
 import com.leanplum.ActionContext.ContextualValues;
 import com.leanplum.callbacks.ActionCallback;
 import com.leanplum.callbacks.RegisterDeviceCallback;
@@ -938,16 +936,8 @@ public class Leanplum {
         response.optJSONObject(Constants.Keys.REGIONS));
     List<Map<String, Object>> variants = JsonConverter.listFromJsonOrDefault(
         response.optJSONArray(Constants.Keys.VARIANTS));
-    VariantDebugInfo variantDebugInfo = null;
-    try {
-      String variantDebugInfoString = response.optString(Constants.Keys.VARIANT_DEBUG_INFO);
-      if (variantDebugInfoString != null) {
-        Gson gson = new Gson();
-        variantDebugInfo = gson.fromJson(variantDebugInfoString, VariantDebugInfo.class);
-      }
-    } catch (Throwable t) {
-      Util.handleException(t);
-    }
+    Map<String, Object> variantDebugInfoDictionary = (Map<String, Object>)response.optJSONObject(Constants.Keys.VARIANT_DEBUG_INFO);
+    VariantDebugInfo variantDebugInfo = new VariantDebugInfo(variantDebugInfoDictionary);
 
     if (alwaysApply
         || !values.equals(VarCache.getDiffs())
@@ -2131,16 +2121,14 @@ public class Leanplum {
     return locationCollectionEnabled;
   }
 
-  private static void parseVariantDebugInfo(JSONObject response) {
-    try {
-      String variantDebugInfoString = response.optString(Constants.Keys.VARIANT_DEBUG_INFO);
-      if (variantDebugInfoString != null) {
-        Gson gson = new Gson();
-        VariantDebugInfo variantDebugInfo = gson.fromJson(variantDebugInfoString, VariantDebugInfo.class);
-        VarCache.setVariantDebugInfo(variantDebugInfo);
-      }
-    } catch (Throwable t) {
-      Util.handleException(t);
+    private static void parseVariantDebugInfo(JSONObject response) {
+        try {
+            Map<String, Object> variantDebugInfoDictionary = (Map<String, Object>)  response.optJSONObject(Constants.Keys.VARIANT_DEBUG_INFO);
+            VariantDebugInfo variantDebugInfo = new VariantDebugInfo(variantDebugInfoDictionary);
+            VarCache.setVariantDebugInfo(variantDebugInfo);
+        } catch (Throwable t) {
+            Util.handleException(t);
+        }
     }
-  }
+
 }

--- a/AndroidSDKCore/src/main/java/com/leanplum/Leanplum.java
+++ b/AndroidSDKCore/src/main/java/com/leanplum/Leanplum.java
@@ -2125,7 +2125,7 @@ public class Leanplum {
           JSONObject variantDebugInfoDictionary = response.optJSONObject(Constants.Keys.VARIANT_DEBUG_INFO);
           VariantDebugInfo variantDebugInfo = new VariantDebugInfo(JsonConverter.mapFromJson(variantDebugInfoDictionary));
           VarCache.setVariantDebugInfo(variantDebugInfo);
-//          VarCache.saveDiffs();
+          VarCache.saveDiffs();
           VarCache.loadDiffs();
         } catch (Throwable t) {
           Log.e(t);

--- a/AndroidSDKCore/src/main/java/com/leanplum/Leanplum.java
+++ b/AndroidSDKCore/src/main/java/com/leanplum/Leanplum.java
@@ -254,7 +254,7 @@ public class Leanplum {
    * Set variant debig info to be obtained from the server.
    */
   public static void setVariantDebugInfoEnabled(boolean variantDebugInfoEnabled) {
-    LeanplumInternal.setVariantDebugInfoEnabled(variantDebugInfoEnabled);
+    LeanplumInternal.setIsVariantDebugInfoEnabled(variantDebugInfoEnabled);
   }
 
   /**

--- a/AndroidSDKCore/src/main/java/com/leanplum/Leanplum.java
+++ b/AndroidSDKCore/src/main/java/com/leanplum/Leanplum.java
@@ -779,6 +779,7 @@ public class Leanplum {
               Log.d("No variants received from the server.");
             }
 
+            parseVariantDebugInfo(response);
             if (BuildUtil.isNotificationChannelSupported(context)) {
               // Get notification channels and groups.
               JSONArray notificationChannels = response.optJSONArray(
@@ -812,8 +813,6 @@ public class Leanplum {
             if (response.optBoolean(Constants.Keys.LOGGING_ENABLED, false)) {
               Constants.loggingEnabled = true;
             }
-
-            parseVariantDebugInfo(response);
 
             // Allow bidirectional realtime variable updates.
             if (Constants.isDevelopmentModeEnabled) {
@@ -2123,11 +2122,14 @@ public class Leanplum {
 
     private static void parseVariantDebugInfo(JSONObject response) {
         try {
-            Map<String, Object> variantDebugInfoDictionary = (Map<String, Object>)  response.optJSONObject(Constants.Keys.VARIANT_DEBUG_INFO);
-            VariantDebugInfo variantDebugInfo = new VariantDebugInfo(variantDebugInfoDictionary);
-            VarCache.setVariantDebugInfo(variantDebugInfo);
+          JSONObject variantDebugInfoDictionary = response.optJSONObject(Constants.Keys.VARIANT_DEBUG_INFO);
+          VariantDebugInfo variantDebugInfo = new VariantDebugInfo(JsonConverter.mapFromJson(variantDebugInfoDictionary));
+          VarCache.setVariantDebugInfo(variantDebugInfo);
+//          VarCache.saveDiffs();
+          VarCache.loadDiffs();
         } catch (Throwable t) {
-            Util.handleException(t);
+          Log.e(t);
+          Util.handleException(t);
         }
     }
 

--- a/AndroidSDKCore/src/main/java/com/leanplum/Leanplum.java
+++ b/AndroidSDKCore/src/main/java/com/leanplum/Leanplum.java
@@ -254,7 +254,9 @@ public class Leanplum {
   }
 
   /**
-   * Set variant debig info to be obtained from the server.
+   * Set this to true if you want details about the variable assignments
+   * on the server.
+   * Default is NO.
    */
   public static void setVariantDebugInfoEnabled(boolean variantDebugInfoEnabled) {
     LeanplumInternal.setIsVariantDebugInfoEnabled(variantDebugInfoEnabled);

--- a/AndroidSDKCore/src/main/java/com/leanplum/Leanplum.java
+++ b/AndroidSDKCore/src/main/java/com/leanplum/Leanplum.java
@@ -511,7 +511,8 @@ public class Leanplum {
             VarCache.getUpdateRuleDiffs(),
             VarCache.getEventRuleDiffs(),
             new HashMap<String, Object>(),
-            new ArrayList<Map<String, Object>>());
+            new ArrayList<Map<String, Object>>(),
+                null);
         LeanplumInbox.getInstance().update(new HashMap<String, LeanplumInboxMessage>(), 0, false);
         return;
       }
@@ -937,6 +938,16 @@ public class Leanplum {
         response.optJSONObject(Constants.Keys.REGIONS));
     List<Map<String, Object>> variants = JsonConverter.listFromJsonOrDefault(
         response.optJSONArray(Constants.Keys.VARIANTS));
+    VariantDebugInfo variantDebugInfo = null;
+    try {
+      String variantDebugInfoString = response.optString(Constants.Keys.VARIANT_DEBUG_INFO);
+      if (variantDebugInfoString != null) {
+        Gson gson = new Gson();
+        variantDebugInfo = gson.fromJson(variantDebugInfoString, VariantDebugInfo.class);
+      }
+    } catch (Throwable t) {
+      Util.handleException(t);
+    }
 
     if (alwaysApply
         || !values.equals(VarCache.getDiffs())
@@ -945,7 +956,7 @@ public class Leanplum {
         || !eventRules.equals(VarCache.getEventRuleDiffs())
         || !regions.equals(VarCache.regions())) {
       VarCache.applyVariableDiffs(values, messages, updateRules,
-          eventRules, regions, variants);
+          eventRules, regions, variants, variantDebugInfo);
     }
   }
 

--- a/AndroidSDKCore/src/main/java/com/leanplum/Leanplum.java
+++ b/AndroidSDKCore/src/main/java/com/leanplum/Leanplum.java
@@ -251,10 +251,10 @@ public class Leanplum {
   }
 
   /**
-   * Set content assignments to be obtained from the server.
+   * Set variant debig info to be obtained from the server.
    */
-  public static void setContentAssignmentsEnabled(boolean contentAssignmentsEnabled) {
-    LeanplumInternal.setIsContentAssignmentsEnabled(contentAssignmentsEnabled);
+  public static void setVariantDebugInfoEnabled(boolean variantDebugInfoEnabled) {
+    LeanplumInternal.setVariantDebugInfoEnabled(variantDebugInfoEnabled);
   }
 
   /**
@@ -671,8 +671,8 @@ public class Leanplum {
     // Get the current inbox messages on the device.
     params.put(Constants.Params.INBOX_MESSAGES, LeanplumInbox.getInstance().messagesIds());
 
-    if (LeanplumInternal.getIsContentAssignmentsEnabled()) {
-      params.put(Constants.Params.INCLUDE_CONTENT_ASSIGNMENTS, true);
+    if (LeanplumInternal.getIsVariantDebugInfoEnabled()) {
+      params.put(Constants.Params.INCLUDE_VARIANT_DEBUG_INFO, true);
     }
 
     Util.initializePreLeanplumInstall(params);
@@ -811,10 +811,10 @@ public class Leanplum {
               Constants.loggingEnabled = true;
             }
 
-            Map<String, Object> contentAssignments = JsonConverter.mapFromJsonOrDefault(
-                    response.optJSONObject(Constants.Keys.CONTENT_ASSIGNMENTS));
-            if (contentAssignments.size() > 0) {
-              VarCache.setContentAssignments(contentAssignments);
+            Map<String, Object> variantDebugInfo = JsonConverter.mapFromJsonOrDefault(
+                    response.optJSONObject(Constants.Keys.VARIANT_DEBUG_INFO));
+            if (variantDebugInfo.size() > 0) {
+              VarCache.setVariantDebugInfo(variantDebugInfo);
             }
 
             // Allow bidirectional realtime variable updates.
@@ -1941,8 +1941,8 @@ public class Leanplum {
       Map<String, Object> params = new HashMap<>();
       params.put(Constants.Params.INCLUDE_DEFAULTS, Boolean.toString(false));
       params.put(Constants.Params.INBOX_MESSAGES, LeanplumInbox.getInstance().messagesIds());
-      if (LeanplumInternal.getIsContentAssignmentsEnabled()) {
-        params.put(Constants.Params.INCLUDE_CONTENT_ASSIGNMENTS, true);
+      if (LeanplumInternal.getIsVariantDebugInfoEnabled()) {
+        params.put(Constants.Params.INCLUDE_VARIANT_DEBUG_INFO, true);
       }
       Request req = Request.post(Constants.Methods.GET_VARS, params);
       req.onResponse(new Request.ResponseCallback() {
@@ -1962,10 +1962,10 @@ public class Leanplum {
                 Constants.loggingEnabled = true;
               }
 
-              Map<String, Object> contentAssignments = JsonConverter.mapFromJsonOrDefault(
-                      response.optJSONObject(Constants.Keys.CONTENT_ASSIGNMENTS));
-              if (contentAssignments.size() > 0) {
-                VarCache.setContentAssignments(contentAssignments);
+              Map<String, Object> variantDebugInfo = JsonConverter.mapFromJsonOrDefault(
+                      response.optJSONObject(Constants.Keys.VARIANT_DEBUG_INFO));
+              if (variantDebugInfo.size() > 0) {
+                VarCache.setVariantDebugInfo(variantDebugInfo);
               }
             }
             if (callback != null) {
@@ -2074,12 +2074,12 @@ public class Leanplum {
    * on the server.
    * Default is NO.
    */
-  public static Map<String, Object> contentAssignments() {
-    Map<String, Object> contentAssignments = VarCache.getContentAssignments();
-    if (contentAssignments == null) {
+  public static Map<String, Object> variantDebugInfo() {
+    Map<String, Object> variantDebugInfo = VarCache.getVariantDebugInfo();
+    if (variantDebugInfo == null) {
       return new HashMap<>();
     }
-    return contentAssignments;
+    return variantDebugInfo;
   }
 
   /**

--- a/AndroidSDKCore/src/main/java/com/leanplum/Leanplum.java
+++ b/AndroidSDKCore/src/main/java/com/leanplum/Leanplum.java
@@ -23,7 +23,6 @@ package com.leanplum;
 
 import android.app.Activity;
 import android.content.Context;
-import android.graphics.drawable.Drawable;
 import android.location.Location;
 import android.os.AsyncTask;
 import android.text.TextUtils;
@@ -51,7 +50,6 @@ import com.leanplum.internal.VarCache;
 import com.leanplum.messagetemplates.MessageTemplates;
 import com.leanplum.utils.BuildUtil;
 import com.leanplum.utils.SharedPreferencesUtil;
-import com.sun.tools.internal.jxc.ap.Const;
 
 import org.json.JSONArray;
 import org.json.JSONObject;

--- a/AndroidSDKCore/src/main/java/com/leanplum/Leanplum.java
+++ b/AndroidSDKCore/src/main/java/com/leanplum/Leanplum.java
@@ -671,9 +671,7 @@ public class Leanplum {
     // Get the current inbox messages on the device.
     params.put(Constants.Params.INBOX_MESSAGES, LeanplumInbox.getInstance().messagesIds());
 
-    if (LeanplumInternal.getIsVariantDebugInfoEnabled()) {
-      params.put(Constants.Params.INCLUDE_VARIANT_DEBUG_INFO, true);
-    }
+    params.put(Constants.Params.INCLUDE_VARIANT_DEBUG_INFO, LeanplumInternal.getIsVariantDebugInfoEnabled());
 
     Util.initializePreLeanplumInstall(params);
 
@@ -1941,9 +1939,8 @@ public class Leanplum {
       Map<String, Object> params = new HashMap<>();
       params.put(Constants.Params.INCLUDE_DEFAULTS, Boolean.toString(false));
       params.put(Constants.Params.INBOX_MESSAGES, LeanplumInbox.getInstance().messagesIds());
-      if (LeanplumInternal.getIsVariantDebugInfoEnabled()) {
-        params.put(Constants.Params.INCLUDE_VARIANT_DEBUG_INFO, true);
-      }
+      params.put(Constants.Params.INCLUDE_VARIANT_DEBUG_INFO, LeanplumInternal.getIsVariantDebugInfoEnabled());
+
       Request req = Request.post(Constants.Methods.GET_VARS, params);
       req.onResponse(new Request.ResponseCallback() {
         @Override
@@ -2070,9 +2067,7 @@ public class Leanplum {
   }
 
   /**
-   * Set this to true if you want details about the variable assignments
-   * on the server.
-   * Default is NO.
+   * Details about the variable assignments on the server.
    */
   public static Map<String, Object> variantDebugInfo() {
     Map<String, Object> variantDebugInfo = VarCache.getVariantDebugInfo();

--- a/AndroidSDKCore/src/main/java/com/leanplum/Leanplum.java
+++ b/AndroidSDKCore/src/main/java/com/leanplum/Leanplum.java
@@ -2125,8 +2125,6 @@ public class Leanplum {
           JSONObject variantDebugInfoDictionary = response.optJSONObject(Constants.Keys.VARIANT_DEBUG_INFO);
           VariantDebugInfo variantDebugInfo = new VariantDebugInfo(JsonConverter.mapFromJson(variantDebugInfoDictionary));
           VarCache.setVariantDebugInfo(variantDebugInfo);
-          VarCache.saveDiffs();
-          VarCache.loadDiffs();
         } catch (Throwable t) {
           Log.e(t);
           Util.handleException(t);

--- a/AndroidSDKCore/src/main/java/com/leanplum/Leanplum.java
+++ b/AndroidSDKCore/src/main/java/com/leanplum/Leanplum.java
@@ -251,13 +251,6 @@ public class Leanplum {
   }
 
   /**
-   * Set content assignments to be obtained from the server.
-   */
-  public static void setContentAssignmentsEnabled(boolean contentAssignmentsEnabled) {
-    LeanplumInternal.setIsContentAssignmentsEnabled(contentAssignmentsEnabled);
-  }
-
-  /**
    * Whether screen tracking is enabled or not.
    *
    * @return Boolean - true if enabled
@@ -477,7 +470,12 @@ public class Leanplum {
   }
 
   static synchronized void start(final Context context, final String userId,
-      final Map<String, ?> attributes, StartCallback response, final Boolean isBackground) {
+                                 final Map<String, ?> attributes, StartCallback response, final Boolean isBackground) {
+    Leanplum.start(context, userId, attributes, response, isBackground, false);
+  }
+
+    static synchronized void start(final Context context, final String userId,
+                                   final Map<String, ?> attributes, StartCallback response, final Boolean isBackground, final boolean includeContentAssignments) {
     try {
       OsHandler.getInstance();
 
@@ -506,7 +504,8 @@ public class Leanplum {
             VarCache.getUpdateRuleDiffs(),
             VarCache.getEventRuleDiffs(),
             new HashMap<String, Object>(),
-            new ArrayList<Map<String, Object>>());
+            new ArrayList<Map<String, Object>>(),
+                new HashMap<String, Object>());
         LeanplumInbox.getInstance().update(new HashMap<String, LeanplumInboxMessage>(), 0, false);
         return;
       }
@@ -571,7 +570,7 @@ public class Leanplum {
         @Override
         protected Void doInBackground(Void... params) {
           try {
-            startHelper(userId, validAttributes, actuallyInBackground);
+            startHelper(userId, validAttributes, actuallyInBackground, includeContentAssignments);
           } catch (Throwable t) {
             Util.handleException(t);
           }
@@ -599,7 +598,7 @@ public class Leanplum {
   }
 
   private static void startHelper(
-      String userId, final Map<String, ?> attributes, final boolean isBackground) {
+      String userId, final Map<String, ?> attributes, final boolean isBackground, boolean includeContentAssignments) {
     LeanplumEventDataManager.init(context);
     checkAndStartNotificationsModules();
     Boolean limitAdTracking = null;
@@ -671,7 +670,7 @@ public class Leanplum {
     // Get the current inbox messages on the device.
     params.put(Constants.Params.INBOX_MESSAGES, LeanplumInbox.getInstance().messagesIds());
 
-    if (LeanplumInternal.getIsContentAssignmentsEnabled()) {
+    if (includeContentAssignments) {
       params.put(Constants.Params.INCLUDE_CONTENT_ASSIGNMENTS, true);
     }
 
@@ -938,6 +937,8 @@ public class Leanplum {
         response.optJSONObject(Constants.Keys.REGIONS));
     List<Map<String, Object>> variants = JsonConverter.listFromJsonOrDefault(
         response.optJSONArray(Constants.Keys.VARIANTS));
+    Map<String, Object> contentAssignments = JsonConverter.mapFromJsonOrDefault(
+            response.optJSONObject(Constants.Keys.CONTENT_ASSIGNMENTS));
 
     if (alwaysApply
         || !values.equals(VarCache.getDiffs())
@@ -946,7 +947,7 @@ public class Leanplum {
         || !eventRules.equals(VarCache.getEventRuleDiffs())
         || !regions.equals(VarCache.regions())) {
       VarCache.applyVariableDiffs(values, messages, updateRules,
-          eventRules, regions, variants);
+          eventRules, regions, variants, contentAssignments);
     }
   }
 
@@ -1931,6 +1932,20 @@ public class Leanplum {
    */
   @SuppressWarnings("SameParameterValue")
   public static void forceContentUpdate(final VariablesChangedCallback callback) {
+    forceContentUpdate(callback, false);
+  }
+
+  /**
+   * Forces content to update from the server. If variables have changed, the appropriate callbacks
+   * will fire. Use sparingly as if the app is updated, you'll have to deal with potentially
+   * inconsistent state or user experience.
+   *
+   * @param callback The callback to invoke when the call completes from the server. The callback
+   * will fire regardless of whether the variables have changed.
+   * @param includeContentAssignments Boolean to decide whether or not the response should include
+   *                                  details about the A/B tests running for this user.
+   */
+  public static void forceContentUpdate(final VariablesChangedCallback callback, boolean includeContentAssignments) {
     if (Constants.isNoop()) {
       if (callback != null) {
         OsHandler.getInstance().post(callback);
@@ -1941,7 +1956,7 @@ public class Leanplum {
       Map<String, Object> params = new HashMap<>();
       params.put(Constants.Params.INCLUDE_DEFAULTS, Boolean.toString(false));
       params.put(Constants.Params.INBOX_MESSAGES, LeanplumInbox.getInstance().messagesIds());
-      if (LeanplumInternal.getIsContentAssignmentsEnabled()) {
+      if (includeContentAssignments) {
         params.put(Constants.Params.INCLUDE_CONTENT_ASSIGNMENTS, true);
       }
       Request req = Request.post(Constants.Methods.GET_VARS, params);

--- a/AndroidSDKCore/src/main/java/com/leanplum/internal/Constants.java
+++ b/AndroidSDKCore/src/main/java/com/leanplum/internal/Constants.java
@@ -144,6 +144,7 @@ public class Constants {
     public static final String IAP_CURRENCY_CODE = "currencyCode";
     public static final String IAP_ITEM = "item";
     public static final String INCLUDE_DEFAULTS = "includeDefaults";
+    public static final String INCLUDE_CONTENT_ASSIGNMENTS = "includeContentAssignments";
     public static final String INCLUDE_MESSAGE_ID = "includeMessageId";
     public static final String INFO = "info";
     public static final String INSTALL_DATE = "installDate";
@@ -200,6 +201,7 @@ public class Constants {
     public static final String REGION = "region";
     public static final String REGION_STATE = "regionState";
     public static final String REGIONS = "regions";
+    public static final String CONTENT_ASSIGNMENTS = "contentAssignments";
     public static final String SIZE = "size";
     public static final String SUBTITLE = "Subtitle";
     public static final String SYNC_INBOX = "syncNewsfeed";

--- a/AndroidSDKCore/src/main/java/com/leanplum/internal/Constants.java
+++ b/AndroidSDKCore/src/main/java/com/leanplum/internal/Constants.java
@@ -144,7 +144,7 @@ public class Constants {
     public static final String IAP_CURRENCY_CODE = "currencyCode";
     public static final String IAP_ITEM = "item";
     public static final String INCLUDE_DEFAULTS = "includeDefaults";
-    public static final String INCLUDE_CONTENT_ASSIGNMENTS = "includeContentAssignments";
+    public static final String INCLUDE_VARIANT_DEBUG_INFO = "includeVariantDebugInfo";
     public static final String INCLUDE_MESSAGE_ID = "includeMessageId";
     public static final String INFO = "info";
     public static final String INSTALL_DATE = "installDate";
@@ -201,7 +201,7 @@ public class Constants {
     public static final String REGION = "region";
     public static final String REGION_STATE = "regionState";
     public static final String REGIONS = "regions";
-    public static final String CONTENT_ASSIGNMENTS = "contentAssignments";
+    public static final String VARIANT_DEBUG_INFO = "variantDebugInfo";
     public static final String SIZE = "size";
     public static final String SUBTITLE = "Subtitle";
     public static final String SYNC_INBOX = "syncNewsfeed";

--- a/AndroidSDKCore/src/main/java/com/leanplum/internal/LeanplumInternal.java
+++ b/AndroidSDKCore/src/main/java/com/leanplum/internal/LeanplumInternal.java
@@ -73,7 +73,6 @@ public class LeanplumInternal {
   private static final Queue<Map<String, ?>> userAttributeChanges = new ConcurrentLinkedQueue<>();
   private static final ArrayList<Runnable> startIssuedHandlers = new ArrayList<>();
   private static boolean isScreenTrackingEnabled = false;
-  private static boolean isContentAssignmentsEnabled = false;
 
   private static void onHasStartedAndRegisteredAsDeveloperAndFinishedSyncing() {
     if (!hasStartedAndRegisteredAsDeveloper) {
@@ -672,14 +671,6 @@ public class LeanplumInternal {
 
   public static boolean getIsScreenTrackingEnabled() {
     return isScreenTrackingEnabled;
-  }
-
-  public static boolean getIsContentAssignmentsEnabled() {
-    return isContentAssignmentsEnabled;
-  }
-
-  public static void setIsContentAssignmentsEnabled(boolean _isContentAssignmentsEnabled) {
-    isContentAssignmentsEnabled = _isContentAssignmentsEnabled;
   }
 
   public static void enableAutomaticScreenTracking() {

--- a/AndroidSDKCore/src/main/java/com/leanplum/internal/LeanplumInternal.java
+++ b/AndroidSDKCore/src/main/java/com/leanplum/internal/LeanplumInternal.java
@@ -73,6 +73,7 @@ public class LeanplumInternal {
   private static final Queue<Map<String, ?>> userAttributeChanges = new ConcurrentLinkedQueue<>();
   private static final ArrayList<Runnable> startIssuedHandlers = new ArrayList<>();
   private static boolean isScreenTrackingEnabled = false;
+  private static boolean isContentAssignmentsEnabled = false;
 
   private static void onHasStartedAndRegisteredAsDeveloperAndFinishedSyncing() {
     if (!hasStartedAndRegisteredAsDeveloper) {
@@ -671,6 +672,14 @@ public class LeanplumInternal {
 
   public static boolean getIsScreenTrackingEnabled() {
     return isScreenTrackingEnabled;
+  }
+
+  public static boolean getIsContentAssignmentsEnabled() {
+    return isContentAssignmentsEnabled;
+  }
+
+  public static void setIsContentAssignmentsEnabled(boolean _isContentAssignmentsEnabled) {
+    isContentAssignmentsEnabled = _isContentAssignmentsEnabled;
   }
 
   public static void enableAutomaticScreenTracking() {

--- a/AndroidSDKCore/src/main/java/com/leanplum/internal/LeanplumInternal.java
+++ b/AndroidSDKCore/src/main/java/com/leanplum/internal/LeanplumInternal.java
@@ -73,7 +73,7 @@ public class LeanplumInternal {
   private static final Queue<Map<String, ?>> userAttributeChanges = new ConcurrentLinkedQueue<>();
   private static final ArrayList<Runnable> startIssuedHandlers = new ArrayList<>();
   private static boolean isScreenTrackingEnabled = false;
-  private static boolean isContentAssignmentsEnabled = false;
+  private static boolean isVariantDebugInfoEnabled = false;
 
   private static void onHasStartedAndRegisteredAsDeveloperAndFinishedSyncing() {
     if (!hasStartedAndRegisteredAsDeveloper) {
@@ -674,12 +674,12 @@ public class LeanplumInternal {
     return isScreenTrackingEnabled;
   }
 
-  public static boolean getIsContentAssignmentsEnabled() {
-    return isContentAssignmentsEnabled;
+  public static boolean getIsVariantDebugInfoEnabled() {
+    return isVariantDebugInfoEnabled;
   }
 
-  public static void setIsContentAssignmentsEnabled(boolean _isContentAssignmentsEnabled) {
-    isContentAssignmentsEnabled = _isContentAssignmentsEnabled;
+  public static void setIsVariantDebugInfoEnabled(boolean _isVariantDebugInfoEnabled) {
+    isVariantDebugInfoEnabled= _isVariantDebugInfoEnabled;
   }
 
   public static void enableAutomaticScreenTracking() {

--- a/AndroidSDKCore/src/main/java/com/leanplum/internal/Socket.java
+++ b/AndroidSDKCore/src/main/java/com/leanplum/internal/Socket.java
@@ -307,7 +307,7 @@ public class Socket {
         return;
       }
       VarCache.applyVariableDiffs(
-          JsonConverter.mapFromJson(object), null, null, null, null, null, null);
+          JsonConverter.mapFromJson(object), null, null, null, null, null);
     } catch (JSONException e) {
       Log.e("Couldn't applyVars for preview.", e);
     } catch (Throwable e) {

--- a/AndroidSDKCore/src/main/java/com/leanplum/internal/Socket.java
+++ b/AndroidSDKCore/src/main/java/com/leanplum/internal/Socket.java
@@ -307,7 +307,7 @@ public class Socket {
         return;
       }
       VarCache.applyVariableDiffs(
-          JsonConverter.mapFromJson(object), null, null, null, null, null);
+          JsonConverter.mapFromJson(object), null, null, null, null, null, null);
     } catch (JSONException e) {
       Log.e("Couldn't applyVars for preview.", e);
     } catch (Throwable e) {

--- a/AndroidSDKCore/src/main/java/com/leanplum/internal/VarCache.java
+++ b/AndroidSDKCore/src/main/java/com/leanplum/internal/VarCache.java
@@ -339,13 +339,12 @@ public class VarCache {
     SharedPreferences defaults = context.getSharedPreferences(LEANPLUM, Context.MODE_PRIVATE);
     if (Request.token() == null) {
       applyVariableDiffs(
-              new HashMap<String, Object>(),
-              new HashMap<String, Object>(),
-              new ArrayList<Map<String, Object>>(),
-              new ArrayList<Map<String, Object>>(),
-              new HashMap<String, Object>(),
-              new ArrayList<Map<String, Object>>(),
-              new HashMap<String, Object>());
+          new HashMap<String, Object>(),
+          new HashMap<String, Object>(),
+          new ArrayList<Map<String, Object>>(),
+          new ArrayList<Map<String, Object>>(),
+          new HashMap<String, Object>(),
+          new ArrayList<Map<String, Object>>());
       return;
     }
     try {
@@ -361,15 +360,13 @@ public class VarCache {
           defaults, Constants.Defaults.EVENT_RULES_KEY, "[]");
       String regions = aesContext.decodePreference(defaults, Constants.Defaults.REGIONS_KEY, "{}");
       String variants = aesContext.decodePreference(defaults, Constants.Keys.VARIANTS, "[]");
-      String contentAssignments = aesContext.decodePreference(defaults, Constants.Keys.CONTENT_ASSIGNMENTS, "{}");
       applyVariableDiffs(
-              JsonConverter.fromJson(variables),
-              JsonConverter.fromJson(messages),
-              JsonConverter.<Map<String, Object>>listFromJson(new JSONArray(updateRules)),
-              JsonConverter.<Map<String, Object>>listFromJson(new JSONArray(eventRules)),
-              JsonConverter.fromJson(regions),
-              JsonConverter.<Map<String, Object>>listFromJson(new JSONArray(variants)),
-              JsonConverter.fromJson(contentAssignments));
+          JsonConverter.fromJson(variables),
+          JsonConverter.fromJson(messages),
+          JsonConverter.<Map<String, Object>>listFromJson(new JSONArray(updateRules)),
+          JsonConverter.<Map<String, Object>>listFromJson(new JSONArray(eventRules)),
+          JsonConverter.fromJson(regions),
+          JsonConverter.<Map<String, Object>>listFromJson(new JSONArray(variants)));
       String deviceId = aesContext.decodePreference(defaults, Constants.Params.DEVICE_ID, null);
       if (deviceId != null) {
         if (Util.isValidDeviceId(deviceId)) {
@@ -447,16 +444,6 @@ public class VarCache {
     } catch (JSONException e1) {
       Log.e("Error converting " + variants + " to JSON.\n" + Log.getStackTraceString(e1));
     }
-
-    try {
-      if (contentAssignments != null) {
-        String contentAssignmentsJson = aesContext.encrypt(JsonConverter.toJson(contentAssignments));
-        editor.putString(Constants.Keys.CONTENT_ASSIGNMENTS, contentAssignmentsJson);
-      }
-    } catch (Throwable e) {
-      Util.handleException(e);
-    }
-
     editor.putString(Constants.Params.DEVICE_ID, aesContext.encrypt(Request.deviceId()));
     editor.putString(Constants.Params.USER_ID, aesContext.encrypt(Request.userId()));
     editor.putString(Constants.Keys.LOGGING_ENABLED,
@@ -512,8 +499,7 @@ public class VarCache {
       List<Map<String, Object>> updateRules,
       List<Map<String, Object>> eventRules,
       Map<String, Object> regions,
-      List<Map<String, Object>> variants,
-      Map<String, Object> contentAssignments) {
+      List<Map<String, Object>> variants) {
     if (diffs != null) {
       VarCache.diffs = diffs;
       computeMergedDictionary();
@@ -590,9 +576,6 @@ public class VarCache {
       VarCache.variants = variants;
     }
 
-    if (contentAssignments != null) {
-      VarCache.contentAssignments = contentAssignments;
-    }
     contentVersion++;
 
     if (!silent) {

--- a/AndroidSDKCore/src/main/java/com/leanplum/internal/VarCache.java
+++ b/AndroidSDKCore/src/main/java/com/leanplum/internal/VarCache.java
@@ -87,6 +87,7 @@ public class VarCache {
   private static boolean silent;
   private static int contentVersion;
   private static Map<String, Object> userAttributes;
+  private static Map<String, Object> contentAssignments;
 
   private static final String NAME_COMPONENT_REGEX = "(?:[^\\.\\[.(\\\\]+|\\\\.)+";
   private static final Pattern NAME_COMPONENT_PATTERN = Pattern.compile(NAME_COMPONENT_REGEX);
@@ -320,6 +321,14 @@ public class VarCache {
 
   public static boolean hasReceivedDiffs() {
     return hasReceivedDiffs;
+  }
+
+  public static Map<String, Object> getContentAssignments() {
+    return contentAssignments;
+  }
+
+  public static void setContentAssignments(Map<String, Object> _contentAssignments) {
+    contentAssignments = _contentAssignments;
   }
 
   public static void loadDiffs() {
@@ -878,6 +887,7 @@ public class VarCache {
    */
   public static void reset() {
     vars.clear();
+    contentAssignments.clear();
     fileAttributes.clear();
     fileStreams.clear();
     valuesFromClient.clear();

--- a/AndroidSDKCore/src/main/java/com/leanplum/internal/VarCache.java
+++ b/AndroidSDKCore/src/main/java/com/leanplum/internal/VarCache.java
@@ -887,7 +887,7 @@ public class VarCache {
    */
   public static void reset() {
     vars.clear();
-    contentAssignments.clear();
+    contentAssignments = null;
     fileAttributes.clear();
     fileStreams.clear();
     valuesFromClient.clear();

--- a/AndroidSDKCore/src/main/java/com/leanplum/internal/VarCache.java
+++ b/AndroidSDKCore/src/main/java/com/leanplum/internal/VarCache.java
@@ -87,7 +87,7 @@ public class VarCache {
   private static boolean silent;
   private static int contentVersion;
   private static Map<String, Object> userAttributes;
-  private static Map<String, Object> contentAssignments;
+  private static Map<String, Object> variantDebugInfo;
 
   private static final String NAME_COMPONENT_REGEX = "(?:[^\\.\\[.(\\\\]+|\\\\.)+";
   private static final Pattern NAME_COMPONENT_PATTERN = Pattern.compile(NAME_COMPONENT_REGEX);
@@ -323,12 +323,12 @@ public class VarCache {
     return hasReceivedDiffs;
   }
 
-  public static Map<String, Object> getContentAssignments() {
-    return contentAssignments;
+  public static Map<String, Object> getVariantDebugInfo() {
+    return variantDebugInfo;
   }
 
-  public static void setContentAssignments(Map<String, Object> _contentAssignments) {
-    contentAssignments = _contentAssignments;
+  public static void setVariantDebugInfo(Map<String, Object> _variantDebugInfo) {
+    variantDebugInfo= _variantDebugInfo;
   }
 
   public static void loadDiffs() {
@@ -887,7 +887,7 @@ public class VarCache {
    */
   public static void reset() {
     vars.clear();
-    contentAssignments = null;
+    variantDebugInfo = null;
     fileAttributes.clear();
     fileStreams.clear();
     valuesFromClient.clear();

--- a/AndroidSDKCore/src/main/java/com/leanplum/internal/VarCache.java
+++ b/AndroidSDKCore/src/main/java/com/leanplum/internal/VarCache.java
@@ -328,7 +328,7 @@ public class VarCache {
   }
 
   public static void setVariantDebugInfo(Map<String, Object> _variantDebugInfo) {
-    variantDebugInfo= _variantDebugInfo;
+    variantDebugInfo = _variantDebugInfo;
   }
 
   public static void loadDiffs() {

--- a/AndroidSDKCore/src/main/java/com/leanplum/internal/VarCache.java
+++ b/AndroidSDKCore/src/main/java/com/leanplum/internal/VarCache.java
@@ -339,12 +339,13 @@ public class VarCache {
     SharedPreferences defaults = context.getSharedPreferences(LEANPLUM, Context.MODE_PRIVATE);
     if (Request.token() == null) {
       applyVariableDiffs(
-          new HashMap<String, Object>(),
-          new HashMap<String, Object>(),
-          new ArrayList<Map<String, Object>>(),
-          new ArrayList<Map<String, Object>>(),
-          new HashMap<String, Object>(),
-          new ArrayList<Map<String, Object>>());
+              new HashMap<String, Object>(),
+              new HashMap<String, Object>(),
+              new ArrayList<Map<String, Object>>(),
+              new ArrayList<Map<String, Object>>(),
+              new HashMap<String, Object>(),
+              new ArrayList<Map<String, Object>>(),
+              new HashMap<String, Object>());
       return;
     }
     try {
@@ -360,13 +361,15 @@ public class VarCache {
           defaults, Constants.Defaults.EVENT_RULES_KEY, "[]");
       String regions = aesContext.decodePreference(defaults, Constants.Defaults.REGIONS_KEY, "{}");
       String variants = aesContext.decodePreference(defaults, Constants.Keys.VARIANTS, "[]");
+      String contentAssignments = aesContext.decodePreference(defaults, Constants.Keys.CONTENT_ASSIGNMENTS, "{}");
       applyVariableDiffs(
-          JsonConverter.fromJson(variables),
-          JsonConverter.fromJson(messages),
-          JsonConverter.<Map<String, Object>>listFromJson(new JSONArray(updateRules)),
-          JsonConverter.<Map<String, Object>>listFromJson(new JSONArray(eventRules)),
-          JsonConverter.fromJson(regions),
-          JsonConverter.<Map<String, Object>>listFromJson(new JSONArray(variants)));
+              JsonConverter.fromJson(variables),
+              JsonConverter.fromJson(messages),
+              JsonConverter.<Map<String, Object>>listFromJson(new JSONArray(updateRules)),
+              JsonConverter.<Map<String, Object>>listFromJson(new JSONArray(eventRules)),
+              JsonConverter.fromJson(regions),
+              JsonConverter.<Map<String, Object>>listFromJson(new JSONArray(variants)),
+              JsonConverter.fromJson(contentAssignments));
       String deviceId = aesContext.decodePreference(defaults, Constants.Params.DEVICE_ID, null);
       if (deviceId != null) {
         if (Util.isValidDeviceId(deviceId)) {
@@ -444,6 +447,16 @@ public class VarCache {
     } catch (JSONException e1) {
       Log.e("Error converting " + variants + " to JSON.\n" + Log.getStackTraceString(e1));
     }
+
+    try {
+      if (contentAssignments != null) {
+        String contentAssignmentsJson = aesContext.encrypt(JsonConverter.toJson(contentAssignments));
+        editor.putString(Constants.Keys.CONTENT_ASSIGNMENTS, contentAssignmentsJson);
+      }
+    } catch (Throwable e) {
+      Util.handleException(e);
+    }
+
     editor.putString(Constants.Params.DEVICE_ID, aesContext.encrypt(Request.deviceId()));
     editor.putString(Constants.Params.USER_ID, aesContext.encrypt(Request.userId()));
     editor.putString(Constants.Keys.LOGGING_ENABLED,
@@ -499,7 +512,8 @@ public class VarCache {
       List<Map<String, Object>> updateRules,
       List<Map<String, Object>> eventRules,
       Map<String, Object> regions,
-      List<Map<String, Object>> variants) {
+      List<Map<String, Object>> variants,
+      Map<String, Object> contentAssignments) {
     if (diffs != null) {
       VarCache.diffs = diffs;
       computeMergedDictionary();
@@ -576,6 +590,9 @@ public class VarCache {
       VarCache.variants = variants;
     }
 
+    if (contentAssignments != null) {
+      VarCache.contentAssignments = contentAssignments;
+    }
     contentVersion++;
 
     if (!silent) {

--- a/AndroidSDKCore/src/main/java/com/leanplum/internal/VarCache.java
+++ b/AndroidSDKCore/src/main/java/com/leanplum/internal/VarCache.java
@@ -24,7 +24,6 @@ package com.leanplum.internal;
 import android.content.Context;
 import android.content.SharedPreferences;
 
-import com.google.gson.Gson;
 import com.leanplum.ActionContext;
 import com.leanplum.CacheUpdateBlock;
 import com.leanplum.Leanplum;
@@ -363,15 +362,8 @@ public class VarCache {
           defaults, Constants.Defaults.EVENT_RULES_KEY, "[]");
       String regions = aesContext.decodePreference(defaults, Constants.Defaults.REGIONS_KEY, "{}");
       String variants = aesContext.decodePreference(defaults, Constants.Keys.VARIANTS, "[]");
-      VariantDebugInfo debugInfo = null;
-
-      try {
-        Gson gson = new Gson();
-        String variantDebugInfo = aesContext.decodePreference(defaults, Constants.Keys.VARIANT_DEBUG_INFO, "{}");
-        debugInfo = gson.fromJson(variantDebugInfo, VariantDebugInfo.class);
-      } catch (Throwable t) {
-        Util.handleException(t);
-      }
+      String variantDebugInfo = aesContext.decodePreference(defaults, Constants.Keys.VARIANT_DEBUG_INFO, "{}");
+      VariantDebugInfo debugInfo = new VariantDebugInfo(JsonConverter.fromJson(variantDebugInfo));
 
       applyVariableDiffs(
           JsonConverter.fromJson(variables),
@@ -459,14 +451,9 @@ public class VarCache {
       Log.e("Error converting " + variants + " to JSON.\n" + Log.getStackTraceString(e1));
     }
 
-    try {
-      if (variantDebugInfo != null) {
-        Gson gson = new Gson();
-        String variantDebugInfoJson = gson.toJson(variantDebugInfo);
-        editor.putString(Constants.Keys.VARIANT_DEBUG_INFO, aesContext.encrypt(variantDebugInfoJson));
-      }
-    } catch (Throwable t) {
-      Log.e("Error converting variantDebugInfo to JSON.\n" + Log.getStackTraceString(t));
+    if (variantDebugInfo != null) {
+      String variantDebugInfoJson = JsonConverter.toJson(variantDebugInfo.asDictionary());
+      editor.putString(Constants.Keys.VARIANT_DEBUG_INFO, aesContext.encrypt(variantDebugInfoJson));
     }
 
     editor.putString(Constants.Params.DEVICE_ID, aesContext.encrypt(Request.deviceId()));

--- a/AndroidSDKCore/src/main/java/com/leanplum/internal/VarCache.java
+++ b/AndroidSDKCore/src/main/java/com/leanplum/internal/VarCache.java
@@ -30,6 +30,7 @@ import com.leanplum.Leanplum;
 import com.leanplum.LocationManager;
 import com.leanplum.Var;
 import com.leanplum.internal.FileManager.HashResults;
+import com.leanplum.models.VariantDebugInfo;
 import com.leanplum.utils.SharedPreferencesUtil;
 
 import org.json.JSONArray;
@@ -87,7 +88,7 @@ public class VarCache {
   private static boolean silent;
   private static int contentVersion;
   private static Map<String, Object> userAttributes;
-  private static Map<String, Object> variantDebugInfo;
+  private static VariantDebugInfo variantDebugInfo;
 
   private static final String NAME_COMPONENT_REGEX = "(?:[^\\.\\[.(\\\\]+|\\\\.)+";
   private static final Pattern NAME_COMPONENT_PATTERN = Pattern.compile(NAME_COMPONENT_REGEX);
@@ -323,11 +324,11 @@ public class VarCache {
     return hasReceivedDiffs;
   }
 
-  public static Map<String, Object> getVariantDebugInfo() {
+  public static VariantDebugInfo getVariantDebugInfo() {
     return variantDebugInfo;
   }
 
-  public static void setVariantDebugInfo(Map<String, Object> _variantDebugInfo) {
+  public static void setVariantDebugInfo(VariantDebugInfo _variantDebugInfo) {
     variantDebugInfo = _variantDebugInfo;
   }
 

--- a/AndroidSDKCore/src/main/java/com/leanplum/models/ABTest.java
+++ b/AndroidSDKCore/src/main/java/com/leanplum/models/ABTest.java
@@ -1,0 +1,42 @@
+package com.leanplum.models;
+
+import java.util.Map;
+
+public class ABTest {
+    private Double id;
+    private Double variantId;
+    private Map<String, Object> vars;
+
+    public ABTest() {
+    }
+
+    public ABTest(Double id, Double variantId, Map<String, Object> vars) {
+        this.id = id;
+        this.variantId = variantId;
+        this.vars = vars;
+    }
+
+    public Double getId() {
+        return id;
+    }
+
+    public void setId(Double id) {
+        this.id = id;
+    }
+
+    public Double getVariantId() {
+        return id;
+    }
+
+    public void setVariantId(Double variantId) {
+        this.variantId = variantId;
+    }
+
+    public Map<String, Object> getVars() {
+        return vars;
+    }
+
+    public void setVars(Map<String, Object> vars) {
+        this.vars = vars;
+    }
+}

--- a/AndroidSDKCore/src/main/java/com/leanplum/models/ABTest.java
+++ b/AndroidSDKCore/src/main/java/com/leanplum/models/ABTest.java
@@ -4,14 +4,14 @@ import java.util.HashMap;
 import java.util.Map;
 
 public class ABTest {
-    private String id;
-    private String variantId;
+    private Long id;
+    private Long variantId;
     private Map<String, Object> vars;
 
     public ABTest() {
     }
 
-    public ABTest(String id, String variantId, Map<String, Object> vars) {
+    public ABTest(Long id, Long variantId, Map<String, Object> vars) {
         this.id = id;
         this.variantId = variantId;
         this.vars = vars;
@@ -20,24 +20,24 @@ public class ABTest {
     //todo: move to framework
     public ABTest(Map<String, Object> dict) {
         Map<String, Object> vars = (Map<String, Object>) dict.get("vars");
-        this.id = (String) dict.get("id");
-        this.variantId = (String) dict.get("variantId");
+        this.id = (Long) dict.get("id");
+        this.variantId = (Long) dict.get("variantId");
         this.vars = vars;
     }
 
-    public String getId() {
+    public Long getId() {
         return id;
     }
 
-    public void setId(String id) {
+    public void setId(Long id) {
         this.id = id;
     }
 
-    public String getVariantId() {
+    public Long getVariantId() {
         return id;
     }
 
-    public void setVariantId(String variantId) {
+    public void setVariantId(Long variantId) {
         this.variantId = variantId;
     }
 

--- a/AndroidSDKCore/src/main/java/com/leanplum/models/ABTest.java
+++ b/AndroidSDKCore/src/main/java/com/leanplum/models/ABTest.java
@@ -1,34 +1,43 @@
 package com.leanplum.models;
 
+import java.util.HashMap;
 import java.util.Map;
 
 public class ABTest {
-    private Double id;
-    private Double variantId;
+    private String id;
+    private String variantId;
     private Map<String, Object> vars;
 
     public ABTest() {
     }
 
-    public ABTest(Double id, Double variantId, Map<String, Object> vars) {
+    public ABTest(String id, String variantId, Map<String, Object> vars) {
         this.id = id;
         this.variantId = variantId;
         this.vars = vars;
     }
 
-    public Double getId() {
+    //todo: move to framework
+    public ABTest(Map<String, Object> dict) {
+        Map<String, Object> vars = (Map<String, Object>) dict.get("vars");
+        this.id = (String) dict.get("id");
+        this.variantId = (String) dict.get("variantId");
+        this.vars = vars;
+    }
+
+    public String getId() {
         return id;
     }
 
-    public void setId(Double id) {
+    public void setId(String id) {
         this.id = id;
     }
 
-    public Double getVariantId() {
+    public String getVariantId() {
         return id;
     }
 
-    public void setVariantId(Double variantId) {
+    public void setVariantId(String variantId) {
         this.variantId = variantId;
     }
 
@@ -39,4 +48,14 @@ public class ABTest {
     public void setVars(Map<String, Object> vars) {
         this.vars = vars;
     }
+
+    //todo: move to framework
+    public Map<String, Object> asDictionary() {
+        Map<String, Object> dict = new HashMap<>();
+        dict.put("id", id);
+        dict.put("variantId", variantId);
+        dict.put("vars", vars);
+        return dict;
+    }
+
 }

--- a/AndroidSDKCore/src/main/java/com/leanplum/models/VariantDebugInfo.java
+++ b/AndroidSDKCore/src/main/java/com/leanplum/models/VariantDebugInfo.java
@@ -12,7 +12,7 @@ public class VariantDebugInfo {
         this.abTests = abTests;
     }
 
-    public List<ABTest> GetAbTests() {
+    public List<ABTest> getAbTests() {
         return abTests;
     }
 

--- a/AndroidSDKCore/src/main/java/com/leanplum/models/VariantDebugInfo.java
+++ b/AndroidSDKCore/src/main/java/com/leanplum/models/VariantDebugInfo.java
@@ -17,7 +17,11 @@ public class VariantDebugInfo {
 
     //todo: move to framework
     public VariantDebugInfo(Map<String, Object> dict) {
-        List<ABTest> abTests = (List<ABTest>) dict.get("abTests");
+        List<Map<String, Object>> abTestDicts = (List<Map<String, Object>>) dict.get("abTests");
+        List<ABTest> abTests = new ArrayList<>();
+        for (Map<String, Object> abTestDict : abTestDicts) {
+            abTests.add(new ABTest(abTestDict));
+        }
         this.abTests = abTests;
     }
 

--- a/AndroidSDKCore/src/main/java/com/leanplum/models/VariantDebugInfo.java
+++ b/AndroidSDKCore/src/main/java/com/leanplum/models/VariantDebugInfo.java
@@ -1,0 +1,23 @@
+package com.leanplum.models;
+
+import java.util.List;
+
+public class VariantDebugInfo {
+    private List<ABTest> abTests;
+
+    public VariantDebugInfo() {
+    }
+
+    public VariantDebugInfo(List<ABTest> abTests) {
+        this.abTests = abTests;
+    }
+
+    public List<ABTest> GetAbTests() {
+        return abTests;
+    }
+
+    public void setAbTests(List<ABTest> abTests) {
+        this.abTests = abTests;
+    }
+
+}

--- a/AndroidSDKCore/src/main/java/com/leanplum/models/VariantDebugInfo.java
+++ b/AndroidSDKCore/src/main/java/com/leanplum/models/VariantDebugInfo.java
@@ -1,6 +1,9 @@
 package com.leanplum.models;
 
+import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 public class VariantDebugInfo {
     private List<ABTest> abTests;
@@ -12,12 +15,29 @@ public class VariantDebugInfo {
         this.abTests = abTests;
     }
 
+    //todo: move to framework
+    public VariantDebugInfo(Map<String, Object> dict) {
+        List<ABTest> abTests = (List<ABTest>) dict.get("abTests");
+        this.abTests = abTests;
+    }
+
     public List<ABTest> getAbTests() {
         return abTests;
     }
 
     public void setAbTests(List<ABTest> abTests) {
         this.abTests = abTests;
+    }
+
+    //todo: move to framework
+    public Map<String, Object> asDictionary() {
+        List<Map<String, Object>> abTestDicts = new ArrayList<>();
+        for (ABTest abTest : abTests) {
+            abTestDicts.add(abTest.asDictionary());
+        }
+        Map<String, Object> dict = new HashMap<>();
+        dict.put("abTests", abTestDicts);
+        return dict;
     }
 
 }

--- a/AndroidSDKPush/src/main/java/com/leanplum/LeanplumPushService.java
+++ b/AndroidSDKPush/src/main/java/com/leanplum/LeanplumPushService.java
@@ -270,7 +270,7 @@ public class LeanplumPushService {
                       messages = null;
                     }
                     if (values != null || messages != null) {
-                      VarCache.applyVariableDiffs(values, messages, null, null, regions, variants, null);
+                      VarCache.applyVariableDiffs(values, messages, null, null, regions, variants);
                     }
                   }
                   onComplete.variablesChanged();

--- a/AndroidSDKPush/src/main/java/com/leanplum/LeanplumPushService.java
+++ b/AndroidSDKPush/src/main/java/com/leanplum/LeanplumPushService.java
@@ -270,7 +270,7 @@ public class LeanplumPushService {
                       messages = null;
                     }
                     if (values != null || messages != null) {
-                      VarCache.applyVariableDiffs(values, messages, null, null, regions, variants);
+                      VarCache.applyVariableDiffs(values, messages, null, null, regions, variants, null);
                     }
                   }
                   onComplete.variablesChanged();

--- a/AndroidSDKTests/src/test/java/com/leanplum/LeanplumActionContextTest.java
+++ b/AndroidSDKTests/src/test/java/com/leanplum/LeanplumActionContextTest.java
@@ -288,7 +288,7 @@ public class LeanplumActionContextTest extends AbstractTest {
         VarCache.applyVariableDiffs(null, new HashMap<>(
                 ImmutableMap.<String, Object>of(Long.toString(chainedMessageId),
                 ImmutableMap.<String, Object>of())),
-                null, null, null, null, null);
+                null, null, null, null);
         // Since it now exists locally, we should return false for forceContentUpdate.
         Assert.assertFalse(ActionContext.shouldForceContentUpdateForChainedMessage(
                 JsonConverter.fromJson(jsonData)));

--- a/AndroidSDKTests/src/test/java/com/leanplum/LeanplumActionContextTest.java
+++ b/AndroidSDKTests/src/test/java/com/leanplum/LeanplumActionContextTest.java
@@ -288,7 +288,7 @@ public class LeanplumActionContextTest extends AbstractTest {
         VarCache.applyVariableDiffs(null, new HashMap<>(
                 ImmutableMap.<String, Object>of(Long.toString(chainedMessageId),
                 ImmutableMap.<String, Object>of())),
-                null, null, null, null);
+                null, null, null, null, null);
         // Since it now exists locally, we should return false for forceContentUpdate.
         Assert.assertFalse(ActionContext.shouldForceContentUpdateForChainedMessage(
                 JsonConverter.fromJson(jsonData)));

--- a/AndroidSDKTests/src/test/java/com/leanplum/LeanplumTest.java
+++ b/AndroidSDKTests/src/test/java/com/leanplum/LeanplumTest.java
@@ -383,7 +383,7 @@ public class LeanplumTest extends AbstractTest {
       }});
     }};
 
-    VarCache.applyVariableDiffs(null, messages, null, null, null, variants);
+    VarCache.applyVariableDiffs(null, messages, null, null, null, variants, null);
     assertEquals(variants, Leanplum.variants());
     assertEquals(messages, Leanplum.messageMetadata());
   }

--- a/AndroidSDKTests/src/test/java/com/leanplum/LeanplumTest.java
+++ b/AndroidSDKTests/src/test/java/com/leanplum/LeanplumTest.java
@@ -40,6 +40,7 @@ import com.leanplum.internal.FileManager;
 import com.leanplum.internal.JsonConverter;
 import com.leanplum.internal.LeanplumEventDataManager;
 import com.leanplum.internal.LeanplumEventDataManagerTest;
+import com.leanplum.internal.Log;
 import com.leanplum.internal.Request;
 import com.leanplum.internal.Util;
 import com.leanplum.internal.VarCache;
@@ -357,6 +358,36 @@ public class LeanplumTest extends AbstractTest {
     countDownLatch.await(10, TimeUnit.SECONDS);
     assertTrue(Leanplum.hasStarted());
     assertTrue(Request.userId().equals(userId));
+  }
+
+  @Test
+  public void testStartWithVariantDebugInfo() {
+    ResponseHelper.seedResponse("/responses/simple_start_response.json");
+
+    // Expected request params.
+    final HashMap<String, Object> expectedRequestParams = CollectionUtil.newHashMap(
+            "city", "(detect)",
+            "country", "(detect)",
+            "location", "(detect)",
+            "region", "(detect)",
+            "locale", "en_US",
+            "includeVariantDebugInfo", true
+    );
+
+    Leanplum.setVariantDebugInfoEnabled(true);
+    // Validate request.
+    RequestHelper.addRequestHandler(new RequestHelper.RequestHandler() {
+      @Override
+      public void onRequest(String httpMethod, String apiMethod, Map<String, Object> params) {
+        assertEquals(Constants.Methods.START, apiMethod);
+
+        // Validate request.
+        assertTrue(params.keySet().containsAll(expectedRequestParams.keySet()));
+        assertTrue(params.values().containsAll(expectedRequestParams.values()));
+      }
+    });
+    Leanplum.start(mContext);
+    assertTrue(Leanplum.hasStarted());
   }
 
   /**
@@ -771,6 +802,13 @@ public class LeanplumTest extends AbstractTest {
     // Validate components.
     assertArrayEquals(groupStringVariable.nameComponents(), new String[] {"groups", "strings"});
     assertArrayEquals(groupIntegerVariable.nameComponents(), new String[] {"groups", "integers"});
+  }
+
+  @Test
+  public void testVariantDebugInfo() throws Exception {
+    setupSDK(mContext, "/responses/start_with_variant_debug_info_response.json");
+    assertNotNull(Leanplum.variantDebugInfo());
+    assertEquals(Leanplum.variantDebugInfo().getAbTests().size(), 2);
   }
 
   @Test

--- a/AndroidSDKTests/src/test/java/com/leanplum/LeanplumTest.java
+++ b/AndroidSDKTests/src/test/java/com/leanplum/LeanplumTest.java
@@ -383,7 +383,7 @@ public class LeanplumTest extends AbstractTest {
       }});
     }};
 
-    VarCache.applyVariableDiffs(null, messages, null, null, null, variants, null);
+    VarCache.applyVariableDiffs(null, messages, null, null, null, variants);
     assertEquals(variants, Leanplum.variants());
     assertEquals(messages, Leanplum.messageMetadata());
   }

--- a/AndroidSDKTests/src/test/resources/responses/start_with_variant_debug_info_response.json
+++ b/AndroidSDKTests/src/test/resources/responses/start_with_variant_debug_info_response.json
@@ -1,0 +1,296 @@
+{
+    "response": [{
+                 "uploadUrl": "https:\/\/www.leanplum.com\/_ah\/upload\/AMmfu6by_4mWZUn19c8v_omIeRezDaIfzqCosKTZTY4HnsxrA963YsrYMMnTPd538fmb4Gyx17-evF7X_QBqFIYjwPuTeHzihGM5-FHkW8o1zKxNl8E9yB2ZiumXvOj-gMbotIZYA1I_\/ALBNUaYAAAAAWAZDRSTEVp_wufYkJ7EFVZK_9eVhM32E\/",
+                 "interfaceRules": [
+                 
+                 ],
+                 "actionDefinitions": {
+                 "Confirm": {
+                 "values": {
+                 "Accept action": {
+                 "__name__": ""
+                 },
+                 "Message": "Confirmation message goes here.",
+                 "Cancel action": {
+                 "__name__": ""
+                 },
+                 "Accept text": "Yes",
+                 "Cancel text": "No",
+                 "Title": "LeanplumSample"
+                 },
+                 "kinds": {
+                 "Accept action": "ACTION",
+                 "Message": "TEXT",
+                 "Cancel action": "ACTION",
+                 "Accept text": "TEXT",
+                 "Cancel text": "TEXT",
+                 "Title": "TEXT"
+                 },
+                 "kind": 3,
+                 "options": null
+                 },
+                 "Center Popup": {
+                 "values": {
+                 "Layout": {
+                 "Height": 250,
+                 "Width": 300
+                 },
+                 "Accept action": {
+                 "__name__": ""
+                 },
+                 "Message": {
+                 "Text": "Popup message goes here.",
+                 "Color": 4278190080
+                 },
+                 "Accept button": {
+                 "Text": "OK",
+                 "Text color": 4278221311,
+                 "Background color": 4294967295
+                 },
+                 "Background color": 4294967295,
+                 "Title": {
+                 "Text": "LeanplumSample",
+                 "Color": 4278190080
+                 },
+                 "Background image": ""
+                 },
+                 "kinds": {
+                 "Layout.Width": "NUMBER",
+                 "Accept action": "ACTION",
+                 "Message": "GROUP",
+                 "Message.Color": "COLOR",
+                 "Accept button": "GROUP",
+                 "Title": "GROUP",
+                 "Background color": "COLOR",
+                 "Layout.Height": "NUMBER",
+                 "Layout": "GROUP",
+                 "Message.Text": "TEXT",
+                 "Accept button.Text": "TEXT",
+                 "Accept button.Background color": "COLOR",
+                 "Title.Color": "COLOR",
+                 "Accept button.Text color": "COLOR",
+                 "Title.Text": "TEXT",
+                 "Background image": "FILE"
+                 },
+                 "kind": 3,
+                 "options": null
+                 },
+                 "Alert": {
+                 "values": {
+                 "Dismiss action": {
+                 "__name__": ""
+                 },
+                 "Message": "Alert message goes here.",
+                 "Dismiss text": "OK",
+                 "Title": "LeanplumSample"
+                 },
+                 "kinds": {
+                 "Dismiss action": "ACTION",
+                 "Message": "TEXT",
+                 "Dismiss text": "TEXT",
+                 "Title": "TEXT"
+                 },
+                 "kind": 3,
+                 "options": null
+                 },
+                 "Web Interstitial": {
+                 "values": {
+                 "Has dismiss button": true,
+                 "Close URL": "http:\/\/leanplum:close",
+                 "URL": "http:\/\/www.example.com"
+                 },
+                 "kinds": {
+                 "Has dismiss button": "BOOLEAN",
+                 "Close URL": "TEXT",
+                 "URL": "TEXT"
+                 },
+                 "kind": 3,
+                 "options": null
+                 },
+                 "Register For Push": {
+                 "values": {
+                 
+                 },
+                 "kinds": {
+                 
+                 },
+                 "kind": 2,
+                 "options": null
+                 },
+                 "Push Ask to Ask": {
+                 "values": {
+                 "Layout": {
+                 "Height": 250,
+                 "Width": 300
+                 },
+                 "Message": {
+                 "Text": "Tap OK to receive important notifications from our app.",
+                 "Color": 4278190080
+                 },
+                 "Cancel action": {
+                 "__name__": ""
+                 },
+                 "Accept button": {
+                 "Text": "OK",
+                 "Text color": 4278221311,
+                 "Background color": 4294967295
+                 },
+                 "Cancel button": {
+                 "Text": "Maybe Later",
+                 "Text color": 4286545791,
+                 "Background color": 4294967295
+                 },
+                 "Background color": 4294967295,
+                 "Title": {
+                 "Text": "LeanplumSample",
+                 "Color": 4278190080
+                 },
+                 "Background image": ""
+                 },
+                 "kinds": {
+                 "Layout.Width": "NUMBER",
+                 "Cancel button.Background color": "COLOR",
+                 "Message": "GROUP",
+                 "Message.Color": "COLOR",
+                 "Accept button": "GROUP",
+                 "Cancel button": "GROUP",
+                 "Title": "GROUP",
+                 "Background color": "COLOR",
+                 "Layout.Height": "NUMBER",
+                 "Layout": "GROUP",
+                 "Cancel action": "ACTION",
+                 "Message.Text": "TEXT",
+                 "Accept button.Text": "TEXT",
+                 "Accept button.Background color": "COLOR",
+                 "Title.Color": "COLOR",
+                 "Cancel button.Text": "TEXT",
+                 "Accept button.Text color": "COLOR",
+                 "Cancel button.Text color": "COLOR",
+                 "Title.Text": "TEXT",
+                 "Background image": "FILE"
+                 },
+                 "kind": 3,
+                 "options": null
+                 },
+                 "Interstitial": {
+                 "values": {
+                 "Accept action": {
+                 "__name__": ""
+                 },
+                 "Message": {
+                 "Text": "Interstitial message goes here.",
+                 "Color": 4278190080
+                 },
+                 "Accept button": {
+                 "Text": "OK",
+                 "Text color": 4278221311,
+                 "Background color": 4294967295
+                 },
+                 "Background color": 4294967295,
+                 "Title": {
+                 "Text": "LeanplumSample",
+                 "Color": 4278190080
+                 },
+                 "Background image": ""
+                 },
+                 "kinds": {
+                 "Accept action": "ACTION",
+                 "Message": "GROUP",
+                 "Accept button.Background color": "COLOR",
+                 "Accept button.Text": "TEXT",
+                 "Message.Text": "TEXT",
+                 "Title.Color": "COLOR",
+                 "Message.Color": "COLOR",
+                 "Accept button.Text color": "COLOR",
+                 "Accept button": "GROUP",
+                 "Background color": "COLOR",
+                 "Title": "GROUP",
+                 "Background image": "FILE",
+                 "Title.Text": "TEXT"
+                 },
+                 "kind": 3,
+                 "options": null
+                 },
+                 "Open URL": {
+                 "values": {
+                 "URL": "http:\/\/www.example.com"
+                 },
+                 "kinds": {
+                 "URL": "TEXT"
+                 },
+                 "kind": 2,
+                 "options": null
+                 }
+                 },
+                 "isRegistered": false,
+                 "regions": {
+                 
+                 },
+                 "messages": {
+                 
+                 },
+                 "varsFromCode": {
+                 "emptyDictionary": {
+                 "integerValue": 50
+                 },
+                 "dictionaryVariable": {
+                 "unicode": "?.!s\u0153\u2211\u03c0\u00f8\u02c6\u02dc\u00a8&\/\/.sd",
+                 "test_number": 535,
+                 "test_string": "string"
+                 },
+                 "arrayVariable": {
+                 "[0]": 1,
+                 "[2]": 3,
+                 "[1]": 2,
+                 "[3]": 4,
+                 "[4]": 5
+                 },
+                 "intVariable": 100,
+                 "boolVariable": false,
+                 "floatVariable": 5,
+                 "integerVariable": 1,
+                 "fileVariable": "Mario1.png",
+                 "stringVariable": "test_string"
+                 },
+                 "latestVersion": "1.4.0.2",
+                 "vars": {
+                 
+                 },
+                 "variantDebugInfo": {
+                 "abTests": [{
+                             "id": 200,
+                             "variantId": 201,
+                             "vars": {
+                             "buyButtonColor": "orange"
+                             }
+                             },
+                             {
+                             "id": 300,
+                             "variantId": 302,
+                             "vars": {
+                             "buyButtonColor": "red",
+                             "price": 10
+                             }
+                             }
+                             ]
+                 },
+                 "fileAttributes": {
+                 "PlugIns\/Leanplum-SDK_Tests.xctest\/test.file": {
+                 "_empty_": {
+                 "hash": "754e4eaae3c92be6e5d45c92b385c8fd",
+                 "size": 25
+                 }
+                 }
+                 },
+                 "token": "jRSv9YRFQ9yVPN80JP0quwHmN9rKk0Crm7awgTwZgCs",
+                 "variants": [
+                 
+                 ],
+                 "syncNewsfeed": false,
+                 "success": true,
+                 "interfaceEvents": [
+                 
+                 ],
+                 "isRegisteredFromOtherApp": false
+                 }]
+}


### PR DESCRIPTION
PRD: https://leanplum.atlassian.net/wiki/spaces/PRODDEV/pages/548503556/Tinder+Expose+granular+information+on+variables+and+A+B+tests+to+SDK

We allow a flag to be set in "includeVariantDebugInfo" that retrieves content assignment details from the server. We then allow access to this object through Leanplum.variantDebugInfo