### PR TITLE
E2-1790 android socket fix

### DIFF
--- a/AndroidSDKCore/src/main/java/com/leanplum/internal/Socket.java
+++ b/AndroidSDKCore/src/main/java/com/leanplum/internal/Socket.java
@@ -81,6 +81,9 @@ public class Socket {
       @Override
       public void onError(Exception error) {
         Log.e("Development socket error", error);
+
+        // if error happens during connecting, reset flag
+        connecting = false;
       }
 
       @Override

--- a/AndroidSDKCore/src/main/java/com/leanplum/internal/WebSocketClient.java
+++ b/AndroidSDKCore/src/main/java/com/leanplum/internal/WebSocketClient.java
@@ -99,24 +99,23 @@ class WebSocketClient {
       @Override
       public void run() {
         try {
-          int port = (mURI.getPort() != -1) ? mURI.getPort() : (mURI.getScheme().equals("wss") ? 443 : 80);
+          int port = (mURI.getPort() != -1) ? mURI.getPort() : (mURI.getScheme().equals("https") ? 443 : 80);
 
           String path = TextUtils.isEmpty(mURI.getPath()) ? "/" : mURI.getPath();
           if (!TextUtils.isEmpty(mURI.getQuery())) {
             path += "?" + mURI.getQuery();
           }
 
-          String originScheme = mURI.getScheme().equals("wss") ? "https" : "http";
           URI origin = null;
           try {
-            origin = new URI(originScheme, "//" + mURI.getHost(), null);
+            origin = new URI(mURI.getScheme(), "//" + mURI.getHost(), null);
           } catch (URISyntaxException e) {
             Util.handleException(e);
           }
 
           SocketFactory factory;
           try {
-            factory = mURI.getScheme().equals("wss") ? getSSLSocketFactory() : SocketFactory.getDefault();
+            factory = mURI.getScheme().equals("https") ? getSSLSocketFactory() : SocketFactory.getDefault();
           } catch (GeneralSecurityException e) {
             Util.handleException(e);
             return;

--- a/AndroidSDKCore/src/main/java/com/leanplum/internal/WebSocketClient.java
+++ b/AndroidSDKCore/src/main/java/com/leanplum/internal/WebSocketClient.java
@@ -99,7 +99,7 @@ class WebSocketClient {
       @Override
       public void run() {
         try {
-          int port = (mURI.getPort() != -1) ? mURI.getPort() : (mURI.getScheme().equals("https") ? 443 : 80);
+          int port = (mURI.getPort() != -1) ? mURI.getPort() : (isSecure() ? 443 : 80);
 
           String path = TextUtils.isEmpty(mURI.getPath()) ? "/" : mURI.getPath();
           if (!TextUtils.isEmpty(mURI.getQuery())) {
@@ -115,7 +115,7 @@ class WebSocketClient {
 
           SocketFactory factory;
           try {
-            factory = mURI.getScheme().equals("https") ? getSSLSocketFactory() : SocketFactory.getDefault();
+            factory = isSecure() ? getSSLSocketFactory() : SocketFactory.getDefault();
           } catch (GeneralSecurityException e) {
             Util.handleException(e);
             return;
@@ -183,6 +183,10 @@ class WebSocketClient {
       }
     });
     mThread.start();
+  }
+
+  public boolean isSecure() {
+    return mURI.getScheme().equals("https");
   }
 
   public void disconnect() {

--- a/AndroidSDKTests/src/test/java/com/leanplum/internal/WebSocketClientTest.java
+++ b/AndroidSDKTests/src/test/java/com/leanplum/internal/WebSocketClientTest.java
@@ -1,57 +1,57 @@
-/*
- * Copyright 2019, Leanplum, Inc. All rights reserved.
- *
- * Licensed to the Apache Software Foundation (ASF) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The ASF licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
- *
- *        http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
- */
-
-package com.leanplum.internal;
-
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.robolectric.RobolectricTestRunner;
-
-import java.net.URI;
-import java.net.URISyntaxException;
-
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-
-import com.leanplum.internal.WebSocketClient;
-
-/**
- * Tests for {@link WebSocketClient} class.
- *
- * @author Grace Gu
- */
-
-@RunWith(RobolectricTestRunner.class)
-public class WebSocketClientTest {
-
-  // java doesn't support wss so we expect WebSocketClient to respect http vs https
-  @Test
-  public void testIsSecure() throws URISyntaxException {
-    WebSocketClient webSocketClient = new WebSocketClient(new URI("https://dev.leanplum.com"), null, null);
-    assertTrue(webSocketClient.isSecure());
-  }
-
-  @Test
-  public void testIsNotSecure() throws URISyntaxException {
-    WebSocketClient webSocketClient = new WebSocketClient(new URI("http://dev.leanplum.com"), null, null);
-    assertFalse(webSocketClient.isSecure());
-  }
-}
+///*
+// * Copyright 2019, Leanplum, Inc. All rights reserved.
+// *
+// * Licensed to the Apache Software Foundation (ASF) under one
+// * or more contributor license agreements.  See the NOTICE file
+// * distributed with this work for additional information
+// * regarding copyright ownership.  The ASF licenses this file
+// * to you under the Apache License, Version 2.0 (the
+// * "License"); you may not use this file except in compliance
+// * with the License.  You may obtain a copy of the License at
+// *
+// *        http://www.apache.org/licenses/LICENSE-2.0
+// *
+// * Unless required by applicable law or agreed to in writing,
+// * software distributed under the License is distributed on an
+// * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// * KIND, either express or implied.  See the License for the
+// * specific language governing permissions and limitations
+// * under the License.
+// */
+//
+//package com.leanplum.internal;
+//
+//import org.junit.Test;
+//import org.junit.runner.RunWith;
+//import org.robolectric.RobolectricTestRunner;
+//
+//import java.net.URI;
+//import java.net.URISyntaxException;
+//
+//import static org.junit.Assert.assertFalse;
+//import static org.junit.Assert.assertTrue;
+//
+//import com.leanplum.internal.WebSocketClient;
+//
+///**
+// * Tests for {@link WebSocketClient} class.
+// *
+// * @author Grace Gu
+// */
+//
+//@RunWith(RobolectricTestRunner.class)
+//public class WebSocketClientTest {
+//
+//  // java doesn't support wss so we expect WebSocketClient to respect http vs https
+//  @Test
+//  public void testIsSecure() throws URISyntaxException {
+//    WebSocketClient webSocketClient = new WebSocketClient(new URI("https://dev.leanplum.com"), null, null);
+//    assertTrue(webSocketClient.isSecure());
+//  }
+//
+//  @Test
+//  public void testIsNotSecure() throws URISyntaxException {
+//    WebSocketClient webSocketClient = new WebSocketClient(new URI("http://dev.leanplum.com"), null, null);
+//    assertFalse(webSocketClient.isSecure());
+//  }
+//}

--- a/AndroidSDKTests/src/test/java/com/leanplum/internal/WebSocketClientTest.java
+++ b/AndroidSDKTests/src/test/java/com/leanplum/internal/WebSocketClientTest.java
@@ -20,35 +20,25 @@
  */
 package com.leanplum.internal;
 
-import android.content.Context;
-
 import com.leanplum.Leanplum;
 import com.leanplum.__setup.LeanplumTestApp;
 
-import org.json.JSONArray;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.Matchers;
 import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.rule.PowerMockRule;
 import org.robolectric.RobolectricTestRunner;
-import org.robolectric.RuntimeEnvironment;
 import org.robolectric.annotation.Config;
 
-import java.lang.reflect.Method;
 import java.net.URI;
 import java.net.URISyntaxException;
 
-import static junit.framework.Assert.assertEquals;
-import static junit.framework.Assert.assertNotNull;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
-import static org.powermock.api.mockito.PowerMockito.doReturn;
-import static org.powermock.api.mockito.PowerMockito.mockStatic;
 import static org.powermock.api.mockito.PowerMockito.spy;
-import static org.powermock.api.mockito.PowerMockito.when;
 
 /**
  * Tests for {@link WebSocketClient} class.
@@ -82,60 +72,15 @@ public class WebSocketClientTest {
 
   // java doesn't support wss so we expect WebSocketClient to respect http vs https
   @Test
-  public void testIsSecure() {//throws URISyntaxException {
-//    WebSocketClient webSocketClient = new WebSocketClient(new URI("https://dev.leanplum.com"), null, null);
-//    assertTrue(webSocketClient.isSecure());
+  public void testIsSecure() throws URISyntaxException {
+    WebSocketClient webSocketClient = new WebSocketClient(new URI("https://dev.leanplum.com"), null, null);
+    assertTrue(webSocketClient.isSecure());
     assertTrue(true);
   }
 
-//  /**
-//   * Test for {@link WebSocketClient#userAgentString()} that should return user-agent.
-//   *
-//   * @throws Exception
-//   */
-//  @Test
-//  public void testUserAgentString() throws Exception {
-//    mockStatic(Util.class);
-//    mockStatic(RequestOld.class);
-//    spy(Leanplum.class);
-//    SocketIOClient socketIOClient = new SocketIOClient(new URI(""), new SocketIOClient.Handler() {
-//      @Override
-//      public void onConnect() {
-//
-//      }
-//
-//      @Override
-//      public void on(String event, JSONArray arguments) {
-//
-//      }
-//
-//      @Override
-//      public void onDisconnect(int code, String reason) {
-//
-//      }
-//
-//      @Override
-//      public void onError(Exception error) {
-//
-//      }
-//    });
-//    Method userAgentStringMethod = SocketIOClient.class.getDeclaredMethod("userAgentString");
-//    userAgentStringMethod.setAccessible(true);
-//    assertNotNull(userAgentStringMethod);
-//    Constants.LEANPLUM_VERSION = "1";
-//    Constants.CLIENT = "android";
-//    when(RequestOld.class, "appId").thenReturn("app_id");
-//    when(Util.class, "getVersionName").thenReturn("app_version");
-//    when(Util.class, "getApplicationName", Matchers.any(Context.class)).thenReturn("app_name");
-//
-//    // Test with a non-null Context.
-//    doReturn(RuntimeEnvironment.application).when(Leanplum.class, "getContext");
-//    assertEquals("app_name/app_version(app_id; android; 1/s)",
-//        (String) userAgentStringMethod.invoke(socketIOClient));
-//
-//    // Test with a null Context.
-//    doReturn(null).when(Leanplum.class, "getContext");
-//    assertEquals("websocket(app_id; android; 1/s)",
-//        (String) userAgentStringMethod.invoke(socketIOClient));
-//  }
+  @Test
+  public void testIsNotSecure() throws URISyntaxException {
+    WebSocketClient webSocketClient = new WebSocketClient(new URI("http://dev.leanplum.com"), null, null);
+    assertFalse(webSocketClient.isSecure());
+  }
 }

--- a/AndroidSDKTests/src/test/java/com/leanplum/internal/WebSocketClientTest.java
+++ b/AndroidSDKTests/src/test/java/com/leanplum/internal/WebSocketClientTest.java
@@ -23,6 +23,8 @@ package com.leanplum.internal;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
+import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 
@@ -32,6 +34,7 @@ import java.net.URISyntaxException;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
+import com.leanplum.Leanplum;
 import com.leanplum.__setup.LeanplumTestApp;
 import com.leanplum.internal.WebSocketClient;
 
@@ -46,6 +49,14 @@ import com.leanplum.internal.WebSocketClient;
     sdk = 16,
     application = LeanplumTestApp.class
 )
+@PowerMockIgnore({
+    "org.mockito.*",
+    "org.robolectric.*",
+    "org.json.*",
+    "org.powermock.*",
+    "android.*"
+})
+@PrepareForTest({Leanplum.class, Util.class, SocketIOClient.class, RequestOld.class})
 public class WebSocketClientTest {
 
   // java doesn't support wss so we expect WebSocketClient to respect http vs https

--- a/AndroidSDKTests/src/test/java/com/leanplum/internal/WebSocketClientTest.java
+++ b/AndroidSDKTests/src/test/java/com/leanplum/internal/WebSocketClientTest.java
@@ -18,32 +18,41 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-
 package com.leanplum.internal;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.powermock.core.classloader.annotations.PowerMockIgnore;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.robolectric.RobolectricTestRunner;
-import org.robolectric.annotation.Config;
-
-import java.net.URI;
-import java.net.URISyntaxException;
-
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import android.content.Context;
 
 import com.leanplum.Leanplum;
 import com.leanplum.__setup.LeanplumTestApp;
-import com.leanplum.internal.WebSocketClient;
+
+import org.json.JSONArray;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Matchers;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.rule.PowerMockRule;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.RuntimeEnvironment;
+import org.robolectric.annotation.Config;
+
+import java.lang.reflect.Method;
+import java.net.URI;
+
+import static junit.framework.Assert.assertEquals;
+import static junit.framework.Assert.assertNotNull;
+import static org.powermock.api.mockito.PowerMockito.doReturn;
+import static org.powermock.api.mockito.PowerMockito.mockStatic;
+import static org.powermock.api.mockito.PowerMockito.spy;
+import static org.powermock.api.mockito.PowerMockito.when;
 
 /**
  * Tests for {@link WebSocketClient} class.
  *
  * @author Grace Gu
  */
-
 @RunWith(RobolectricTestRunner.class)
 @Config(
     sdk = 16,
@@ -58,17 +67,65 @@ import com.leanplum.internal.WebSocketClient;
 })
 @PrepareForTest({Leanplum.class, Util.class, WebSocketClient.class, RequestOld.class})
 public class WebSocketClientTest {
+  @Rule
+  public PowerMockRule rule = new PowerMockRule();
 
-  // java doesn't support wss so we expect WebSocketClient to respect http vs https
+  /**
+   * Runs before every test case.
+   */
+  @Before
+  public void setUp() {
+    spy(WebSocketClient.class);
+  }
+
+//  /**
+//   * Test for {@link WebSocketClient#userAgentString()} that should return user-agent.
+//   *
+//   * @throws Exception
+//   */
 //  @Test
-//  public void testIsSecure() throws URISyntaxException {
-//    WebSocketClient webSocketClient = new WebSocketClient(new URI("https://dev.leanplum.com"), null, null);
-//    assertTrue(webSocketClient.isSecure());
-//  }
+//  public void testUserAgentString() throws Exception {
+//    mockStatic(Util.class);
+//    mockStatic(RequestOld.class);
+//    spy(Leanplum.class);
+//    SocketIOClient socketIOClient = new SocketIOClient(new URI(""), new SocketIOClient.Handler() {
+//      @Override
+//      public void onConnect() {
 //
-//  @Test
-//  public void testIsNotSecure() throws URISyntaxException {
-//    WebSocketClient webSocketClient = new WebSocketClient(new URI("http://dev.leanplum.com"), null, null);
-//    assertFalse(webSocketClient.isSecure());
+//      }
+//
+//      @Override
+//      public void on(String event, JSONArray arguments) {
+//
+//      }
+//
+//      @Override
+//      public void onDisconnect(int code, String reason) {
+//
+//      }
+//
+//      @Override
+//      public void onError(Exception error) {
+//
+//      }
+//    });
+//    Method userAgentStringMethod = SocketIOClient.class.getDeclaredMethod("userAgentString");
+//    userAgentStringMethod.setAccessible(true);
+//    assertNotNull(userAgentStringMethod);
+//    Constants.LEANPLUM_VERSION = "1";
+//    Constants.CLIENT = "android";
+//    when(RequestOld.class, "appId").thenReturn("app_id");
+//    when(Util.class, "getVersionName").thenReturn("app_version");
+//    when(Util.class, "getApplicationName", Matchers.any(Context.class)).thenReturn("app_name");
+//
+//    // Test with a non-null Context.
+//    doReturn(RuntimeEnvironment.application).when(Leanplum.class, "getContext");
+//    assertEquals("app_name/app_version(app_id; android; 1/s)",
+//        (String) userAgentStringMethod.invoke(socketIOClient));
+//
+//    // Test with a null Context.
+//    doReturn(null).when(Leanplum.class, "getContext");
+//    assertEquals("websocket(app_id; android; 1/s)",
+//        (String) userAgentStringMethod.invoke(socketIOClient));
 //  }
 }

--- a/AndroidSDKTests/src/test/java/com/leanplum/internal/WebSocketClientTest.java
+++ b/AndroidSDKTests/src/test/java/com/leanplum/internal/WebSocketClientTest.java
@@ -31,6 +31,8 @@ import java.net.URISyntaxException;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
+import com.leanplum.internal.WebSocketClient;
+
 /**
  * Tests for {@link WebSocketClient} class.
  *

--- a/AndroidSDKTests/src/test/java/com/leanplum/internal/WebSocketClientTest.java
+++ b/AndroidSDKTests/src/test/java/com/leanplum/internal/WebSocketClientTest.java
@@ -39,7 +39,7 @@ import com.leanplum.internal.WebSocketClient;
  * @author Grace Gu
  */
 
-@RunWith(RobolectricTestRunner.class)
+//@RunWith(RobolectricTestRunner.class)
 public class WebSocketClientTest {
 
   // java doesn't support wss so we expect WebSocketClient to respect http vs https

--- a/AndroidSDKTests/src/test/java/com/leanplum/internal/WebSocketClientTest.java
+++ b/AndroidSDKTests/src/test/java/com/leanplum/internal/WebSocketClientTest.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2019, Leanplum, Inc. All rights reserved.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.leanplum.internal;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Tests for {@link WebSocketClient} class.
+ *
+ * @author Grace Gu
+ */
+
+@RunWith(RobolectricTestRunner.class)
+public class WebSocketClientTest {
+
+  // java doesn't support wss so we expect WebSocketClient to respect http vs https
+  @Test
+  public void testIsSecure() throws URISyntaxException {
+    WebSocketClient webSocketClient = new WebSocketClient(new URI("https://dev.leanplum.com"), null, null);
+    assertTrue(webSocketClient.isSecure());
+  }
+
+  @Test
+  public void testIsNotSecure() throws URISyntaxException {
+    WebSocketClient webSocketClient = new WebSocketClient(new URI("http://dev.leanplum.com"), null, null);
+    assertFalse(webSocketClient.isSecure());
+  }
+}

--- a/AndroidSDKTests/src/test/java/com/leanplum/internal/WebSocketClientTest.java
+++ b/AndroidSDKTests/src/test/java/com/leanplum/internal/WebSocketClientTest.java
@@ -1,48 +1,48 @@
-///*
-// * Copyright 2019, Leanplum, Inc. All rights reserved.
-// *
-// * Licensed to the Apache Software Foundation (ASF) under one
-// * or more contributor license agreements.  See the NOTICE file
-// * distributed with this work for additional information
-// * regarding copyright ownership.  The ASF licenses this file
-// * to you under the Apache License, Version 2.0 (the
-// * "License"); you may not use this file except in compliance
-// * with the License.  You may obtain a copy of the License at
-// *
-// *        http://www.apache.org/licenses/LICENSE-2.0
-// *
-// * Unless required by applicable law or agreed to in writing,
-// * software distributed under the License is distributed on an
-// * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-// * KIND, either express or implied.  See the License for the
-// * specific language governing permissions and limitations
-// * under the License.
-// */
-//
-//package com.leanplum.internal;
-//
-//import org.junit.Test;
-//import org.junit.runner.RunWith;
-//import org.robolectric.RobolectricTestRunner;
-//
-//import java.net.URI;
-//import java.net.URISyntaxException;
-//
-//import static org.junit.Assert.assertFalse;
-//import static org.junit.Assert.assertTrue;
-//
-//import com.leanplum.internal.WebSocketClient;
-//
-///**
-// * Tests for {@link WebSocketClient} class.
-// *
-// * @author Grace Gu
-// */
-//
-//@RunWith(RobolectricTestRunner.class)
-//public class WebSocketClientTest {
-//
-//  // java doesn't support wss so we expect WebSocketClient to respect http vs https
+/*
+ * Copyright 2019, Leanplum, Inc. All rights reserved.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.leanplum.internal;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import com.leanplum.internal.WebSocketClient;
+
+/**
+ * Tests for {@link WebSocketClient} class.
+ *
+ * @author Grace Gu
+ */
+
+@RunWith(RobolectricTestRunner.class)
+public class WebSocketClientTest {
+
+  // java doesn't support wss so we expect WebSocketClient to respect http vs https
 //  @Test
 //  public void testIsSecure() throws URISyntaxException {
 //    WebSocketClient webSocketClient = new WebSocketClient(new URI("https://dev.leanplum.com"), null, null);
@@ -54,4 +54,4 @@
 //    WebSocketClient webSocketClient = new WebSocketClient(new URI("http://dev.leanplum.com"), null, null);
 //    assertFalse(webSocketClient.isSecure());
 //  }
-//}
+}

--- a/AndroidSDKTests/src/test/java/com/leanplum/internal/WebSocketClientTest.java
+++ b/AndroidSDKTests/src/test/java/com/leanplum/internal/WebSocketClientTest.java
@@ -56,7 +56,7 @@ import com.leanplum.internal.WebSocketClient;
     "org.powermock.*",
     "android.*"
 })
-@PrepareForTest({Leanplum.class, Util.class, SocketIOClient.class, RequestOld.class})
+@PrepareForTest({Leanplum.class, Util.class, WebSocketClient.class, RequestOld.class})
 public class WebSocketClientTest {
 
   // java doesn't support wss so we expect WebSocketClient to respect http vs https

--- a/AndroidSDKTests/src/test/java/com/leanplum/internal/WebSocketClientTest.java
+++ b/AndroidSDKTests/src/test/java/com/leanplum/internal/WebSocketClientTest.java
@@ -24,6 +24,7 @@ package com.leanplum.internal;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
 
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -31,6 +32,7 @@ import java.net.URISyntaxException;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
+import com.leanplum.__setup.LeanplumTestApp;
 import com.leanplum.internal.WebSocketClient;
 
 /**
@@ -39,7 +41,11 @@ import com.leanplum.internal.WebSocketClient;
  * @author Grace Gu
  */
 
-//@RunWith(RobolectricTestRunner.class)
+@RunWith(RobolectricTestRunner.class)
+@Config(
+    sdk = 16,
+    application = LeanplumTestApp.class
+)
 public class WebSocketClientTest {
 
   // java doesn't support wss so we expect WebSocketClient to respect http vs https

--- a/AndroidSDKTests/src/test/java/com/leanplum/internal/WebSocketClientTest.java
+++ b/AndroidSDKTests/src/test/java/com/leanplum/internal/WebSocketClientTest.java
@@ -40,9 +40,11 @@ import org.robolectric.annotation.Config;
 
 import java.lang.reflect.Method;
 import java.net.URI;
+import java.net.URISyntaxException;
 
 import static junit.framework.Assert.assertEquals;
 import static junit.framework.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 import static org.powermock.api.mockito.PowerMockito.doReturn;
 import static org.powermock.api.mockito.PowerMockito.mockStatic;
 import static org.powermock.api.mockito.PowerMockito.spy;
@@ -76,6 +78,14 @@ public class WebSocketClientTest {
   @Before
   public void setUp() {
     spy(WebSocketClient.class);
+  }
+
+  // java doesn't support wss so we expect WebSocketClient to respect http vs https
+  @Test
+  public void testIsSecure() {//throws URISyntaxException {
+//    WebSocketClient webSocketClient = new WebSocketClient(new URI("https://dev.leanplum.com"), null, null);
+//    assertTrue(webSocketClient.isSecure());
+    assertTrue(true);
   }
 
 //  /**


### PR DESCRIPTION
Fix 1:
Originally we do various checks to see whether our connection is secure, like

`int port = (mURI.getPort() != -1) ? mURI.getPort() : (mURI.getScheme().equals("wss") ? 443 : 80);`

However wss is not supported in our URI java library so getScheme() returns http or https, so the condition is aways false. Before, we were using http, so checking for "wss" should return false, we were being passed to the correct port. However once we switched to https we expect these checks to return true, but since checking "wss" returns false, we are being passed to the wrong path.

The fix is to check for https instead of wss.

Fix 2:
We were not resetting flag `connecting` to false when connection fails, so even though we are supposed to retry connecting every few seconds, we are not currently doing that. This is a fix for that.