### PR TITLE
change directory for getting jar file

### DIFF
--- a/common-methods.gradle
+++ b/common-methods.gradle
@@ -24,7 +24,7 @@ ext {
 def publishing_task(libraryArtifactId, packageName) {
 
     task makeJar(type: Copy) {
-        from('build/intermediates/bundles/release/')
+        from('build/intermediates/packaged-classes/release/')
         into('build/outputs/jar/')
         include('classes.jar')
         rename('classes.jar', packageName + '-release.jar')


### PR DESCRIPTION
gradle plugin 3.1.4 puts the intermediate jar in a different location than the gradle plugin 3.0.2

Since we've upgraded the gradle version previously, this update fixes the makeJar task

