### PR TITLE
Use name instead of message for counter name

### DIFF
--- a/AndroidSDKCore/src/main/java/com/leanplum/internal/Constants.java
+++ b/AndroidSDKCore/src/main/java/com/leanplum/internal/Constants.java
@@ -151,6 +151,7 @@ public class Constants {
     public static final String KINDS = "kinds";
     public static final String LIMIT_TRACKING = "limitTracking";
     public static final String MESSAGE = "message";
+    public static final String NAME = "name";
     public static final String COUNT = "count";
     public static final String MESSAGE_ID = "messageId";
     public static final String NEW_USER_ID = "newUserId";

--- a/AndroidSDKCore/src/main/java/com/leanplum/internal/CountAggregator.java
+++ b/AndroidSDKCore/src/main/java/com/leanplum/internal/CountAggregator.java
@@ -44,7 +44,7 @@ public class CountAggregator {
         Map<String, Object> params = new HashMap<>();
 
         params.put(Constants.Params.TYPE, Constants.Values.SDK_COUNT);
-        params.put(Constants.Params.MESSAGE, name);
+        params.put(Constants.Params.NAME, name);
         params.put(Constants.Params.COUNT, count);
 
         return params;

--- a/AndroidSDKTests/src/test/java/com/leanplum/internal/CountAggregatorTest.java
+++ b/AndroidSDKTests/src/test/java/com/leanplum/internal/CountAggregatorTest.java
@@ -126,7 +126,7 @@ public class CountAggregatorTest extends AbstractTest {
     Map<String, Object> params = countAggregator.makeParams(testString, 2);
 
     assertEquals(Constants.Values.SDK_COUNT, params.get(Constants.Params.TYPE));
-    assertEquals(testString, params.get(Constants.Params.MESSAGE));
+    assertEquals(testString, params.get(Constants.Params.NAME));
     assertEquals(2, params.get(Constants.Params.COUNT));
   }
 


### PR DESCRIPTION
Per spec https://leanplum.atlassian.net/wiki/spaces/ENG/pages/624394247/SDK+Counting

The arg is "name" for counter name, not "message".