### PR TITLE
LP-10041: Fix to allow multiple notifications on same priority

### DIFF
--- a/AndroidSDKCore/src/main/java/com/leanplum/internal/LeanplumInternal.java
+++ b/AndroidSDKCore/src/main/java/com/leanplum/internal/LeanplumInternal.java
@@ -245,17 +245,25 @@ public class LeanplumInternal {
         }
       });
       int priorityThreshold = actionContexts.get(0).getPriority();
-      boolean messageActionTriggered = false;
+      int countDownThreshold = fetchCountDown(actionContexts.get(0));
+      Boolean isPrioritySame = false;
       for (final ActionContext actionContext : actionContexts) {
         if (actionContext.getPriority() > priorityThreshold) {
           break;
         }
-
+        // check if priority is same.
+        if (isPrioritySame) {
+          int currentCountDown = fetchCountDown(actionContext);
+          //multiple messages have same priority and same countDown, only display one message
+          if (currentCountDown == countDownThreshold) {
+            break;
+          }
+        }
+        isPrioritySame = true;
         if (actionContext.actionName().equals(ActionManager.HELD_BACK_ACTION_NAME)) {
           ActionManager.getInstance().recordHeldBackImpression(
               actionContext.getMessageId(), actionContext.getOriginalMessageId());
-        } else if (!messageActionTriggered) {
-          messageActionTriggered = true;
+        } else {
           LeanplumInternal.triggerAction(actionContext, new VariablesChangedCallback() {
             @Override
             public void variablesChanged() {
@@ -269,6 +277,19 @@ public class LeanplumInternal {
         }
       }
     }
+  }
+
+  private static int fetchCountDown(ActionContext context) {
+    // Get eta.
+    Object countdownObj;
+    if (((BaseActionContext) context).isPreview()) {
+      countdownObj = 5.0;
+    } else {
+      Map<String, Object> messageConfig = CollectionUtil.uncheckedCast(
+          VarCache.getMessageDiffs().get(context.messageId));
+      countdownObj = messageConfig.get("countdown");
+    }
+    return ((Number) countdownObj).intValue();
   }
 
   private static Map<String, Object> makeTrackArgs(final String event, double value, String info,

--- a/AndroidSDKTests/src/test/java/com/leanplum/LeanplumTest.java
+++ b/AndroidSDKTests/src/test/java/com/leanplum/LeanplumTest.java
@@ -701,6 +701,40 @@ public class LeanplumTest extends AbstractTest {
   }
 
   @Test
+  public void testTrackEventsSamePriority() {
+
+    // Setup sdk first.
+    setupSDK(mContext, "/responses/simple_start_response.json");
+
+    // Setup event values.
+    final String eventName = "pushLocal";
+    // Validate request for track with event name.
+    RequestHelper.addRequestHandler(new RequestHelper.RequestHandler() {
+      @Override
+      public void onRequest(String httpMethod, String apiMethod, Map<String, Object> params) {
+        assertEquals(Constants.Methods.TRACK, apiMethod);
+        String requestEventName = (String) params.get("event");
+        assertEquals(eventName, requestEventName);
+      }
+    });
+
+    // Validate response for event with same priority and countdown
+    ResponseHelper.seedResponse("/responses/simple_start_response.json");
+
+    Leanplum.start(mContext, new StartCallback() {
+      @Override
+      public void onResponse(boolean success) {
+        //App successfully starts with local notifications with same priority and countdown
+        assertTrue(success);
+      }
+    });
+
+    assertTrue(Leanplum.hasStarted());
+    Leanplum.track(eventName);
+
+  }
+
+  @Test
   public void testAdvance() throws Exception {
     setupSDK(RuntimeEnvironment.application, "/responses/simple_start_response.json");
 

--- a/AndroidSDKTests/src/test/resources/responses/simple_start_response.json
+++ b/AndroidSDKTests/src/test/resources/responses/simple_start_response.json
@@ -4,6 +4,70 @@
       "uploadUrl": "https:\/\/www.leanplum.com\/_ah\/upload\/AMmfu6by_4mWZUn19c8v_omIeRezDaIfzqCosKTZTY4HnsxrA963YsrYMMnTPd538fmb4Gyx17-evF7X_QBqFIYjwPuTeHzihGM5-FHkW8o1zKxNl8E9yB2ZiumXvOj-gMbotIZYA1I_\/ALBNUaYAAAAAWAZDRSTEVp_wufYkJ7EFVZK_9eVhM32E\/",
       "interfaceRules": [
       ],
+      "messages": {
+        "4982955628167168": {
+          "countdown": 5,
+          "action": "__Push Notification",
+          "whenTriggers": {
+            "children": [{
+              "subject": "event",
+              "objects": [],
+              "verb": "triggers",
+              "noun": "pushLocal",
+              "secondaryVerb": "="
+            }],
+            "verb": "OR"
+          },
+          "parentCampaignId": null,
+          "vars": {
+            "Message": "Push Local #1",
+            "__name__": "__Push Notification"
+          },
+          "hasImpressionCriteria": false,
+          "priority": 1000,
+          "whenLimits": {
+            "children": [],
+            "subject": null,
+            "objects": []
+          },
+          "unlessTriggers": {
+            "children": [],
+            "subject": null,
+            "objects": []
+          }
+        },
+        "5571264209354752": {
+          "countdown": 5,
+          "action": "__Push Notification",
+          "whenTriggers": {
+            "children": [{
+              "subject": "event",
+              "objects": [],
+              "verb": "triggers",
+              "noun": "pushLocal",
+              "secondaryVerb": "="
+            }],
+            "verb": "OR"
+          },
+          "parentCampaignId": null,
+          "vars": {
+            "Message": "Push Local #2",
+            "__name__": "__Push Notification"
+          },
+          "hasImpressionCriteria": false,
+          "priority": 1000,
+          "whenLimits": {
+            "children": [],
+            "subject": null,
+            "objects": []
+          },
+          "unlessTriggers": {
+            "children": [],
+            "subject": null,
+            "objects": []
+          }
+        }
+      },
       "actionDefinitions": {
         "Confirm": {
           "values": {
@@ -222,8 +286,6 @@
       },
       "isRegistered": false,
       "regions": {
-      },
-      "messages": {
       },
       "varsFromCode": {
         "emptyDictionary": {


### PR DESCRIPTION
Fix to allow multiple notification only if priority of event type is same.
Ans only display 1 notification if priority and delay is exactly same.
WIP: Currently manually testing and deciding on unit testing strategy.

Fixes #

## Proposed Changes

  -
  -
  -

