### PR TITLE
Allow users to access VariantDebugInfo by setting a flag

### DIFF
--- a/AndroidSDKCore/src/main/java/com/leanplum/Leanplum.java
+++ b/AndroidSDKCore/src/main/java/com/leanplum/Leanplum.java
@@ -251,7 +251,9 @@ public class Leanplum {
   }
 
   /**
-   * Set variant debig info to be obtained from the server.
+   * Set this to true if you want details about the variable assignments
+   * on the server.
+   * Default is NO.
    */
   public static void setVariantDebugInfoEnabled(boolean variantDebugInfoEnabled) {
     LeanplumInternal.setIsVariantDebugInfoEnabled(variantDebugInfoEnabled);

--- a/AndroidSDKCore/src/main/java/com/leanplum/Leanplum.java
+++ b/AndroidSDKCore/src/main/java/com/leanplum/Leanplum.java
@@ -508,7 +508,8 @@ public class Leanplum {
             VarCache.getUpdateRuleDiffs(),
             VarCache.getEventRuleDiffs(),
             new HashMap<String, Object>(),
-            new ArrayList<Map<String, Object>>());
+            new ArrayList<Map<String, Object>>(),
+            new HashMap<String, Object>());
         LeanplumInbox.getInstance().update(new HashMap<String, LeanplumInboxMessage>(), 0, false);
         return;
       }
@@ -811,11 +812,7 @@ public class Leanplum {
               Constants.loggingEnabled = true;
             }
 
-            Map<String, Object> variantDebugInfo = JsonConverter.mapFromJsonOrDefault(
-                    response.optJSONObject(Constants.Keys.VARIANT_DEBUG_INFO));
-            if (variantDebugInfo.size() > 0) {
-              VarCache.setVariantDebugInfo(variantDebugInfo);
-            }
+            parseVariantDebugInfo(response);
 
             // Allow bidirectional realtime variable updates.
             if (Constants.isDevelopmentModeEnabled) {
@@ -938,6 +935,8 @@ public class Leanplum {
         response.optJSONObject(Constants.Keys.REGIONS));
     List<Map<String, Object>> variants = JsonConverter.listFromJsonOrDefault(
         response.optJSONArray(Constants.Keys.VARIANTS));
+    Map<String, Object> variantDebugInfo = JsonConverter.mapFromJsonOrDefault(
+            response.optJSONObject(Constants.Keys.VARIANT_DEBUG_INFO));
 
     if (alwaysApply
         || !values.equals(VarCache.getDiffs())
@@ -946,7 +945,7 @@ public class Leanplum {
         || !eventRules.equals(VarCache.getEventRuleDiffs())
         || !regions.equals(VarCache.regions())) {
       VarCache.applyVariableDiffs(values, messages, updateRules,
-          eventRules, regions, variants);
+          eventRules, regions, variants, variantDebugInfo);
     }
   }
 
@@ -1961,11 +1960,7 @@ public class Leanplum {
                 Constants.loggingEnabled = true;
               }
 
-              Map<String, Object> variantDebugInfo = JsonConverter.mapFromJsonOrDefault(
-                      response.optJSONObject(Constants.Keys.VARIANT_DEBUG_INFO));
-              if (variantDebugInfo.size() > 0) {
-                VarCache.setVariantDebugInfo(variantDebugInfo);
-              }
+              parseVariantDebugInfo(response);
             }
             if (callback != null) {
               OsHandler.getInstance().post(callback);
@@ -2127,5 +2122,13 @@ public class Leanplum {
    */
   public static boolean isLocationCollectionEnabled() {
     return locationCollectionEnabled;
+  }
+
+  private static void parseVariantDebugInfo(JSONObject response) {
+    Map<String, Object> variantDebugInfo = JsonConverter.mapFromJsonOrDefault(
+            response.optJSONObject(Constants.Keys.VARIANT_DEBUG_INFO));
+    if (variantDebugInfo.size() > 0) {
+      VarCache.setVariantDebugInfo(variantDebugInfo);
+    }
   }
 }

--- a/AndroidSDKCore/src/main/java/com/leanplum/Leanplum.java
+++ b/AndroidSDKCore/src/main/java/com/leanplum/Leanplum.java
@@ -254,7 +254,7 @@ public class Leanplum {
    * Set variant debig info to be obtained from the server.
    */
   public static void setVariantDebugInfoEnabled(boolean variantDebugInfoEnabled) {
-    LeanplumInternal.setVariantDebugInfoEnabled(variantDebugInfoEnabled);
+    LeanplumInternal.setIsVariantDebugInfoEnabled(variantDebugInfoEnabled);
   }
 
   /**

--- a/AndroidSDKCore/src/main/java/com/leanplum/Leanplum.java
+++ b/AndroidSDKCore/src/main/java/com/leanplum/Leanplum.java
@@ -251,10 +251,10 @@ public class Leanplum {
   }
 
   /**
-   * Set content assignments to be obtained from the server.
+   * Set variant debig info to be obtained from the server.
    */
-  public static void setContentAssignmentsEnabled(boolean contentAssignmentsEnabled) {
-    LeanplumInternal.setIsContentAssignmentsEnabled(contentAssignmentsEnabled);
+  public static void setVariantDebugInfoEnabled(boolean variantDebugInfoEnabled) {
+    LeanplumInternal.setVariantDebugInfoEnabled(variantDebugInfoEnabled);
   }
 
   /**
@@ -671,8 +671,8 @@ public class Leanplum {
     // Get the current inbox messages on the device.
     params.put(Constants.Params.INBOX_MESSAGES, LeanplumInbox.getInstance().messagesIds());
 
-    if (LeanplumInternal.getIsContentAssignmentsEnabled()) {
-      params.put(Constants.Params.INCLUDE_CONTENT_ASSIGNMENTS, true);
+    if (LeanplumInternal.getIsVariantDebugInfoEnabled()) {
+      params.put(Constants.Params.INCLUDE_VARIANT_DEBUG_INFO, true);
     }
 
     Util.initializePreLeanplumInstall(params);
@@ -811,10 +811,10 @@ public class Leanplum {
               Constants.loggingEnabled = true;
             }
 
-            Map<String, Object> contentAssignments = JsonConverter.mapFromJsonOrDefault(
-                    response.optJSONObject(Constants.Keys.CONTENT_ASSIGNMENTS));
-            if (contentAssignments.size() > 0) {
-              VarCache.setContentAssignments(contentAssignments);
+            Map<String, Object> variantDebugInfo = JsonConverter.mapFromJsonOrDefault(
+                    response.optJSONObject(Constants.Keys.VARIANT_DEBUG_INFO));
+            if (variantDebugInfo.size() > 0) {
+              VarCache.setVariantDebugInfo(variantDebugInfo);
             }
 
             // Allow bidirectional realtime variable updates.
@@ -1941,8 +1941,8 @@ public class Leanplum {
       Map<String, Object> params = new HashMap<>();
       params.put(Constants.Params.INCLUDE_DEFAULTS, Boolean.toString(false));
       params.put(Constants.Params.INBOX_MESSAGES, LeanplumInbox.getInstance().messagesIds());
-      if (LeanplumInternal.getIsContentAssignmentsEnabled()) {
-        params.put(Constants.Params.INCLUDE_CONTENT_ASSIGNMENTS, true);
+      if (LeanplumInternal.getIsVariantDebugInfoEnabled()) {
+        params.put(Constants.Params.INCLUDE_VARIANT_DEBUG_INFO, true);
       }
       Request req = Request.post(Constants.Methods.GET_VARS, params);
       req.onResponse(new Request.ResponseCallback() {
@@ -1962,10 +1962,10 @@ public class Leanplum {
                 Constants.loggingEnabled = true;
               }
 
-              Map<String, Object> contentAssignments = JsonConverter.mapFromJsonOrDefault(
-                      response.optJSONObject(Constants.Keys.CONTENT_ASSIGNMENTS));
-              if (contentAssignments.size() > 0) {
-                VarCache.setContentAssignments(contentAssignments);
+              Map<String, Object> variantDebugInfo = JsonConverter.mapFromJsonOrDefault(
+                      response.optJSONObject(Constants.Keys.VARIANT_DEBUG_INFO));
+              if (variantDebugInfo.size() > 0) {
+                VarCache.setVariantDebugInfo(variantDebugInfo);
               }
             }
             if (callback != null) {
@@ -2074,12 +2074,12 @@ public class Leanplum {
    * on the server.
    * Default is NO.
    */
-  public static Map<String, Object> contentAssignments() {
-    Map<String, Object> contentAssignments = VarCache.getContentAssignments();
-    if (contentAssignments == null) {
+  public static Map<String, Object> variantDebugInfo() {
+    Map<String, Object> variantDebugInfo = VarCache.getVariantDebugInfo();
+    if (variantDebugInfo == null) {
       return new HashMap<>();
     }
-    return contentAssignments;
+    return variantDebugInfo;
   }
 
   /**

--- a/AndroidSDKCore/src/main/java/com/leanplum/Leanplum.java
+++ b/AndroidSDKCore/src/main/java/com/leanplum/Leanplum.java
@@ -23,7 +23,6 @@ package com.leanplum;
 
 import android.app.Activity;
 import android.content.Context;
-import android.graphics.drawable.Drawable;
 import android.location.Location;
 import android.os.AsyncTask;
 import android.text.TextUtils;
@@ -51,7 +50,6 @@ import com.leanplum.internal.VarCache;
 import com.leanplum.messagetemplates.MessageTemplates;
 import com.leanplum.utils.BuildUtil;
 import com.leanplum.utils.SharedPreferencesUtil;
-import com.sun.tools.internal.jxc.ap.Const;
 
 import org.json.JSONArray;
 import org.json.JSONObject;

--- a/AndroidSDKCore/src/main/java/com/leanplum/Leanplum.java
+++ b/AndroidSDKCore/src/main/java/com/leanplum/Leanplum.java
@@ -671,9 +671,7 @@ public class Leanplum {
     // Get the current inbox messages on the device.
     params.put(Constants.Params.INBOX_MESSAGES, LeanplumInbox.getInstance().messagesIds());
 
-    if (LeanplumInternal.getIsVariantDebugInfoEnabled()) {
-      params.put(Constants.Params.INCLUDE_VARIANT_DEBUG_INFO, true);
-    }
+    params.put(Constants.Params.INCLUDE_VARIANT_DEBUG_INFO, LeanplumInternal.getIsVariantDebugInfoEnabled());
 
     Util.initializePreLeanplumInstall(params);
 
@@ -1941,9 +1939,8 @@ public class Leanplum {
       Map<String, Object> params = new HashMap<>();
       params.put(Constants.Params.INCLUDE_DEFAULTS, Boolean.toString(false));
       params.put(Constants.Params.INBOX_MESSAGES, LeanplumInbox.getInstance().messagesIds());
-      if (LeanplumInternal.getIsVariantDebugInfoEnabled()) {
-        params.put(Constants.Params.INCLUDE_VARIANT_DEBUG_INFO, true);
-      }
+      params.put(Constants.Params.INCLUDE_VARIANT_DEBUG_INFO, LeanplumInternal.getIsVariantDebugInfoEnabled());
+
       Request req = Request.post(Constants.Methods.GET_VARS, params);
       req.onResponse(new Request.ResponseCallback() {
         @Override
@@ -2070,9 +2067,7 @@ public class Leanplum {
   }
 
   /**
-   * Set this to true if you want details about the variable assignments
-   * on the server.
-   * Default is NO.
+   * Details about the variable assignments on the server.
    */
   public static Map<String, Object> variantDebugInfo() {
     Map<String, Object> variantDebugInfo = VarCache.getVariantDebugInfo();

--- a/AndroidSDKCore/src/main/java/com/leanplum/Leanplum.java
+++ b/AndroidSDKCore/src/main/java/com/leanplum/Leanplum.java
@@ -251,13 +251,6 @@ public class Leanplum {
   }
 
   /**
-   * Set content assignments to be obtained from the server.
-   */
-  public static void setContentAssignmentsEnabled(boolean contentAssignmentsEnabled) {
-    LeanplumInternal.setIsContentAssignmentsEnabled(contentAssignmentsEnabled);
-  }
-
-  /**
    * Whether screen tracking is enabled or not.
    *
    * @return Boolean - true if enabled
@@ -477,7 +470,12 @@ public class Leanplum {
   }
 
   static synchronized void start(final Context context, final String userId,
-      final Map<String, ?> attributes, StartCallback response, final Boolean isBackground) {
+                                 final Map<String, ?> attributes, StartCallback response, final Boolean isBackground) {
+    Leanplum.start(context, userId, attributes, response, isBackground, false);
+  }
+
+    static synchronized void start(final Context context, final String userId,
+                                   final Map<String, ?> attributes, StartCallback response, final Boolean isBackground, final boolean includeContentAssignments) {
     try {
       OsHandler.getInstance();
 
@@ -506,7 +504,8 @@ public class Leanplum {
             VarCache.getUpdateRuleDiffs(),
             VarCache.getEventRuleDiffs(),
             new HashMap<String, Object>(),
-            new ArrayList<Map<String, Object>>());
+            new ArrayList<Map<String, Object>>(),
+                new HashMap<String, Object>());
         LeanplumInbox.getInstance().update(new HashMap<String, LeanplumInboxMessage>(), 0, false);
         return;
       }
@@ -571,7 +570,7 @@ public class Leanplum {
         @Override
         protected Void doInBackground(Void... params) {
           try {
-            startHelper(userId, validAttributes, actuallyInBackground);
+            startHelper(userId, validAttributes, actuallyInBackground, includeContentAssignments);
           } catch (Throwable t) {
             Util.handleException(t);
           }
@@ -599,7 +598,7 @@ public class Leanplum {
   }
 
   private static void startHelper(
-      String userId, final Map<String, ?> attributes, final boolean isBackground) {
+      String userId, final Map<String, ?> attributes, final boolean isBackground, boolean includeContentAssignments) {
     LeanplumEventDataManager.init(context);
     checkAndStartNotificationsModules();
     Boolean limitAdTracking = null;
@@ -671,7 +670,7 @@ public class Leanplum {
     // Get the current inbox messages on the device.
     params.put(Constants.Params.INBOX_MESSAGES, LeanplumInbox.getInstance().messagesIds());
 
-    if (LeanplumInternal.getIsContentAssignmentsEnabled()) {
+    if (includeContentAssignments) {
       params.put(Constants.Params.INCLUDE_CONTENT_ASSIGNMENTS, true);
     }
 
@@ -938,6 +937,8 @@ public class Leanplum {
         response.optJSONObject(Constants.Keys.REGIONS));
     List<Map<String, Object>> variants = JsonConverter.listFromJsonOrDefault(
         response.optJSONArray(Constants.Keys.VARIANTS));
+    Map<String, Object> contentAssignments = JsonConverter.mapFromJsonOrDefault(
+            response.optJSONObject(Constants.Keys.CONTENT_ASSIGNMENTS));
 
     if (alwaysApply
         || !values.equals(VarCache.getDiffs())
@@ -946,7 +947,7 @@ public class Leanplum {
         || !eventRules.equals(VarCache.getEventRuleDiffs())
         || !regions.equals(VarCache.regions())) {
       VarCache.applyVariableDiffs(values, messages, updateRules,
-          eventRules, regions, variants);
+          eventRules, regions, variants, contentAssignments);
     }
   }
 
@@ -1931,6 +1932,20 @@ public class Leanplum {
    */
   @SuppressWarnings("SameParameterValue")
   public static void forceContentUpdate(final VariablesChangedCallback callback) {
+    forceContentUpdate(callback, false);
+  }
+
+  /**
+   * Forces content to update from the server. If variables have changed, the appropriate callbacks
+   * will fire. Use sparingly as if the app is updated, you'll have to deal with potentially
+   * inconsistent state or user experience.
+   *
+   * @param callback The callback to invoke when the call completes from the server. The callback
+   * will fire regardless of whether the variables have changed.
+   * @param includeContentAssignments Boolean to decide whether or not the response should include
+   *                                  details about the A/B tests running for this user.
+   */
+  public static void forceContentUpdate(final VariablesChangedCallback callback, boolean includeContentAssignments) {
     if (Constants.isNoop()) {
       if (callback != null) {
         OsHandler.getInstance().post(callback);
@@ -1941,7 +1956,7 @@ public class Leanplum {
       Map<String, Object> params = new HashMap<>();
       params.put(Constants.Params.INCLUDE_DEFAULTS, Boolean.toString(false));
       params.put(Constants.Params.INBOX_MESSAGES, LeanplumInbox.getInstance().messagesIds());
-      if (LeanplumInternal.getIsContentAssignmentsEnabled()) {
+      if (includeContentAssignments) {
         params.put(Constants.Params.INCLUDE_CONTENT_ASSIGNMENTS, true);
       }
       Request req = Request.post(Constants.Methods.GET_VARS, params);

--- a/AndroidSDKCore/src/main/java/com/leanplum/internal/Constants.java
+++ b/AndroidSDKCore/src/main/java/com/leanplum/internal/Constants.java
@@ -144,6 +144,7 @@ public class Constants {
     public static final String IAP_CURRENCY_CODE = "currencyCode";
     public static final String IAP_ITEM = "item";
     public static final String INCLUDE_DEFAULTS = "includeDefaults";
+    public static final String INCLUDE_CONTENT_ASSIGNMENTS = "includeContentAssignments";
     public static final String INCLUDE_MESSAGE_ID = "includeMessageId";
     public static final String INFO = "info";
     public static final String INSTALL_DATE = "installDate";
@@ -200,6 +201,7 @@ public class Constants {
     public static final String REGION = "region";
     public static final String REGION_STATE = "regionState";
     public static final String REGIONS = "regions";
+    public static final String CONTENT_ASSIGNMENTS = "contentAssignments";
     public static final String SIZE = "size";
     public static final String SUBTITLE = "Subtitle";
     public static final String SYNC_INBOX = "syncNewsfeed";

--- a/AndroidSDKCore/src/main/java/com/leanplum/internal/Constants.java
+++ b/AndroidSDKCore/src/main/java/com/leanplum/internal/Constants.java
@@ -144,7 +144,7 @@ public class Constants {
     public static final String IAP_CURRENCY_CODE = "currencyCode";
     public static final String IAP_ITEM = "item";
     public static final String INCLUDE_DEFAULTS = "includeDefaults";
-    public static final String INCLUDE_CONTENT_ASSIGNMENTS = "includeContentAssignments";
+    public static final String INCLUDE_VARIANT_DEBUG_INFO = "includeVariantDebugInfo";
     public static final String INCLUDE_MESSAGE_ID = "includeMessageId";
     public static final String INFO = "info";
     public static final String INSTALL_DATE = "installDate";
@@ -201,7 +201,7 @@ public class Constants {
     public static final String REGION = "region";
     public static final String REGION_STATE = "regionState";
     public static final String REGIONS = "regions";
-    public static final String CONTENT_ASSIGNMENTS = "contentAssignments";
+    public static final String VARIANT_DEBUG_INFO = "variantDebugInfo";
     public static final String SIZE = "size";
     public static final String SUBTITLE = "Subtitle";
     public static final String SYNC_INBOX = "syncNewsfeed";

--- a/AndroidSDKCore/src/main/java/com/leanplum/internal/LeanplumInternal.java
+++ b/AndroidSDKCore/src/main/java/com/leanplum/internal/LeanplumInternal.java
@@ -73,7 +73,6 @@ public class LeanplumInternal {
   private static final Queue<Map<String, ?>> userAttributeChanges = new ConcurrentLinkedQueue<>();
   private static final ArrayList<Runnable> startIssuedHandlers = new ArrayList<>();
   private static boolean isScreenTrackingEnabled = false;
-  private static boolean isContentAssignmentsEnabled = false;
 
   private static void onHasStartedAndRegisteredAsDeveloperAndFinishedSyncing() {
     if (!hasStartedAndRegisteredAsDeveloper) {
@@ -672,14 +671,6 @@ public class LeanplumInternal {
 
   public static boolean getIsScreenTrackingEnabled() {
     return isScreenTrackingEnabled;
-  }
-
-  public static boolean getIsContentAssignmentsEnabled() {
-    return isContentAssignmentsEnabled;
-  }
-
-  public static void setIsContentAssignmentsEnabled(boolean _isContentAssignmentsEnabled) {
-    isContentAssignmentsEnabled = _isContentAssignmentsEnabled;
   }
 
   public static void enableAutomaticScreenTracking() {

--- a/AndroidSDKCore/src/main/java/com/leanplum/internal/LeanplumInternal.java
+++ b/AndroidSDKCore/src/main/java/com/leanplum/internal/LeanplumInternal.java
@@ -73,6 +73,7 @@ public class LeanplumInternal {
   private static final Queue<Map<String, ?>> userAttributeChanges = new ConcurrentLinkedQueue<>();
   private static final ArrayList<Runnable> startIssuedHandlers = new ArrayList<>();
   private static boolean isScreenTrackingEnabled = false;
+  private static boolean isContentAssignmentsEnabled = false;
 
   private static void onHasStartedAndRegisteredAsDeveloperAndFinishedSyncing() {
     if (!hasStartedAndRegisteredAsDeveloper) {
@@ -671,6 +672,14 @@ public class LeanplumInternal {
 
   public static boolean getIsScreenTrackingEnabled() {
     return isScreenTrackingEnabled;
+  }
+
+  public static boolean getIsContentAssignmentsEnabled() {
+    return isContentAssignmentsEnabled;
+  }
+
+  public static void setIsContentAssignmentsEnabled(boolean _isContentAssignmentsEnabled) {
+    isContentAssignmentsEnabled = _isContentAssignmentsEnabled;
   }
 
   public static void enableAutomaticScreenTracking() {

--- a/AndroidSDKCore/src/main/java/com/leanplum/internal/LeanplumInternal.java
+++ b/AndroidSDKCore/src/main/java/com/leanplum/internal/LeanplumInternal.java
@@ -73,7 +73,7 @@ public class LeanplumInternal {
   private static final Queue<Map<String, ?>> userAttributeChanges = new ConcurrentLinkedQueue<>();
   private static final ArrayList<Runnable> startIssuedHandlers = new ArrayList<>();
   private static boolean isScreenTrackingEnabled = false;
-  private static boolean isContentAssignmentsEnabled = false;
+  private static boolean isVariantDebugInfoEnabled = false;
 
   private static void onHasStartedAndRegisteredAsDeveloperAndFinishedSyncing() {
     if (!hasStartedAndRegisteredAsDeveloper) {
@@ -674,12 +674,12 @@ public class LeanplumInternal {
     return isScreenTrackingEnabled;
   }
 
-  public static boolean getIsContentAssignmentsEnabled() {
-    return isContentAssignmentsEnabled;
+  public static boolean getIsVariantDebugInfoEnabled() {
+    return isVariantDebugInfoEnabled;
   }
 
-  public static void setIsContentAssignmentsEnabled(boolean _isContentAssignmentsEnabled) {
-    isContentAssignmentsEnabled = _isContentAssignmentsEnabled;
+  public static void setIsVariantDebugInfoEnabled(boolean _isVariantDebugInfoEnabled) {
+    isVariantDebugInfoEnabled= _isVariantDebugInfoEnabled;
   }
 
   public static void enableAutomaticScreenTracking() {

--- a/AndroidSDKCore/src/main/java/com/leanplum/internal/Socket.java
+++ b/AndroidSDKCore/src/main/java/com/leanplum/internal/Socket.java
@@ -307,7 +307,7 @@ public class Socket {
         return;
       }
       VarCache.applyVariableDiffs(
-          JsonConverter.mapFromJson(object), null, null, null, null, null, null);
+          JsonConverter.mapFromJson(object), null, null, null, null, null);
     } catch (JSONException e) {
       Log.e("Couldn't applyVars for preview.", e);
     } catch (Throwable e) {

--- a/AndroidSDKCore/src/main/java/com/leanplum/internal/Socket.java
+++ b/AndroidSDKCore/src/main/java/com/leanplum/internal/Socket.java
@@ -307,7 +307,7 @@ public class Socket {
         return;
       }
       VarCache.applyVariableDiffs(
-          JsonConverter.mapFromJson(object), null, null, null, null, null);
+          JsonConverter.mapFromJson(object), null, null, null, null, null, null);
     } catch (JSONException e) {
       Log.e("Couldn't applyVars for preview.", e);
     } catch (Throwable e) {

--- a/AndroidSDKCore/src/main/java/com/leanplum/internal/VarCache.java
+++ b/AndroidSDKCore/src/main/java/com/leanplum/internal/VarCache.java
@@ -327,8 +327,8 @@ public class VarCache {
     return variantDebugInfo;
   }
 
-  public static void setVariantDebugInfo(Map<String, Object> _variantDebugInfo) {
-    variantDebugInfo = _variantDebugInfo;
+  public static void setVariantDebugInfo(Map<String, Object> variantDebugInfo) {
+    VarCache.variantDebugInfo = variantDebugInfo;
   }
 
   public static void loadDiffs() {
@@ -345,7 +345,7 @@ public class VarCache {
           new ArrayList<Map<String, Object>>(),
           new HashMap<String, Object>(),
           new ArrayList<Map<String, Object>>(),
-              new HashMap<String, Object>());
+          new HashMap<String, Object>());
       return;
     }
     try {
@@ -369,7 +369,7 @@ public class VarCache {
           JsonConverter.<Map<String, Object>>listFromJson(new JSONArray(eventRules)),
           JsonConverter.fromJson(regions),
           JsonConverter.<Map<String, Object>>listFromJson(new JSONArray(variants)),
-              JsonConverter.fromJson(variantDebugInfo));
+          JsonConverter.fromJson(variantDebugInfo));
       String deviceId = aesContext.decodePreference(defaults, Constants.Params.DEVICE_ID, null);
       if (deviceId != null) {
         if (Util.isValidDeviceId(deviceId)) {
@@ -449,7 +449,8 @@ public class VarCache {
     }
 
     if (variantDebugInfo != null) {
-      String variantDebugInfoCipher = aesContext.encrypt(JsonConverter.toJson(variantDebugInfo));
+      String a = JsonConverter.toJson(variantDebugInfo);
+      String variantDebugInfoCipher = aesContext.encrypt(a);
       editor.putString(Constants.Keys.VARIANT_DEBUG_INFO, variantDebugInfoCipher);
     }
 
@@ -901,7 +902,7 @@ public class VarCache {
    */
   public static void reset() {
     vars.clear();
-    variantDebugInfo = null;
+    variantDebugInfo.clear();
     fileAttributes.clear();
     fileStreams.clear();
     valuesFromClient.clear();

--- a/AndroidSDKCore/src/main/java/com/leanplum/internal/VarCache.java
+++ b/AndroidSDKCore/src/main/java/com/leanplum/internal/VarCache.java
@@ -339,13 +339,12 @@ public class VarCache {
     SharedPreferences defaults = context.getSharedPreferences(LEANPLUM, Context.MODE_PRIVATE);
     if (Request.token() == null) {
       applyVariableDiffs(
-              new HashMap<String, Object>(),
-              new HashMap<String, Object>(),
-              new ArrayList<Map<String, Object>>(),
-              new ArrayList<Map<String, Object>>(),
-              new HashMap<String, Object>(),
-              new ArrayList<Map<String, Object>>(),
-              new HashMap<String, Object>());
+          new HashMap<String, Object>(),
+          new HashMap<String, Object>(),
+          new ArrayList<Map<String, Object>>(),
+          new ArrayList<Map<String, Object>>(),
+          new HashMap<String, Object>(),
+          new ArrayList<Map<String, Object>>());
       return;
     }
     try {
@@ -361,15 +360,13 @@ public class VarCache {
           defaults, Constants.Defaults.EVENT_RULES_KEY, "[]");
       String regions = aesContext.decodePreference(defaults, Constants.Defaults.REGIONS_KEY, "{}");
       String variants = aesContext.decodePreference(defaults, Constants.Keys.VARIANTS, "[]");
-      String contentAssignments = aesContext.decodePreference(defaults, Constants.Keys.CONTENT_ASSIGNMENTS, "{}");
       applyVariableDiffs(
-              JsonConverter.fromJson(variables),
-              JsonConverter.fromJson(messages),
-              JsonConverter.<Map<String, Object>>listFromJson(new JSONArray(updateRules)),
-              JsonConverter.<Map<String, Object>>listFromJson(new JSONArray(eventRules)),
-              JsonConverter.fromJson(regions),
-              JsonConverter.<Map<String, Object>>listFromJson(new JSONArray(variants)),
-              JsonConverter.fromJson(contentAssignments));
+          JsonConverter.fromJson(variables),
+          JsonConverter.fromJson(messages),
+          JsonConverter.<Map<String, Object>>listFromJson(new JSONArray(updateRules)),
+          JsonConverter.<Map<String, Object>>listFromJson(new JSONArray(eventRules)),
+          JsonConverter.fromJson(regions),
+          JsonConverter.<Map<String, Object>>listFromJson(new JSONArray(variants)));
       String deviceId = aesContext.decodePreference(defaults, Constants.Params.DEVICE_ID, null);
       if (deviceId != null) {
         if (Util.isValidDeviceId(deviceId)) {
@@ -447,16 +444,6 @@ public class VarCache {
     } catch (JSONException e1) {
       Log.e("Error converting " + variants + " to JSON.\n" + Log.getStackTraceString(e1));
     }
-
-    try {
-      if (contentAssignments != null) {
-        String contentAssignmentsJson = aesContext.encrypt(JsonConverter.toJson(contentAssignments));
-        editor.putString(Constants.Keys.CONTENT_ASSIGNMENTS, contentAssignmentsJson);
-      }
-    } catch (Throwable e) {
-      Util.handleException(e);
-    }
-
     editor.putString(Constants.Params.DEVICE_ID, aesContext.encrypt(Request.deviceId()));
     editor.putString(Constants.Params.USER_ID, aesContext.encrypt(Request.userId()));
     editor.putString(Constants.Keys.LOGGING_ENABLED,
@@ -512,8 +499,7 @@ public class VarCache {
       List<Map<String, Object>> updateRules,
       List<Map<String, Object>> eventRules,
       Map<String, Object> regions,
-      List<Map<String, Object>> variants,
-      Map<String, Object> contentAssignments) {
+      List<Map<String, Object>> variants) {
     if (diffs != null) {
       VarCache.diffs = diffs;
       computeMergedDictionary();
@@ -590,9 +576,6 @@ public class VarCache {
       VarCache.variants = variants;
     }
 
-    if (contentAssignments != null) {
-      VarCache.contentAssignments = contentAssignments;
-    }
     contentVersion++;
 
     if (!silent) {

--- a/AndroidSDKCore/src/main/java/com/leanplum/internal/VarCache.java
+++ b/AndroidSDKCore/src/main/java/com/leanplum/internal/VarCache.java
@@ -87,6 +87,7 @@ public class VarCache {
   private static boolean silent;
   private static int contentVersion;
   private static Map<String, Object> userAttributes;
+  private static Map<String, Object> contentAssignments;
 
   private static final String NAME_COMPONENT_REGEX = "(?:[^\\.\\[.(\\\\]+|\\\\.)+";
   private static final Pattern NAME_COMPONENT_PATTERN = Pattern.compile(NAME_COMPONENT_REGEX);
@@ -320,6 +321,14 @@ public class VarCache {
 
   public static boolean hasReceivedDiffs() {
     return hasReceivedDiffs;
+  }
+
+  public static Map<String, Object> getContentAssignments() {
+    return contentAssignments;
+  }
+
+  public static void setContentAssignments(Map<String, Object> _contentAssignments) {
+    contentAssignments = _contentAssignments;
   }
 
   public static void loadDiffs() {
@@ -878,6 +887,7 @@ public class VarCache {
    */
   public static void reset() {
     vars.clear();
+    contentAssignments.clear();
     fileAttributes.clear();
     fileStreams.clear();
     valuesFromClient.clear();

--- a/AndroidSDKCore/src/main/java/com/leanplum/internal/VarCache.java
+++ b/AndroidSDKCore/src/main/java/com/leanplum/internal/VarCache.java
@@ -887,7 +887,7 @@ public class VarCache {
    */
   public static void reset() {
     vars.clear();
-    contentAssignments.clear();
+    contentAssignments = null;
     fileAttributes.clear();
     fileStreams.clear();
     valuesFromClient.clear();

--- a/AndroidSDKCore/src/main/java/com/leanplum/internal/VarCache.java
+++ b/AndroidSDKCore/src/main/java/com/leanplum/internal/VarCache.java
@@ -87,7 +87,7 @@ public class VarCache {
   private static boolean silent;
   private static int contentVersion;
   private static Map<String, Object> userAttributes;
-  private static Map<String, Object> contentAssignments;
+  private static Map<String, Object> variantDebugInfo;
 
   private static final String NAME_COMPONENT_REGEX = "(?:[^\\.\\[.(\\\\]+|\\\\.)+";
   private static final Pattern NAME_COMPONENT_PATTERN = Pattern.compile(NAME_COMPONENT_REGEX);
@@ -323,12 +323,12 @@ public class VarCache {
     return hasReceivedDiffs;
   }
 
-  public static Map<String, Object> getContentAssignments() {
-    return contentAssignments;
+  public static Map<String, Object> getVariantDebugInfo() {
+    return variantDebugInfo;
   }
 
-  public static void setContentAssignments(Map<String, Object> _contentAssignments) {
-    contentAssignments = _contentAssignments;
+  public static void setVariantDebugInfo(Map<String, Object> _variantDebugInfo) {
+    variantDebugInfo= _variantDebugInfo;
   }
 
   public static void loadDiffs() {
@@ -887,7 +887,7 @@ public class VarCache {
    */
   public static void reset() {
     vars.clear();
-    contentAssignments = null;
+    variantDebugInfo = null;
     fileAttributes.clear();
     fileStreams.clear();
     valuesFromClient.clear();

--- a/AndroidSDKCore/src/main/java/com/leanplum/internal/VarCache.java
+++ b/AndroidSDKCore/src/main/java/com/leanplum/internal/VarCache.java
@@ -328,7 +328,7 @@ public class VarCache {
   }
 
   public static void setVariantDebugInfo(Map<String, Object> _variantDebugInfo) {
-    variantDebugInfo= _variantDebugInfo;
+    variantDebugInfo = _variantDebugInfo;
   }
 
   public static void loadDiffs() {

--- a/AndroidSDKCore/src/main/java/com/leanplum/internal/VarCache.java
+++ b/AndroidSDKCore/src/main/java/com/leanplum/internal/VarCache.java
@@ -344,7 +344,8 @@ public class VarCache {
           new ArrayList<Map<String, Object>>(),
           new ArrayList<Map<String, Object>>(),
           new HashMap<String, Object>(),
-          new ArrayList<Map<String, Object>>());
+          new ArrayList<Map<String, Object>>(),
+              new HashMap<String, Object>());
       return;
     }
     try {
@@ -360,13 +361,15 @@ public class VarCache {
           defaults, Constants.Defaults.EVENT_RULES_KEY, "[]");
       String regions = aesContext.decodePreference(defaults, Constants.Defaults.REGIONS_KEY, "{}");
       String variants = aesContext.decodePreference(defaults, Constants.Keys.VARIANTS, "[]");
+      String variantDebugInfo = aesContext.decodePreference(defaults, Constants.Keys.VARIANT_DEBUG_INFO, "{}");
       applyVariableDiffs(
           JsonConverter.fromJson(variables),
           JsonConverter.fromJson(messages),
           JsonConverter.<Map<String, Object>>listFromJson(new JSONArray(updateRules)),
           JsonConverter.<Map<String, Object>>listFromJson(new JSONArray(eventRules)),
           JsonConverter.fromJson(regions),
-          JsonConverter.<Map<String, Object>>listFromJson(new JSONArray(variants)));
+          JsonConverter.<Map<String, Object>>listFromJson(new JSONArray(variants)),
+              JsonConverter.fromJson(variantDebugInfo));
       String deviceId = aesContext.decodePreference(defaults, Constants.Params.DEVICE_ID, null);
       if (deviceId != null) {
         if (Util.isValidDeviceId(deviceId)) {
@@ -444,6 +447,12 @@ public class VarCache {
     } catch (JSONException e1) {
       Log.e("Error converting " + variants + " to JSON.\n" + Log.getStackTraceString(e1));
     }
+
+    if (variantDebugInfo != null) {
+      String variantDebugInfoCipher = aesContext.encrypt(JsonConverter.toJson(variantDebugInfo));
+      editor.putString(Constants.Keys.VARIANT_DEBUG_INFO, variantDebugInfoCipher);
+    }
+
     editor.putString(Constants.Params.DEVICE_ID, aesContext.encrypt(Request.deviceId()));
     editor.putString(Constants.Params.USER_ID, aesContext.encrypt(Request.userId()));
     editor.putString(Constants.Keys.LOGGING_ENABLED,
@@ -499,7 +508,8 @@ public class VarCache {
       List<Map<String, Object>> updateRules,
       List<Map<String, Object>> eventRules,
       Map<String, Object> regions,
-      List<Map<String, Object>> variants) {
+      List<Map<String, Object>> variants,
+      Map<String, Object> variantDebugInfo) {
     if (diffs != null) {
       VarCache.diffs = diffs;
       computeMergedDictionary();
@@ -574,6 +584,10 @@ public class VarCache {
 
     if (variants != null) {
       VarCache.variants = variants;
+    }
+
+    if (variantDebugInfo != null) {
+      VarCache.setVariantDebugInfo(variantDebugInfo);
     }
 
     contentVersion++;

--- a/AndroidSDKCore/src/main/java/com/leanplum/internal/VarCache.java
+++ b/AndroidSDKCore/src/main/java/com/leanplum/internal/VarCache.java
@@ -339,12 +339,13 @@ public class VarCache {
     SharedPreferences defaults = context.getSharedPreferences(LEANPLUM, Context.MODE_PRIVATE);
     if (Request.token() == null) {
       applyVariableDiffs(
-          new HashMap<String, Object>(),
-          new HashMap<String, Object>(),
-          new ArrayList<Map<String, Object>>(),
-          new ArrayList<Map<String, Object>>(),
-          new HashMap<String, Object>(),
-          new ArrayList<Map<String, Object>>());
+              new HashMap<String, Object>(),
+              new HashMap<String, Object>(),
+              new ArrayList<Map<String, Object>>(),
+              new ArrayList<Map<String, Object>>(),
+              new HashMap<String, Object>(),
+              new ArrayList<Map<String, Object>>(),
+              new HashMap<String, Object>());
       return;
     }
     try {
@@ -360,13 +361,15 @@ public class VarCache {
           defaults, Constants.Defaults.EVENT_RULES_KEY, "[]");
       String regions = aesContext.decodePreference(defaults, Constants.Defaults.REGIONS_KEY, "{}");
       String variants = aesContext.decodePreference(defaults, Constants.Keys.VARIANTS, "[]");
+      String contentAssignments = aesContext.decodePreference(defaults, Constants.Keys.CONTENT_ASSIGNMENTS, "{}");
       applyVariableDiffs(
-          JsonConverter.fromJson(variables),
-          JsonConverter.fromJson(messages),
-          JsonConverter.<Map<String, Object>>listFromJson(new JSONArray(updateRules)),
-          JsonConverter.<Map<String, Object>>listFromJson(new JSONArray(eventRules)),
-          JsonConverter.fromJson(regions),
-          JsonConverter.<Map<String, Object>>listFromJson(new JSONArray(variants)));
+              JsonConverter.fromJson(variables),
+              JsonConverter.fromJson(messages),
+              JsonConverter.<Map<String, Object>>listFromJson(new JSONArray(updateRules)),
+              JsonConverter.<Map<String, Object>>listFromJson(new JSONArray(eventRules)),
+              JsonConverter.fromJson(regions),
+              JsonConverter.<Map<String, Object>>listFromJson(new JSONArray(variants)),
+              JsonConverter.fromJson(contentAssignments));
       String deviceId = aesContext.decodePreference(defaults, Constants.Params.DEVICE_ID, null);
       if (deviceId != null) {
         if (Util.isValidDeviceId(deviceId)) {
@@ -444,6 +447,16 @@ public class VarCache {
     } catch (JSONException e1) {
       Log.e("Error converting " + variants + " to JSON.\n" + Log.getStackTraceString(e1));
     }
+
+    try {
+      if (contentAssignments != null) {
+        String contentAssignmentsJson = aesContext.encrypt(JsonConverter.toJson(contentAssignments));
+        editor.putString(Constants.Keys.CONTENT_ASSIGNMENTS, contentAssignmentsJson);
+      }
+    } catch (Throwable e) {
+      Util.handleException(e);
+    }
+
     editor.putString(Constants.Params.DEVICE_ID, aesContext.encrypt(Request.deviceId()));
     editor.putString(Constants.Params.USER_ID, aesContext.encrypt(Request.userId()));
     editor.putString(Constants.Keys.LOGGING_ENABLED,
@@ -499,7 +512,8 @@ public class VarCache {
       List<Map<String, Object>> updateRules,
       List<Map<String, Object>> eventRules,
       Map<String, Object> regions,
-      List<Map<String, Object>> variants) {
+      List<Map<String, Object>> variants,
+      Map<String, Object> contentAssignments) {
     if (diffs != null) {
       VarCache.diffs = diffs;
       computeMergedDictionary();
@@ -576,6 +590,9 @@ public class VarCache {
       VarCache.variants = variants;
     }
 
+    if (contentAssignments != null) {
+      VarCache.contentAssignments = contentAssignments;
+    }
     contentVersion++;
 
     if (!silent) {

--- a/AndroidSDKCore/src/main/java/com/leanplum/internal/VarCache.java
+++ b/AndroidSDKCore/src/main/java/com/leanplum/internal/VarCache.java
@@ -87,7 +87,7 @@ public class VarCache {
   private static boolean silent;
   private static int contentVersion;
   private static Map<String, Object> userAttributes;
-  private static Map<String, Object> variantDebugInfo;
+  private static Map<String, Object> variantDebugInfo = new HashMap<>();
 
   private static final String NAME_COMPONENT_REGEX = "(?:[^\\.\\[.(\\\\]+|\\\\.)+";
   private static final Pattern NAME_COMPONENT_PATTERN = Pattern.compile(NAME_COMPONENT_REGEX);

--- a/AndroidSDKPush/src/main/java/com/leanplum/LeanplumPushService.java
+++ b/AndroidSDKPush/src/main/java/com/leanplum/LeanplumPushService.java
@@ -270,7 +270,7 @@ public class LeanplumPushService {
                       messages = null;
                     }
                     if (values != null || messages != null) {
-                      VarCache.applyVariableDiffs(values, messages, null, null, regions, variants, null);
+                      VarCache.applyVariableDiffs(values, messages, null, null, regions, variants);
                     }
                   }
                   onComplete.variablesChanged();

--- a/AndroidSDKPush/src/main/java/com/leanplum/LeanplumPushService.java
+++ b/AndroidSDKPush/src/main/java/com/leanplum/LeanplumPushService.java
@@ -270,7 +270,7 @@ public class LeanplumPushService {
                       messages = null;
                     }
                     if (values != null || messages != null) {
-                      VarCache.applyVariableDiffs(values, messages, null, null, regions, variants);
+                      VarCache.applyVariableDiffs(values, messages, null, null, regions, variants, null);
                     }
                   }
                   onComplete.variablesChanged();

--- a/AndroidSDKTests/src/test/java/com/leanplum/LeanplumActionContextTest.java
+++ b/AndroidSDKTests/src/test/java/com/leanplum/LeanplumActionContextTest.java
@@ -288,7 +288,7 @@ public class LeanplumActionContextTest extends AbstractTest {
         VarCache.applyVariableDiffs(null, new HashMap<>(
                 ImmutableMap.<String, Object>of(Long.toString(chainedMessageId),
                 ImmutableMap.<String, Object>of())),
-                null, null, null, null, null);
+                null, null, null, null);
         // Since it now exists locally, we should return false for forceContentUpdate.
         Assert.assertFalse(ActionContext.shouldForceContentUpdateForChainedMessage(
                 JsonConverter.fromJson(jsonData)));

--- a/AndroidSDKTests/src/test/java/com/leanplum/LeanplumActionContextTest.java
+++ b/AndroidSDKTests/src/test/java/com/leanplum/LeanplumActionContextTest.java
@@ -288,7 +288,7 @@ public class LeanplumActionContextTest extends AbstractTest {
         VarCache.applyVariableDiffs(null, new HashMap<>(
                 ImmutableMap.<String, Object>of(Long.toString(chainedMessageId),
                 ImmutableMap.<String, Object>of())),
-                null, null, null, null);
+                null, null, null, null, null);
         // Since it now exists locally, we should return false for forceContentUpdate.
         Assert.assertFalse(ActionContext.shouldForceContentUpdateForChainedMessage(
                 JsonConverter.fromJson(jsonData)));

--- a/AndroidSDKTests/src/test/java/com/leanplum/LeanplumTest.java
+++ b/AndroidSDKTests/src/test/java/com/leanplum/LeanplumTest.java
@@ -383,7 +383,7 @@ public class LeanplumTest extends AbstractTest {
       }});
     }};
 
-    VarCache.applyVariableDiffs(null, messages, null, null, null, variants);
+    VarCache.applyVariableDiffs(null, messages, null, null, null, variants, null);
     assertEquals(variants, Leanplum.variants());
     assertEquals(messages, Leanplum.messageMetadata());
   }

--- a/AndroidSDKTests/src/test/java/com/leanplum/LeanplumTest.java
+++ b/AndroidSDKTests/src/test/java/com/leanplum/LeanplumTest.java
@@ -20,7 +20,6 @@
  */
 package com.leanplum;
 
-import android.content.Context;
 import android.graphics.Color;
 import android.location.Address;
 import android.location.Geocoder;
@@ -38,8 +37,6 @@ import com.leanplum.internal.CollectionUtil;
 import com.leanplum.internal.Constants;
 import com.leanplum.internal.FileManager;
 import com.leanplum.internal.JsonConverter;
-import com.leanplum.internal.LeanplumEventDataManager;
-import com.leanplum.internal.LeanplumEventDataManagerTest;
 import com.leanplum.internal.Request;
 import com.leanplum.internal.Util;
 import com.leanplum.internal.VarCache;
@@ -56,7 +53,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
-import java.util.Objects;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
@@ -67,16 +63,11 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
-import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyBoolean;
 import static org.mockito.Matchers.anyDouble;
 import static org.mockito.Matchers.anyInt;
 import static org.mockito.Matchers.anyString;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.times;
-import static org.powermock.api.mockito.PowerMockito.doNothing;
 import static org.powermock.api.mockito.PowerMockito.doReturn;
-import static org.powermock.api.mockito.PowerMockito.verifyStatic;
 import static org.powermock.api.mockito.PowerMockito.whenNew;
 
 /**
@@ -91,11 +82,11 @@ public class LeanplumTest extends AbstractTest {
 
     // Expected request params.
     final HashMap<String, Object> expectedRequestParams = CollectionUtil.newHashMap(
-        "city", "(detect)",
-        "country", "(detect)",
-        "location", "(detect)",
-        "region", "(detect)",
-        "locale", "en_US"
+            "city", "(detect)",
+            "country", "(detect)",
+            "location", "(detect)",
+            "region", "(detect)",
+            "locale", "en_US"
     );
 
     // Validate request.
@@ -123,11 +114,11 @@ public class LeanplumTest extends AbstractTest {
 
     // Expected request params.
     final HashMap<String, Object> expectedRequestParams = CollectionUtil.newHashMap(
-        "city", "(detect)",
-        "country", "(detect)",
-        "location", "(detect)",
-        "region", "(detect)",
-        "locale", "en_US"
+            "city", "(detect)",
+            "country", "(detect)",
+            "location", "(detect)",
+            "region", "(detect)",
+            "locale", "en_US"
     );
 
     // Validate request.
@@ -156,18 +147,18 @@ public class LeanplumTest extends AbstractTest {
 
     // Expected request params.
     final HashMap<String, Object> expectedRequestParams = CollectionUtil.newHashMap(
-        "city", "(detect)",
-        "country", "(detect)",
-        "location", "(detect)",
-        "region", "(detect)",
-        "locale", "en_US"
+            "city", "(detect)",
+            "country", "(detect)",
+            "location", "(detect)",
+            "region", "(detect)",
+            "locale", "en_US"
     );
 
     // Setup user attributes.
     final HashMap<String, Object> userAttributes = CollectionUtil.newHashMap(
-        "name", "John Smith",
-        "age", 42,
-        "address", "New York"
+            "name", "John Smith",
+            "age", 42,
+            "address", "New York"
     );
 
     // Validate request.
@@ -182,9 +173,9 @@ public class LeanplumTest extends AbstractTest {
         String requestUserAttributes = (String) params.get("userAttributes");
 
         assertTrue(userAttributes.keySet()
-            .containsAll(JsonConverter.fromJson(requestUserAttributes).keySet()));
+                .containsAll(JsonConverter.fromJson(requestUserAttributes).keySet()));
         assertTrue(userAttributes.values()
-            .containsAll(JsonConverter.fromJson(requestUserAttributes).values()));
+                .containsAll(JsonConverter.fromJson(requestUserAttributes).values()));
       }
     });
 
@@ -198,11 +189,11 @@ public class LeanplumTest extends AbstractTest {
 
     // Expected request params.
     final HashMap<String, Object> expectedRequestParams = CollectionUtil.newHashMap(
-        "city", "(detect)",
-        "country", "(detect)",
-        "location", "(detect)",
-        "region", "(detect)",
-        "locale", "en_US"
+            "city", "(detect)",
+            "country", "(detect)",
+            "location", "(detect)",
+            "region", "(detect)",
+            "locale", "en_US"
     );
 
     String userId = "user_id";
@@ -230,11 +221,11 @@ public class LeanplumTest extends AbstractTest {
 
     // Expected request params.
     final HashMap<String, Object> expectedRequestParams = CollectionUtil.newHashMap(
-        "city", "(detect)",
-        "country", "(detect)",
-        "location", "(detect)",
-        "region", "(detect)",
-        "locale", "en_US"
+            "city", "(detect)",
+            "country", "(detect)",
+            "location", "(detect)",
+            "region", "(detect)",
+            "locale", "en_US"
     );
 
     String userId = "user_id";
@@ -266,18 +257,18 @@ public class LeanplumTest extends AbstractTest {
 
     // Expected request params.
     final HashMap<String, Object> expectedRequestParams = CollectionUtil.newHashMap(
-        "city", "(detect)",
-        "country", "(detect)",
-        "location", "(detect)",
-        "region", "(detect)",
-        "locale", "en_US"
+            "city", "(detect)",
+            "country", "(detect)",
+            "location", "(detect)",
+            "region", "(detect)",
+            "locale", "en_US"
     );
 
     // Setup user attributes.
     final HashMap<String, Object> userAttributes = CollectionUtil.newHashMap(
-        "name", "John Smith",
-        "age", 42,
-        "address", "New York"
+            "name", "John Smith",
+            "age", 42,
+            "address", "New York"
     );
 
     String userId = "user_id";
@@ -294,9 +285,9 @@ public class LeanplumTest extends AbstractTest {
         String requestUserAttributes = (String) params.get("userAttributes");
 
         assertTrue(userAttributes.keySet()
-            .containsAll(JsonConverter.fromJson(requestUserAttributes).keySet()));
+                .containsAll(JsonConverter.fromJson(requestUserAttributes).keySet()));
         assertTrue(userAttributes.values()
-            .containsAll(JsonConverter.fromJson(requestUserAttributes).values()));
+                .containsAll(JsonConverter.fromJson(requestUserAttributes).values()));
       }
     });
 
@@ -311,18 +302,18 @@ public class LeanplumTest extends AbstractTest {
 
     // Expected request params.
     final HashMap<String, Object> expectedRequestParams = CollectionUtil.newHashMap(
-        "city", "(detect)",
-        "country", "(detect)",
-        "location", "(detect)",
-        "region", "(detect)",
-        "locale", "en_US"
+            "city", "(detect)",
+            "country", "(detect)",
+            "location", "(detect)",
+            "region", "(detect)",
+            "locale", "en_US"
     );
 
     // Setup user attributes.
     final HashMap<String, Object> userAttributes = CollectionUtil.newHashMap(
-        "name", "John Smith",
-        "age", 42,
-        "address", "New York"
+            "name", "John Smith",
+            "age", 42,
+            "address", "New York"
     );
 
     String userId = "user_id";
@@ -341,9 +332,9 @@ public class LeanplumTest extends AbstractTest {
         String requestUserAttributes = (String) params.get("userAttributes");
 
         assertTrue(userAttributes.keySet()
-            .containsAll(JsonConverter.fromJson(requestUserAttributes).keySet()));
+                .containsAll(JsonConverter.fromJson(requestUserAttributes).keySet()));
         assertTrue(userAttributes.values()
-            .containsAll(JsonConverter.fromJson(requestUserAttributes).values()));
+                .containsAll(JsonConverter.fromJson(requestUserAttributes).values()));
       }
     });
 
@@ -360,24 +351,24 @@ public class LeanplumTest extends AbstractTest {
   }
 
   @Test
-  public void testStartWithVariantDebugInfo() {
+  public void shouldStartWithParamToIncludeVariantDebugInfo() {
     ResponseHelper.seedResponse("/responses/simple_start_response.json");
-
-    // Expected request params.
-    final HashMap<String, Object> expectedRequestParams = CollectionUtil.newHashMap(
-            "city", "(detect)",
-            "country", "(detect)",
-            "location", "(detect)",
-            "region", "(detect)",
-            "locale", "en_US",
-            "includeVariantDebugInfo", true
-    );
 
     Leanplum.setVariantDebugInfoEnabled(true);
     // Validate request.
     RequestHelper.addRequestHandler(new RequestHelper.RequestHandler() {
       @Override
       public void onRequest(String httpMethod, String apiMethod, Map<String, Object> params) {
+        // Expected request params.
+        final HashMap<String, Object> expectedRequestParams = CollectionUtil.newHashMap(
+                "city", "(detect)",
+                "country", "(detect)",
+                "location", "(detect)",
+                "region", "(detect)",
+                "locale", "en_US",
+                "includeVariantDebugInfo", true
+        );
+
         assertEquals(Constants.Methods.START, apiMethod);
 
         // Validate request.
@@ -388,7 +379,6 @@ public class LeanplumTest extends AbstractTest {
     Leanplum.start(mContext);
     assertTrue(Leanplum.hasStarted());
   }
-
 
   /**
    * Tests Metadata.
@@ -420,71 +410,6 @@ public class LeanplumTest extends AbstractTest {
   }
 
   @Test
-  public void testCrashes() throws Exception {
-    // Setup sdk first.
-    setupSDK(mContext, "/responses/start_variables_response.json");
-
-    Context currentCotext = Leanplum.getContext();
-    assertNotNull(currentCotext);
-    LeanplumEventDataManager.init(Leanplum.getContext());
-
-    // Add two events to database.
-    Request request1 = new Request("POST", Constants.Methods.GET_INBOX_MESSAGES, null);
-    Request request2 = new Request("POST", Constants.Methods.LOG, null);
-
-    request1.sendEventually();
-    request2.sendEventually();
-
-    final double fraction = 1.0;
-    // Get a number of events in the database.
-    // Expectation: 2 events.
-    List unsentRequests = request1.getUnsentRequests(fraction);
-    assertNotNull(unsentRequests);
-    assertEquals(2, unsentRequests.size());
-
-    // Verify handleException method is never called.
-    verifyStatic(never());
-    Util.handleException(any(Throwable.class));
-
-    doNothing().when(Util.class, "handleException", any(Throwable.class));
-
-    // Crash SDK.
-    ActionContext actionContext = new ActionContext("name", new HashMap<String, Object>() {{
-      put("1", "aaa");
-    }}, "messageId");
-    actionContext.numberNamed("1");
-
-    // Verify handleException method is called 1 time.
-    verifyStatic(times(1));
-    Util.handleException(any(Throwable.class));
-
-    // Get a number of events in the database. Checks if ours two events still here.
-    // Expectation: 2 events.
-    unsentRequests = request1.getUnsentRequests(fraction);
-    assertNotNull(unsentRequests);
-    assertEquals(2, unsentRequests.size());
-
-    // Validate request.
-    RequestHelper.addRequestHandler(new RequestHelper.RequestHandler() {
-      @Override
-      public void onRequest(String httpMethod, String apiMethod, Map<String, Object> params) {
-        assertEquals(Constants.Methods.PAUSE_STATE, apiMethod);
-      }
-    });
-
-    // Call pause method.
-    Leanplum.pauseState();
-
-    // Get a number of events in the database. Make sure we sent all events.
-    // Expectation: 0 events.
-    unsentRequests = request1.getUnsentRequests(fraction);
-    assertNotNull(unsentRequests);
-    assertEquals(0, unsentRequests.size());
-
-    LeanplumEventDataManagerTest.setDatabaseToNull();
-  }
-
-  @Test
   public void testTrack() throws Exception {
     // Setup sdk first.
     setupSDK(mContext, "/responses/simple_start_response.json");
@@ -494,8 +419,8 @@ public class LeanplumTest extends AbstractTest {
     final double eventValue = 10.0;
     final String eventInfo = "test_event_info";
     final HashMap<String, Object> eventParams = CollectionUtil.newHashMap(
-        "test_param_string", "string",
-        "test_param_int", 42
+            "test_param_string", "string",
+            "test_param_int", 42
     );
 
     // Validate request for track with event name.
@@ -556,9 +481,9 @@ public class LeanplumTest extends AbstractTest {
         assertEquals(eventName, requestEventName);
         assertEquals(String.valueOf(eventValue), requestEventValue);
         assertTrue(eventParams.keySet()
-            .containsAll(JsonConverter.fromJson(requestEventParams).keySet()));
+                .containsAll(JsonConverter.fromJson(requestEventParams).keySet()));
         assertTrue(eventParams.values()
-            .containsAll(JsonConverter.fromJson(requestEventParams).values()));
+                .containsAll(JsonConverter.fromJson(requestEventParams).values()));
       }
     });
     Leanplum.track(eventName, eventValue, eventParams);
@@ -574,9 +499,9 @@ public class LeanplumTest extends AbstractTest {
 
         assertEquals(eventName, requestEventName);
         assertTrue(eventParams.keySet()
-            .containsAll(JsonConverter.fromJson(requestEventParams).keySet()));
+                .containsAll(JsonConverter.fromJson(requestEventParams).keySet()));
         assertTrue(eventParams.values()
-            .containsAll(JsonConverter.fromJson(requestEventParams).values()));
+                .containsAll(JsonConverter.fromJson(requestEventParams).values()));
       }
     });
     Leanplum.track(eventName, eventParams);
@@ -611,9 +536,9 @@ public class LeanplumTest extends AbstractTest {
         assertEquals(String.valueOf(eventValue), requestEventValue);
         assertEquals(eventInfo, requestEventInfo);
         assertTrue(eventParams.keySet()
-            .containsAll(JsonConverter.fromJson(requestEventParams).keySet()));
+                .containsAll(JsonConverter.fromJson(requestEventParams).keySet()));
         assertTrue(eventParams.values()
-            .containsAll(JsonConverter.fromJson(requestEventParams).values()));
+                .containsAll(JsonConverter.fromJson(requestEventParams).values()));
       }
     });
     Leanplum.track(eventName, eventValue, eventInfo, eventParams);
@@ -637,7 +562,7 @@ public class LeanplumTest extends AbstractTest {
     });
     Leanplum.trackGooglePlayPurchase(eventName, 10, "USD", "data", "signature");
 
-    // Validate request for purchase.
+    // Validate request for purchae.
     RequestHelper.addRequestHandler(new RequestHelper.RequestHandler() {
       @Override
       public void onRequest(String httpMethod, String apiMethod, Map<String, Object> params) {
@@ -655,23 +580,6 @@ public class LeanplumTest extends AbstractTest {
       }
     });
     Leanplum.trackGooglePlayPurchase(eventName, 10, "USD", "data", "signature", new HashMap<String, Object>());
-
-    // Validate request for manual purchase.
-    RequestHelper.addRequestHandler(new RequestHelper.RequestHandler() {
-      @Override
-      public void onRequest(String httpMethod, String apiMethod, Map<String, Object> params) {
-        assertEquals(Constants.Methods.TRACK, apiMethod);
-
-        String requestEventName = (String) params.get("event");
-        String requestEventValue = (String) params.get("value");
-        String requestCurrencyCode = (String) params.get("currencyCode");
-
-        assertEquals(eventName, requestEventName);
-        assertEquals("1.99", requestEventValue);
-        assertEquals("USD", requestCurrencyCode);
-      }
-    });
-    Leanplum.trackPurchase(eventName, 1.99, "USD", new HashMap<String, Objects>());
   }
 
   @Test
@@ -682,8 +590,8 @@ public class LeanplumTest extends AbstractTest {
     final String stateName = "test_state_name";
     final String stateInfo = "test_state_info";
     final HashMap<String, Object> stateParams = CollectionUtil.newHashMap(
-        "test_param_string", "string",
-        "test_param_int", 42
+            "test_param_string", "string",
+            "test_param_int", 42
     );
 
     // Validate request for advance with name.
@@ -725,9 +633,9 @@ public class LeanplumTest extends AbstractTest {
 
         assertEquals(stateName, requestStateName);
         assertTrue(stateParams.keySet()
-            .containsAll(JsonConverter.fromJson(requestStateParams).keySet()));
+                .containsAll(JsonConverter.fromJson(requestStateParams).keySet()));
         assertTrue(stateParams.values()
-            .containsAll(JsonConverter.fromJson(requestStateParams).values()));
+                .containsAll(JsonConverter.fromJson(requestStateParams).values()));
       }
     });
 
@@ -746,9 +654,9 @@ public class LeanplumTest extends AbstractTest {
         assertEquals(stateName, requestStateName);
         assertEquals(stateInfo, requestStateInfo);
         assertTrue(stateParams.keySet()
-            .containsAll(JsonConverter.fromJson(requestStateParams).keySet()));
+                .containsAll(JsonConverter.fromJson(requestStateParams).keySet()));
         assertTrue(stateParams.values()
-            .containsAll(JsonConverter.fromJson(requestStateParams).values()));
+                .containsAll(JsonConverter.fromJson(requestStateParams).values()));
       }
     });
     Leanplum.advanceTo(stateName, stateInfo, stateParams);
@@ -762,10 +670,10 @@ public class LeanplumTest extends AbstractTest {
     Var<Float> floatVariable = Var.define("test_float", 10.0f);
     Var<List<Integer>> listVariable = Var.define("test_list", Arrays.asList(0, 1, 2, 3, 4, 5));
     Var<HashMap<Object, Object>> dictionaryVariable = Var.define("test_dictionary",
-        CollectionUtil.newHashMap(
-            "dictionary_test_string", "test_string",
-            "dictionary_test_integer", 5
-        ));
+            CollectionUtil.newHashMap(
+                    "dictionary_test_string", "test_string",
+                    "dictionary_test_integer", 5
+            ));
     Var<Integer> colorVariable = Var.defineColor("test_color", 12345);
     Var<String> groupStringVariable = Var.define("groups.strings", "groups_string_test");
     Var<Integer> groupIntegerVariable = Var.define("groups.integers", 5);
@@ -783,7 +691,7 @@ public class LeanplumTest extends AbstractTest {
     assertEquals(floatVariable.defaultValue(), VarCache.getVariable("test_float").value());
     assertEquals(listVariable.defaultValue(), VarCache.getVariable("test_list").value());
     assertEquals(dictionaryVariable.defaultValue(), VarCache.getVariable("test_dictionary")
-        .value());
+            .value());
 
     // Validate values.
     assertEquals(colorVariable.value(), VarCache.getVariable("test_color").value());
@@ -805,11 +713,10 @@ public class LeanplumTest extends AbstractTest {
   }
 
   @Test
-  public void testVariantDebugInfo() throws Exception {
+  public void shouldGetResponseAndReturnVariantDebugInfo() throws Exception {
     setupSDK(mContext, "/responses/start_with_variant_debug_info_response.json");
-    assertNotNull(Leanplum.variantDebugInfo());
+    assertEquals(Leanplum.variantDebugInfo().size(), 1);
     assertNotNull(Leanplum.variantDebugInfo().get("abTests"));
-    assertNull(Leanplum.variantDebugInfo().get("abTests1"));
   }
 
   @Test
@@ -824,10 +731,10 @@ public class LeanplumTest extends AbstractTest {
     boolean booleanVariable = (boolean) VarCache.getVariable("Boolean Variable").value();
     float floatVariable = (float) VarCache.getVariable("numbers.floatVariable").value();
     double doubleVariable = (double) VarCache.getVariable("VariablesTestClass.doubleVariable")
-        .value();
+            .value();
     List<?> listVariable = (List<?>) VarCache.getVariable("listVariable").value();
     HashMap<?, ?> dictionaryVariable = (HashMap<?, ?>) VarCache.getVariable("dictionaryVariable")
-        .value();
+            .value();
 
     // Check if parsing is correct.
     assertEquals(VariablesTestClass.stringVariable, stringVariable);
@@ -863,7 +770,7 @@ public class LeanplumTest extends AbstractTest {
 
   @Test
   public void testActions() throws Exception {
-    setupSDK(mContext, "/responses/simple_start_response.json");
+    setupSDK(mContext, "");
 
     final String actionName = "test_action";
 
@@ -881,9 +788,9 @@ public class LeanplumTest extends AbstractTest {
     args.with(integerArgumentName, 5);
     args.with(stringArgumentName, "test_string");
     args.with(boolArgumentName, true);
-    args.withAsset(fileArgumentName, "leanplum_watermark.jpg");
+    args.withAsset(fileArgumentName, "Mario.png");
     args.with(dictionaryArgumentName, CollectionUtil.newHashMap(
-        "test_value", "test"
+            "test_value", "test"
     ));
     args.with(arrayArgumentName, CollectionUtil.newArrayList(1, 2, 3, 4));
     args.withAction(actionArgumentName, "action_test");
@@ -903,13 +810,13 @@ public class LeanplumTest extends AbstractTest {
         Map<?, ?> definedActions = (HashMap<?, ?>) actionDefinitions.get(actionName);
 
         Map<String, Object> kinds = CollectionUtil.newHashMap(
-            "number_argument", "integer",
-            "string_argument", "string",
-            "color_argument", "color",
-            "dictionary_argument", "group",
-            "array_argument", "list",
-            "action_argument", "action",
-            "bool_argument", "bool"
+                "number_argument", "integer",
+                "string_argument", "string",
+                "color_argument", "color",
+                "dictionary_argument", "group",
+                "array_argument", "list",
+                "action_argument", "action",
+                "bool_argument", "bool"
         );
         Map<?, ?> requestedKinds = (HashMap<?, ?>) definedActions.get("kinds");
 
@@ -927,7 +834,7 @@ public class LeanplumTest extends AbstractTest {
         assertNotNull(values.get(arrayArgumentName));
         assertEquals("action_test", values.get(actionArgumentName));
         assertEquals(Color.BLUE, values.get(colorArgumentName));
-        assertEquals("leanplum_watermark.jpg", values.get(fileArgumentName));
+        assertEquals("Mario.png", values.get(fileArgumentName));
       }
     });
     // Define action.
@@ -968,11 +875,11 @@ public class LeanplumTest extends AbstractTest {
   @Test
   public void testVariablesCallbacksTimeout() throws Exception {
     URLConnection urlConnection = Util.createHttpUrlConnection("www.leanplum.com", "api", "POST",
-        true, 1);
+            true, 1);
     urlConnection.setConnectTimeout(1);
 
     doReturn(urlConnection).when(Util.class, "createHttpUrlConnection", anyString(), anyString(),
-        anyBoolean(), anyInt());
+            anyBoolean(), anyInt());
 
     final CountDownLatch countDownLatch = new CountDownLatch(2);
 
@@ -1041,7 +948,7 @@ public class LeanplumTest extends AbstractTest {
     Geocoder geocoder = Mockito.mock(Geocoder.class);
     whenNew(Geocoder.class).withAnyArguments().thenReturn(geocoder);
     Mockito.when(geocoder.getFromLocation(anyDouble(), anyDouble(), anyInt()))
-        .thenReturn(addresses);
+            .thenReturn(addresses);
 
     // Validate set location request shorthand.
     RequestHelper.addRequestHandler(new RequestHelper.RequestHandler() {
@@ -1253,18 +1160,5 @@ public class LeanplumTest extends AbstractTest {
     Leanplum.removeOnceVariablesChangedAndNoDownloadsPendingHandler(variablesChangedCallback);
     handlers = CollectionUtil.uncheckedCast(TestClassUtil.getField(Leanplum.class, "onceNoDownloadsHandlers"));
     assertEquals(0, handlers.size());
-  }
-
-  /**
-   * Test for {@link Leanplum#getDeviceId()}.
-   */
-  @Test
-  public void testGetDeviceId() {
-    String deviceId = Leanplum.getDeviceId();
-    assertNull(deviceId);
-    Leanplum.start(mContext);
-    assertTrue(Leanplum.hasStarted());
-    deviceId = Leanplum.getDeviceId();
-    assertNotNull(deviceId);
   }
 }

--- a/AndroidSDKTests/src/test/java/com/leanplum/LeanplumTest.java
+++ b/AndroidSDKTests/src/test/java/com/leanplum/LeanplumTest.java
@@ -359,6 +359,37 @@ public class LeanplumTest extends AbstractTest {
     assertTrue(Request.userId().equals(userId));
   }
 
+  @Test
+  public void testStartWithVariantDebugInfo() {
+    ResponseHelper.seedResponse("/responses/simple_start_response.json");
+
+    // Expected request params.
+    final HashMap<String, Object> expectedRequestParams = CollectionUtil.newHashMap(
+            "city", "(detect)",
+            "country", "(detect)",
+            "location", "(detect)",
+            "region", "(detect)",
+            "locale", "en_US",
+            "includeVariantDebugInfo", true
+    );
+
+    Leanplum.setVariantDebugInfoEnabled(true);
+    // Validate request.
+    RequestHelper.addRequestHandler(new RequestHelper.RequestHandler() {
+      @Override
+      public void onRequest(String httpMethod, String apiMethod, Map<String, Object> params) {
+        assertEquals(Constants.Methods.START, apiMethod);
+
+        // Validate request.
+        assertTrue(params.keySet().containsAll(expectedRequestParams.keySet()));
+        assertTrue(params.values().containsAll(expectedRequestParams.values()));
+      }
+    });
+    Leanplum.start(mContext);
+    assertTrue(Leanplum.hasStarted());
+  }
+
+
   /**
    * Tests Metadata.
    */
@@ -383,7 +414,7 @@ public class LeanplumTest extends AbstractTest {
       }});
     }};
 
-    VarCache.applyVariableDiffs(null, messages, null, null, null, variants);
+    VarCache.applyVariableDiffs(null, messages, null, null, null, variants, null);
     assertEquals(variants, Leanplum.variants());
     assertEquals(messages, Leanplum.messageMetadata());
   }
@@ -771,6 +802,12 @@ public class LeanplumTest extends AbstractTest {
     // Validate components.
     assertArrayEquals(groupStringVariable.nameComponents(), new String[] {"groups", "strings"});
     assertArrayEquals(groupIntegerVariable.nameComponents(), new String[] {"groups", "integers"});
+  }
+
+  @Test
+  public void testVariantDebugInfo() throws Exception {
+    setupSDK(mContext, "/responses/start_with_variant_debug_info_response.json");
+    assertNotNull(Leanplum.variantDebugInfo());
   }
 
   @Test

--- a/AndroidSDKTests/src/test/java/com/leanplum/LeanplumTest.java
+++ b/AndroidSDKTests/src/test/java/com/leanplum/LeanplumTest.java
@@ -383,7 +383,7 @@ public class LeanplumTest extends AbstractTest {
       }});
     }};
 
-    VarCache.applyVariableDiffs(null, messages, null, null, null, variants, null);
+    VarCache.applyVariableDiffs(null, messages, null, null, null, variants);
     assertEquals(variants, Leanplum.variants());
     assertEquals(messages, Leanplum.messageMetadata());
   }

--- a/AndroidSDKTests/src/test/java/com/leanplum/LeanplumTest.java
+++ b/AndroidSDKTests/src/test/java/com/leanplum/LeanplumTest.java
@@ -808,6 +808,8 @@ public class LeanplumTest extends AbstractTest {
   public void testVariantDebugInfo() throws Exception {
     setupSDK(mContext, "/responses/start_with_variant_debug_info_response.json");
     assertNotNull(Leanplum.variantDebugInfo());
+    assertNotNull(Leanplum.variantDebugInfo().get("abTests"));
+    assertNull(Leanplum.variantDebugInfo().get("abTests1"));
   }
 
   @Test

--- a/AndroidSDKTests/src/test/resources/responses/start_with_variant_debug_info_response.json
+++ b/AndroidSDKTests/src/test/resources/responses/start_with_variant_debug_info_response.json
@@ -1,0 +1,296 @@
+{
+    "response": [{
+                 "uploadUrl": "https:\/\/www.leanplum.com\/_ah\/upload\/AMmfu6by_4mWZUn19c8v_omIeRezDaIfzqCosKTZTY4HnsxrA963YsrYMMnTPd538fmb4Gyx17-evF7X_QBqFIYjwPuTeHzihGM5-FHkW8o1zKxNl8E9yB2ZiumXvOj-gMbotIZYA1I_\/ALBNUaYAAAAAWAZDRSTEVp_wufYkJ7EFVZK_9eVhM32E\/",
+                 "interfaceRules": [
+                 
+                 ],
+                 "actionDefinitions": {
+                 "Confirm": {
+                 "values": {
+                 "Accept action": {
+                 "__name__": ""
+                 },
+                 "Message": "Confirmation message goes here.",
+                 "Cancel action": {
+                 "__name__": ""
+                 },
+                 "Accept text": "Yes",
+                 "Cancel text": "No",
+                 "Title": "LeanplumSample"
+                 },
+                 "kinds": {
+                 "Accept action": "ACTION",
+                 "Message": "TEXT",
+                 "Cancel action": "ACTION",
+                 "Accept text": "TEXT",
+                 "Cancel text": "TEXT",
+                 "Title": "TEXT"
+                 },
+                 "kind": 3,
+                 "options": null
+                 },
+                 "Center Popup": {
+                 "values": {
+                 "Layout": {
+                 "Height": 250,
+                 "Width": 300
+                 },
+                 "Accept action": {
+                 "__name__": ""
+                 },
+                 "Message": {
+                 "Text": "Popup message goes here.",
+                 "Color": 4278190080
+                 },
+                 "Accept button": {
+                 "Text": "OK",
+                 "Text color": 4278221311,
+                 "Background color": 4294967295
+                 },
+                 "Background color": 4294967295,
+                 "Title": {
+                 "Text": "LeanplumSample",
+                 "Color": 4278190080
+                 },
+                 "Background image": ""
+                 },
+                 "kinds": {
+                 "Layout.Width": "NUMBER",
+                 "Accept action": "ACTION",
+                 "Message": "GROUP",
+                 "Message.Color": "COLOR",
+                 "Accept button": "GROUP",
+                 "Title": "GROUP",
+                 "Background color": "COLOR",
+                 "Layout.Height": "NUMBER",
+                 "Layout": "GROUP",
+                 "Message.Text": "TEXT",
+                 "Accept button.Text": "TEXT",
+                 "Accept button.Background color": "COLOR",
+                 "Title.Color": "COLOR",
+                 "Accept button.Text color": "COLOR",
+                 "Title.Text": "TEXT",
+                 "Background image": "FILE"
+                 },
+                 "kind": 3,
+                 "options": null
+                 },
+                 "Alert": {
+                 "values": {
+                 "Dismiss action": {
+                 "__name__": ""
+                 },
+                 "Message": "Alert message goes here.",
+                 "Dismiss text": "OK",
+                 "Title": "LeanplumSample"
+                 },
+                 "kinds": {
+                 "Dismiss action": "ACTION",
+                 "Message": "TEXT",
+                 "Dismiss text": "TEXT",
+                 "Title": "TEXT"
+                 },
+                 "kind": 3,
+                 "options": null
+                 },
+                 "Web Interstitial": {
+                 "values": {
+                 "Has dismiss button": true,
+                 "Close URL": "http:\/\/leanplum:close",
+                 "URL": "http:\/\/www.example.com"
+                 },
+                 "kinds": {
+                 "Has dismiss button": "BOOLEAN",
+                 "Close URL": "TEXT",
+                 "URL": "TEXT"
+                 },
+                 "kind": 3,
+                 "options": null
+                 },
+                 "Register For Push": {
+                 "values": {
+                 
+                 },
+                 "kinds": {
+                 
+                 },
+                 "kind": 2,
+                 "options": null
+                 },
+                 "Push Ask to Ask": {
+                 "values": {
+                 "Layout": {
+                 "Height": 250,
+                 "Width": 300
+                 },
+                 "Message": {
+                 "Text": "Tap OK to receive important notifications from our app.",
+                 "Color": 4278190080
+                 },
+                 "Cancel action": {
+                 "__name__": ""
+                 },
+                 "Accept button": {
+                 "Text": "OK",
+                 "Text color": 4278221311,
+                 "Background color": 4294967295
+                 },
+                 "Cancel button": {
+                 "Text": "Maybe Later",
+                 "Text color": 4286545791,
+                 "Background color": 4294967295
+                 },
+                 "Background color": 4294967295,
+                 "Title": {
+                 "Text": "LeanplumSample",
+                 "Color": 4278190080
+                 },
+                 "Background image": ""
+                 },
+                 "kinds": {
+                 "Layout.Width": "NUMBER",
+                 "Cancel button.Background color": "COLOR",
+                 "Message": "GROUP",
+                 "Message.Color": "COLOR",
+                 "Accept button": "GROUP",
+                 "Cancel button": "GROUP",
+                 "Title": "GROUP",
+                 "Background color": "COLOR",
+                 "Layout.Height": "NUMBER",
+                 "Layout": "GROUP",
+                 "Cancel action": "ACTION",
+                 "Message.Text": "TEXT",
+                 "Accept button.Text": "TEXT",
+                 "Accept button.Background color": "COLOR",
+                 "Title.Color": "COLOR",
+                 "Cancel button.Text": "TEXT",
+                 "Accept button.Text color": "COLOR",
+                 "Cancel button.Text color": "COLOR",
+                 "Title.Text": "TEXT",
+                 "Background image": "FILE"
+                 },
+                 "kind": 3,
+                 "options": null
+                 },
+                 "Interstitial": {
+                 "values": {
+                 "Accept action": {
+                 "__name__": ""
+                 },
+                 "Message": {
+                 "Text": "Interstitial message goes here.",
+                 "Color": 4278190080
+                 },
+                 "Accept button": {
+                 "Text": "OK",
+                 "Text color": 4278221311,
+                 "Background color": 4294967295
+                 },
+                 "Background color": 4294967295,
+                 "Title": {
+                 "Text": "LeanplumSample",
+                 "Color": 4278190080
+                 },
+                 "Background image": ""
+                 },
+                 "kinds": {
+                 "Accept action": "ACTION",
+                 "Message": "GROUP",
+                 "Accept button.Background color": "COLOR",
+                 "Accept button.Text": "TEXT",
+                 "Message.Text": "TEXT",
+                 "Title.Color": "COLOR",
+                 "Message.Color": "COLOR",
+                 "Accept button.Text color": "COLOR",
+                 "Accept button": "GROUP",
+                 "Background color": "COLOR",
+                 "Title": "GROUP",
+                 "Background image": "FILE",
+                 "Title.Text": "TEXT"
+                 },
+                 "kind": 3,
+                 "options": null
+                 },
+                 "Open URL": {
+                 "values": {
+                 "URL": "http:\/\/www.example.com"
+                 },
+                 "kinds": {
+                 "URL": "TEXT"
+                 },
+                 "kind": 2,
+                 "options": null
+                 }
+                 },
+                 "isRegistered": false,
+                 "regions": {
+                 
+                 },
+                 "messages": {
+                 
+                 },
+                 "varsFromCode": {
+                 "emptyDictionary": {
+                 "integerValue": 50
+                 },
+                 "dictionaryVariable": {
+                 "unicode": "?.!s\u0153\u2211\u03c0\u00f8\u02c6\u02dc\u00a8&\/\/.sd",
+                 "test_number": 535,
+                 "test_string": "string"
+                 },
+                 "arrayVariable": {
+                 "[0]": 1,
+                 "[2]": 3,
+                 "[1]": 2,
+                 "[3]": 4,
+                 "[4]": 5
+                 },
+                 "intVariable": 100,
+                 "boolVariable": false,
+                 "floatVariable": 5,
+                 "integerVariable": 1,
+                 "fileVariable": "Mario1.png",
+                 "stringVariable": "test_string"
+                 },
+                 "latestVersion": "1.4.0.2",
+                 "vars": {
+                 
+                 },
+                 "variantDebugInfo": {
+                 "abTests": [{
+                             "id": 200,
+                             "variantId": 201,
+                             "vars": {
+                             "buyButtonColor": "orange"
+                             }
+                             },
+                             {
+                             "id": 300,
+                             "variantId": 302,
+                             "vars": {
+                             "buyButtonColor": "red",
+                             "price": 10
+                             }
+                             }
+                             ]
+                 },
+                 "fileAttributes": {
+                 "PlugIns\/Leanplum-SDK_Tests.xctest\/test.file": {
+                 "_empty_": {
+                 "hash": "754e4eaae3c92be6e5d45c92b385c8fd",
+                 "size": 25
+                 }
+                 }
+                 },
+                 "token": "jRSv9YRFQ9yVPN80JP0quwHmN9rKk0Crm7awgTwZgCs",
+                 "variants": [
+                 
+                 ],
+                 "syncNewsfeed": false,
+                 "success": true,
+                 "interfaceEvents": [
+                 
+                 ],
+                 "isRegisteredFromOtherApp": false
+                 }]
+}


### PR DESCRIPTION

PRD: https://leanplum.atlassian.net/wiki/spaces/PRODDEV/pages/548503556/Tinder+Expose+granular+information+on+variables+and+A+B+tests+to+SDK

We allow a flag to be set in "includeVariantDebugInfo" that retrieves content assignment details from the server. We then allow access to this object through Leanplum.variantDebugInfo

