### PR TITLE
E2-1537: add method to clear content

### DIFF
--- a/AndroidSDKCore/src/main/java/com/leanplum/Leanplum.java
+++ b/AndroidSDKCore/src/main/java/com/leanplum/Leanplum.java
@@ -2144,9 +2144,9 @@ public class Leanplum {
   }
 
   /**
-   * Clear all local variables and messages.
-   * This should be typically called when a user logs out of your app. Variables will
-   * start sending default values until the server sends updated content.
+   * Clears cached values for messages, variables and test assignments.
+   * Use sparingly as if the app is updated, you'll have to deal with potentially
+   * inconsistent state or user experience.
    */
   public static void clearUserContent() {
     VarCache.clearUserContent();

--- a/AndroidSDKCore/src/main/java/com/leanplum/Leanplum.java
+++ b/AndroidSDKCore/src/main/java/com/leanplum/Leanplum.java
@@ -2142,4 +2142,13 @@ public class Leanplum {
       VarCache.setVariantDebugInfo(variantDebugInfo);
     }
   }
+
+  /**
+   * Clear all local variables and messages.
+   * This should be typically called when a user logs out of your app. Variables will
+   * start sending default values until the server sends updated content.
+   */
+  public static void clearUserContent() {
+    VarCache.clearUserContent();
+  }
 }

--- a/AndroidSDKCore/src/main/java/com/leanplum/internal/VarCache.java
+++ b/AndroidSDKCore/src/main/java/com/leanplum/internal/VarCache.java
@@ -901,6 +901,21 @@ public class VarCache {
     SharedPreferencesUtil.commitChanges(editor);
   }
 
+  public static void clearUserContent() {
+    vars.clear();
+    variants.clear();
+    variantDebugInfo.clear();
+
+    diffs.clear();
+    messageDiffs.clear();
+    messages = null;
+    userAttributes = null;
+
+    devModeValuesFromServer = null;
+    devModeFileAttributesFromServer = null;
+    devModeActionDefinitionsFromServer = null;
+  }
+
   /**
    * Resets the VarCache to stock state.
    */

--- a/AndroidSDKCore/src/main/java/com/leanplum/internal/VarCache.java
+++ b/AndroidSDKCore/src/main/java/com/leanplum/internal/VarCache.java
@@ -910,6 +910,7 @@ public class VarCache {
     messageDiffs.clear();
     messages = null;
     userAttributes = null;
+    merged = null;
 
     devModeValuesFromServer = null;
     devModeFileAttributesFromServer = null;


### PR DESCRIPTION
When a user logs out of an app, we need to clear any stale content for the previously logged in user. This adds a method to do that

