### PR TITLE
E2-1342: add user id param

### DIFF
--- a/AndroidSDKCore/src/main/java/com/leanplum/Leanplum.java
+++ b/AndroidSDKCore/src/main/java/com/leanplum/Leanplum.java
@@ -1107,6 +1107,19 @@ public class Leanplum {
   }
 
   /**
+   * Returns the userId in the current Leanplum session. This should only be called after
+   * Leanplum.start().
+   */
+  public static String getUserId() {
+    if (hasStarted()) {
+      return Request.userId();
+    } else {
+      Log.e("Leanplum.start() must be called before calling getUserId()");
+    }
+    return null;
+  }
+
+  /**
    * Returns an instance to the singleton LeanplumInbox object.
    */
   public static LeanplumInbox getInbox() {


### PR DESCRIPTION
As part of   IE-626 CLOSED  , cust brought up that our Android SDK doesn't have a method for userID equivalent to the iOS SDK.

iOS method : https://www.leanplum.com/dashboard/static/iosdocs/html/interface_leanplum.html#aee4088633a2f520c1fd896029e29f7f7
Android methods : https://www.leanplum.com/dashboard/static/javadoc/index.html -> search for userID

