### PR TITLE
E2-1736: Message archive handles all kinds of text

### DIFF
--- a/AndroidSDKCore/src/main/java/com/leanplum/Leanplum.java
+++ b/AndroidSDKCore/src/main/java/com/leanplum/Leanplum.java
@@ -1362,16 +1362,16 @@ public class Leanplum {
   @VisibleForTesting
   public static String messageBodyFromContext(ActionContext actionContext) {
     Object messageObject =  actionContext.getArgs().get("Message");
-    if (messageObject.getClass().isInstance(String.class)) {
+    if (messageObject instanceof String) {
       return (String) messageObject;
     } else {
       HashMap<String, String> messageDict = (HashMap<String, String>) messageObject;
       if (messageDict.get("Text") != null &&
-              messageDict.get("Text").getClass().isInstance(String.class)) {
+              messageDict.get("Text") instanceof String) {
         return messageDict.get("Text");
       }
       if (messageDict.get("Text value") != null &&
-              messageDict.get("Text value").getClass().isInstance(String.class)) {
+              messageDict.get("Text value") instanceof String) {
         return messageDict.get("Text value");
       }
     }

--- a/AndroidSDKCore/src/main/java/com/leanplum/Leanplum.java
+++ b/AndroidSDKCore/src/main/java/com/leanplum/Leanplum.java
@@ -1359,7 +1359,8 @@ public class Leanplum {
     return new MessageArchiveData(messageID, messageBody, recipientUserID, deliveryDateTime);
   }
 
-  private static String messageBodyFromContext(ActionContext actionContext) {
+  @VisibleForTesting
+  public static String messageBodyFromContext(ActionContext actionContext) {
     Object messageObject =  actionContext.getArgs().get("Message");
     if (messageObject.getClass().isInstance(String.class)) {
       return (String) messageObject;
@@ -1373,6 +1374,8 @@ public class Leanplum {
               messageDict.get("Text value").getClass().isInstance(String.class)) {
         return messageDict.get("Text value");
       }
+    }
+    return null;
   }
 
   /**

--- a/AndroidSDKTests/src/test/java/com/leanplum/LeanplumTest.java
+++ b/AndroidSDKTests/src/test/java/com/leanplum/LeanplumTest.java
@@ -102,11 +102,11 @@ public class LeanplumTest extends AbstractTest {
 
     // Expected request params.
     final HashMap<String, Object> expectedRequestParams = CollectionUtil.newHashMap(
-        "city", "(detect)",
-        "country", "(detect)",
-        "location", "(detect)",
-        "region", "(detect)",
-        "locale", "en_US"
+            "city", "(detect)",
+            "country", "(detect)",
+            "location", "(detect)",
+            "region", "(detect)",
+            "locale", "en_US"
     );
 
     // Validate request.
@@ -134,11 +134,11 @@ public class LeanplumTest extends AbstractTest {
 
     // Expected request params.
     final HashMap<String, Object> expectedRequestParams = CollectionUtil.newHashMap(
-        "city", "(detect)",
-        "country", "(detect)",
-        "location", "(detect)",
-        "region", "(detect)",
-        "locale", "en_US"
+            "city", "(detect)",
+            "country", "(detect)",
+            "location", "(detect)",
+            "region", "(detect)",
+            "locale", "en_US"
     );
 
     // Validate request.
@@ -167,18 +167,18 @@ public class LeanplumTest extends AbstractTest {
 
     // Expected request params.
     final HashMap<String, Object> expectedRequestParams = CollectionUtil.newHashMap(
-        "city", "(detect)",
-        "country", "(detect)",
-        "location", "(detect)",
-        "region", "(detect)",
-        "locale", "en_US"
+            "city", "(detect)",
+            "country", "(detect)",
+            "location", "(detect)",
+            "region", "(detect)",
+            "locale", "en_US"
     );
 
     // Setup user attributes.
     final HashMap<String, Object> userAttributes = CollectionUtil.newHashMap(
-        "name", "John Smith",
-        "age", 42,
-        "address", "New York"
+            "name", "John Smith",
+            "age", 42,
+            "address", "New York"
     );
 
     // Validate request.
@@ -193,9 +193,9 @@ public class LeanplumTest extends AbstractTest {
         String requestUserAttributes = (String) params.get("userAttributes");
 
         assertTrue(userAttributes.keySet()
-            .containsAll(JsonConverter.fromJson(requestUserAttributes).keySet()));
+                .containsAll(JsonConverter.fromJson(requestUserAttributes).keySet()));
         assertTrue(userAttributes.values()
-            .containsAll(JsonConverter.fromJson(requestUserAttributes).values()));
+                .containsAll(JsonConverter.fromJson(requestUserAttributes).values()));
       }
     });
 
@@ -209,11 +209,11 @@ public class LeanplumTest extends AbstractTest {
 
     // Expected request params.
     final HashMap<String, Object> expectedRequestParams = CollectionUtil.newHashMap(
-        "city", "(detect)",
-        "country", "(detect)",
-        "location", "(detect)",
-        "region", "(detect)",
-        "locale", "en_US"
+            "city", "(detect)",
+            "country", "(detect)",
+            "location", "(detect)",
+            "region", "(detect)",
+            "locale", "en_US"
     );
 
     String userId = "user_id";
@@ -241,11 +241,11 @@ public class LeanplumTest extends AbstractTest {
 
     // Expected request params.
     final HashMap<String, Object> expectedRequestParams = CollectionUtil.newHashMap(
-        "city", "(detect)",
-        "country", "(detect)",
-        "location", "(detect)",
-        "region", "(detect)",
-        "locale", "en_US"
+            "city", "(detect)",
+            "country", "(detect)",
+            "location", "(detect)",
+            "region", "(detect)",
+            "locale", "en_US"
     );
 
     String userId = "user_id";
@@ -277,18 +277,18 @@ public class LeanplumTest extends AbstractTest {
 
     // Expected request params.
     final HashMap<String, Object> expectedRequestParams = CollectionUtil.newHashMap(
-        "city", "(detect)",
-        "country", "(detect)",
-        "location", "(detect)",
-        "region", "(detect)",
-        "locale", "en_US"
+            "city", "(detect)",
+            "country", "(detect)",
+            "location", "(detect)",
+            "region", "(detect)",
+            "locale", "en_US"
     );
 
     // Setup user attributes.
     final HashMap<String, Object> userAttributes = CollectionUtil.newHashMap(
-        "name", "John Smith",
-        "age", 42,
-        "address", "New York"
+            "name", "John Smith",
+            "age", 42,
+            "address", "New York"
     );
 
     String userId = "user_id";
@@ -305,9 +305,9 @@ public class LeanplumTest extends AbstractTest {
         String requestUserAttributes = (String) params.get("userAttributes");
 
         assertTrue(userAttributes.keySet()
-            .containsAll(JsonConverter.fromJson(requestUserAttributes).keySet()));
+                .containsAll(JsonConverter.fromJson(requestUserAttributes).keySet()));
         assertTrue(userAttributes.values()
-            .containsAll(JsonConverter.fromJson(requestUserAttributes).values()));
+                .containsAll(JsonConverter.fromJson(requestUserAttributes).values()));
       }
     });
 
@@ -322,18 +322,18 @@ public class LeanplumTest extends AbstractTest {
 
     // Expected request params.
     final HashMap<String, Object> expectedRequestParams = CollectionUtil.newHashMap(
-        "city", "(detect)",
-        "country", "(detect)",
-        "location", "(detect)",
-        "region", "(detect)",
-        "locale", "en_US"
+            "city", "(detect)",
+            "country", "(detect)",
+            "location", "(detect)",
+            "region", "(detect)",
+            "locale", "en_US"
     );
 
     // Setup user attributes.
     final HashMap<String, Object> userAttributes = CollectionUtil.newHashMap(
-        "name", "John Smith",
-        "age", 42,
-        "address", "New York"
+            "name", "John Smith",
+            "age", 42,
+            "address", "New York"
     );
 
     String userId = "user_id";
@@ -352,9 +352,9 @@ public class LeanplumTest extends AbstractTest {
         String requestUserAttributes = (String) params.get("userAttributes");
 
         assertTrue(userAttributes.keySet()
-            .containsAll(JsonConverter.fromJson(requestUserAttributes).keySet()));
+                .containsAll(JsonConverter.fromJson(requestUserAttributes).keySet()));
         assertTrue(userAttributes.values()
-            .containsAll(JsonConverter.fromJson(requestUserAttributes).values()));
+                .containsAll(JsonConverter.fromJson(requestUserAttributes).values()));
       }
     });
 
@@ -505,8 +505,8 @@ public class LeanplumTest extends AbstractTest {
     final double eventValue = 10.0;
     final String eventInfo = "test_event_info";
     final HashMap<String, Object> eventParams = CollectionUtil.newHashMap(
-        "test_param_string", "string",
-        "test_param_int", 42
+            "test_param_string", "string",
+            "test_param_int", 42
     );
 
     // Validate request for track with event name.
@@ -567,9 +567,9 @@ public class LeanplumTest extends AbstractTest {
         assertEquals(eventName, requestEventName);
         assertEquals(String.valueOf(eventValue), requestEventValue);
         assertTrue(eventParams.keySet()
-            .containsAll(JsonConverter.fromJson(requestEventParams).keySet()));
+                .containsAll(JsonConverter.fromJson(requestEventParams).keySet()));
         assertTrue(eventParams.values()
-            .containsAll(JsonConverter.fromJson(requestEventParams).values()));
+                .containsAll(JsonConverter.fromJson(requestEventParams).values()));
       }
     });
     Leanplum.track(eventName, eventValue, eventParams);
@@ -585,9 +585,9 @@ public class LeanplumTest extends AbstractTest {
 
         assertEquals(eventName, requestEventName);
         assertTrue(eventParams.keySet()
-            .containsAll(JsonConverter.fromJson(requestEventParams).keySet()));
+                .containsAll(JsonConverter.fromJson(requestEventParams).keySet()));
         assertTrue(eventParams.values()
-            .containsAll(JsonConverter.fromJson(requestEventParams).values()));
+                .containsAll(JsonConverter.fromJson(requestEventParams).values()));
       }
     });
     Leanplum.track(eventName, eventParams);
@@ -622,9 +622,9 @@ public class LeanplumTest extends AbstractTest {
         assertEquals(String.valueOf(eventValue), requestEventValue);
         assertEquals(eventInfo, requestEventInfo);
         assertTrue(eventParams.keySet()
-            .containsAll(JsonConverter.fromJson(requestEventParams).keySet()));
+                .containsAll(JsonConverter.fromJson(requestEventParams).keySet()));
         assertTrue(eventParams.values()
-            .containsAll(JsonConverter.fromJson(requestEventParams).values()));
+                .containsAll(JsonConverter.fromJson(requestEventParams).values()));
       }
     });
     Leanplum.track(eventName, eventValue, eventInfo, eventParams);
@@ -708,8 +708,8 @@ public class LeanplumTest extends AbstractTest {
     final String stateName = "test_state_name";
     final String stateInfo = "test_state_info";
     final HashMap<String, Object> stateParams = CollectionUtil.newHashMap(
-        "test_param_string", "string",
-        "test_param_int", 42
+            "test_param_string", "string",
+            "test_param_int", 42
     );
 
     // Validate request for advance with name.
@@ -751,9 +751,9 @@ public class LeanplumTest extends AbstractTest {
 
         assertEquals(stateName, requestStateName);
         assertTrue(stateParams.keySet()
-            .containsAll(JsonConverter.fromJson(requestStateParams).keySet()));
+                .containsAll(JsonConverter.fromJson(requestStateParams).keySet()));
         assertTrue(stateParams.values()
-            .containsAll(JsonConverter.fromJson(requestStateParams).values()));
+                .containsAll(JsonConverter.fromJson(requestStateParams).values()));
       }
     });
 
@@ -772,9 +772,9 @@ public class LeanplumTest extends AbstractTest {
         assertEquals(stateName, requestStateName);
         assertEquals(stateInfo, requestStateInfo);
         assertTrue(stateParams.keySet()
-            .containsAll(JsonConverter.fromJson(requestStateParams).keySet()));
+                .containsAll(JsonConverter.fromJson(requestStateParams).keySet()));
         assertTrue(stateParams.values()
-            .containsAll(JsonConverter.fromJson(requestStateParams).values()));
+                .containsAll(JsonConverter.fromJson(requestStateParams).values()));
       }
     });
     Leanplum.advanceTo(stateName, stateInfo, stateParams);
@@ -788,10 +788,10 @@ public class LeanplumTest extends AbstractTest {
     Var<Float> floatVariable = Var.define("test_float", 10.0f);
     Var<List<Integer>> listVariable = Var.define("test_list", Arrays.asList(0, 1, 2, 3, 4, 5));
     Var<HashMap<Object, Object>> dictionaryVariable = Var.define("test_dictionary",
-        CollectionUtil.newHashMap(
-            "dictionary_test_string", "test_string",
-            "dictionary_test_integer", 5
-        ));
+            CollectionUtil.newHashMap(
+                    "dictionary_test_string", "test_string",
+                    "dictionary_test_integer", 5
+            ));
     Var<Integer> colorVariable = Var.defineColor("test_color", 12345);
     Var<String> groupStringVariable = Var.define("groups.strings", "groups_string_test");
     Var<Integer> groupIntegerVariable = Var.define("groups.integers", 5);
@@ -809,7 +809,7 @@ public class LeanplumTest extends AbstractTest {
     assertEquals(floatVariable.defaultValue(), VarCache.getVariable("test_float").value());
     assertEquals(listVariable.defaultValue(), VarCache.getVariable("test_list").value());
     assertEquals(dictionaryVariable.defaultValue(), VarCache.getVariable("test_dictionary")
-        .value());
+            .value());
 
     // Validate values.
     assertEquals(colorVariable.value(), VarCache.getVariable("test_color").value());
@@ -826,8 +826,8 @@ public class LeanplumTest extends AbstractTest {
     assertEquals(listVariable.kind(), "list");
 
     // Validate components.
-    assertArrayEquals(groupStringVariable.nameComponents(), new String[] {"groups", "strings"});
-    assertArrayEquals(groupIntegerVariable.nameComponents(), new String[] {"groups", "integers"});
+    assertArrayEquals(groupStringVariable.nameComponents(), new String[]{"groups", "strings"});
+    assertArrayEquals(groupIntegerVariable.nameComponents(), new String[]{"groups", "integers"});
   }
 
   @Test
@@ -850,10 +850,10 @@ public class LeanplumTest extends AbstractTest {
     boolean booleanVariable = (boolean) VarCache.getVariable("Boolean Variable").value();
     float floatVariable = (float) VarCache.getVariable("numbers.floatVariable").value();
     double doubleVariable = (double) VarCache.getVariable("VariablesTestClass.doubleVariable")
-        .value();
+            .value();
     List<?> listVariable = (List<?>) VarCache.getVariable("listVariable").value();
     HashMap<?, ?> dictionaryVariable = (HashMap<?, ?>) VarCache.getVariable("dictionaryVariable")
-        .value();
+            .value();
 
     // Check if parsing is correct.
     assertEquals(VariablesTestClass.stringVariable, stringVariable);
@@ -909,7 +909,7 @@ public class LeanplumTest extends AbstractTest {
     args.with(boolArgumentName, true);
     args.withAsset(fileArgumentName, "leanplum_watermark.jpg");
     args.with(dictionaryArgumentName, CollectionUtil.newHashMap(
-        "test_value", "test"
+            "test_value", "test"
     ));
     args.with(arrayArgumentName, CollectionUtil.newArrayList(1, 2, 3, 4));
     args.withAction(actionArgumentName, "action_test");
@@ -929,13 +929,13 @@ public class LeanplumTest extends AbstractTest {
         Map<?, ?> definedActions = (HashMap<?, ?>) actionDefinitions.get(actionName);
 
         Map<String, Object> kinds = CollectionUtil.newHashMap(
-            "number_argument", "integer",
-            "string_argument", "string",
-            "color_argument", "color",
-            "dictionary_argument", "group",
-            "array_argument", "list",
-            "action_argument", "action",
-            "bool_argument", "bool"
+                "number_argument", "integer",
+                "string_argument", "string",
+                "color_argument", "color",
+                "dictionary_argument", "group",
+                "array_argument", "list",
+                "action_argument", "action",
+                "bool_argument", "bool"
         );
         Map<?, ?> requestedKinds = (HashMap<?, ?>) definedActions.get("kinds");
 
@@ -994,11 +994,11 @@ public class LeanplumTest extends AbstractTest {
   @Test
   public void testVariablesCallbacksTimeout() throws Exception {
     URLConnection urlConnection = Util.createHttpUrlConnection("www.leanplum.com", "api", "POST",
-        true, 1);
+            true, 1);
     urlConnection.setConnectTimeout(1);
 
     doReturn(urlConnection).when(Util.class, "createHttpUrlConnection", anyString(), anyString(),
-        anyBoolean(), anyInt());
+            anyBoolean(), anyInt());
 
     final CountDownLatch countDownLatch = new CountDownLatch(2);
 
@@ -1067,7 +1067,7 @@ public class LeanplumTest extends AbstractTest {
     Geocoder geocoder = Mockito.mock(Geocoder.class);
     whenNew(Geocoder.class).withAnyArguments().thenReturn(geocoder);
     when(geocoder.getFromLocation(anyDouble(), anyDouble(), anyInt()))
-        .thenReturn(addresses);
+            .thenReturn(addresses);
 
     // Validate set location request shorthand.
     RequestHelper.addRequestHandler(new RequestHelper.RequestHandler() {
@@ -1367,7 +1367,7 @@ public class LeanplumTest extends AbstractTest {
     requests.addAll(startRequestsWithCount(4));
 
     List<JSONObject> responsesList = new ArrayList<>();
-    for (int i=0;i < 15; i ++) {
+    for (int i = 0; i < 15; i++) {
       Map<String, Object> responseMap = new HashMap<>();
       responseMap.put(index, Integer.toString(i));
       responsesList.add(new JSONObject(responseMap));
@@ -1439,7 +1439,8 @@ public class LeanplumTest extends AbstractTest {
   }
 
   private List<Map<String, Object>> startRequestsWithCount(int n) {
-    return requestsWithCountAndPrefix(n, "start");  }
+    return requestsWithCountAndPrefix(n, "start");
+  }
 
   private List<Map<String, Object>> trackRequestsWithCount(int n) {
     return requestsWithCountAndPrefix(n, "track");
@@ -1447,7 +1448,7 @@ public class LeanplumTest extends AbstractTest {
 
   private List<Map<String, Object>> requestsWithCountAndPrefix(int n, String prefix) {
     List<Map<String, Object>> requests = new ArrayList<>();
-    for (int i=0;i < n; i ++) {
+    for (int i = 0; i < n; i++) {
       Map<String, Object> request = new HashMap<>();
       request.put(RequestOld.REQUEST_ID_KEY, prefix + "-uuid-" + Integer.toString(i));
       request.put(Constants.Params.ACTION, Constants.Methods.START);
@@ -1466,7 +1467,7 @@ public class LeanplumTest extends AbstractTest {
 
   private List<JSONObject> responsesWithCountAndPrefix(int n, String prefix) {
     List<JSONObject> responsesList = new ArrayList<>();
-    for (int i=0;i < n; i ++) {
+    for (int i = 0; i < n; i++) {
       Map<String, Object> responseMap = new HashMap<>();
       responseMap.put(RequestOld.REQUEST_ID_KEY, prefix + "-uuid-" + Integer.toString(i));
       responsesList.add(new JSONObject(responseMap));
@@ -1513,5 +1514,23 @@ public class LeanplumTest extends AbstractTest {
     Leanplum.addMessageDisplayedHandler(callbackTest.callback);
     Leanplum.triggerMessageDisplayed(testActionContext);
     assertTrue(callbackTest.callbackCalled);
+  }
+
+  /**
+   * Test trigger message displayed calls callback
+   */
+  @Test
+  public void testMessageBodyFromContextGetsCorrectBody() {
+    final String messageID = "testMessageID";
+    final String messageBody = "testMessageBody";
+    final String userID = "testUserID";
+
+    Map<String, Object> args = new HashMap<>();
+    args.put("Message", messageBody);
+    final ActionContext testActionContext = new ActionContext("test", args, messageID);
+
+    when(Leanplum.getUserId()).thenReturn(userID);
+    String body = Leanplum.messageBodyFromContext(testActionContext);
+    assertEquals(body, messageBody);
   }
 }

--- a/AndroidSDKTests/src/test/java/com/leanplum/LeanplumTest.java
+++ b/AndroidSDKTests/src/test/java/com/leanplum/LeanplumTest.java
@@ -1517,10 +1517,10 @@ public class LeanplumTest extends AbstractTest {
   }
 
   /**
-   * Test trigger message displayed calls callback
+   * Test messageBody gets correct body from context for string.
    */
   @Test
-  public void testMessageBodyFromContextGetsCorrectBody() {
+  public void testMessageBodyFromContextGetsCorrectBodyForString() {
     final String messageID = "testMessageID";
     final String messageBody = "testMessageBody";
     final String userID = "testUserID";
@@ -1533,4 +1533,49 @@ public class LeanplumTest extends AbstractTest {
     String body = Leanplum.messageBodyFromContext(testActionContext);
     assertEquals(body, messageBody);
   }
+
+  /**
+   * Test messageBody gets correct body from context for key text.
+   */
+  @Test
+  public void testMessageBodyFromContextGetsCorrectBodyForKeyText() {
+    final String messageID = "testMessageID";
+    final String messageBody = "testMessageBody";
+    final String userID = "testUserID";
+
+    Map<String, Object> messageObject = new HashMap<>();
+    messageObject.put("Text", messageBody);
+
+    Map<String, Object> args = new HashMap<>();
+    args.put("Message", messageObject);
+
+    final ActionContext testActionContext = new ActionContext("test", args, messageID);
+
+    when(Leanplum.getUserId()).thenReturn(userID);
+    String body = Leanplum.messageBodyFromContext(testActionContext);
+    assertEquals(body, messageBody);
+  }
+
+  /**
+   * Test messageBody gets correct body from context for key text value.
+   */
+  @Test
+  public void testMessageBodyFromContextGetsCorrectBodyForKeyTextValue() {
+    final String messageID = "testMessageID";
+    final String messageBody = "testMessageBody";
+    final String userID = "testUserID";
+
+    Map<String, Object> messageObject = new HashMap<>();
+    messageObject.put("Text value", messageBody);
+
+    Map<String, Object> args = new HashMap<>();
+    args.put("Message", messageObject);
+
+    final ActionContext testActionContext = new ActionContext("test", args, messageID);
+
+    when(Leanplum.getUserId()).thenReturn(userID);
+    String body = Leanplum.messageBodyFromContext(testActionContext);
+    assertEquals(body, messageBody);
+  }
+
 }


### PR DESCRIPTION
For Push message archiving, I had assumed that message["body"] is always a string. However, this is an incorrect assumption. For certain message types, message["body"] is a dictionary. We need to change the code to handle all the different kinds of messages.