### PR TITLE
add new logic for finding response with variables and messages

### DIFF
--- a/AndroidSDKCore/src/main/java/com/leanplum/Leanplum.java
+++ b/AndroidSDKCore/src/main/java/com/leanplum/Leanplum.java
@@ -721,6 +721,16 @@ public class Leanplum {
 
       final int responseCount = Request.numResponses(response);
       for (int i = requests.size() - 1; i >= 0; i--) {
+        // break on finding a response with both messages and variables
+        JSONObject currentResponse = Request.getResponseAt(response, i);
+        JSONObject values = currentResponse.optJSONObject(Constants.Keys.VARS);
+        JSONObject messages = currentResponse.optJSONObject(Constants.Keys.MESSAGES);
+        if (values != null && messages != null) {
+          lastStartResponse = currentResponse;
+          break;
+        }
+
+        // old logic still runs if the above fails
         Map<String, Object> currentRequest = requests.get(i);
         if (Constants.Methods.START.equals(currentRequest.get(Constants.Params.ACTION))) {
           if (i < responseCount) {


### PR DESCRIPTION
https://leanplum.atlassian.net/browse/LP-9792

According to the above ticket, we are getting in a state where the parsed "start" response does not have messages or variables. Since we are only interested in the last response that has both those values, we instead make the search look for that instead