### PR TITLE
E2-1815: download files directly from URL instead of API call

### DIFF
--- a/AndroidSDKCore/src/main/java/com/leanplum/Leanplum.java
+++ b/AndroidSDKCore/src/main/java/com/leanplum/Leanplum.java
@@ -811,8 +811,8 @@ public class Leanplum {
             if (variants == null) {
               Log.d("No variants received from the server.");
             }
-            Map<String, String> filenamesToURL = parseFileURLs(response);
-            FileManager.setFilenameToURL(filenamesToURL);
+            Map<String, String> filenameToURLs = parseFilenameToURLs(response);
+            FileManager.setFilenameToURLs(filenameToURLs);
 
             if (BuildUtil.isNotificationChannelSupported(context)) {
               // Get notification channels and groups.
@@ -2111,8 +2111,8 @@ public class Leanplum {
               }
 
               parseVariantDebugInfo(response);
-              Map<String, String> filenamesToURL = parseFileURLs(response);
-              FileManager.setFilenameToURL(filenamesToURL);
+              Map<String, String> filenameToURLs = parseFilenameToURLs(response);
+              FileManager.setFilenameToURLs(filenameToURLs);
             }
             if (callback != null) {
               OsHandler.getInstance().post(callback);
@@ -2308,7 +2308,7 @@ public class Leanplum {
   }
 
   @VisibleForTesting
-  public static Map<String, String> parseFileURLs(JSONObject response) {
+  public static Map<String, String> parseFilenameToURLs(JSONObject response) {
     JSONObject filesObject = response.optJSONObject(
             Constants.Keys.FILES);
     return JsonConverter.mapFromJson(filesObject);

--- a/AndroidSDKCore/src/main/java/com/leanplum/Leanplum.java
+++ b/AndroidSDKCore/src/main/java/com/leanplum/Leanplum.java
@@ -2112,6 +2112,8 @@ public class Leanplum {
               }
 
               parseVariantDebugInfo(response);
+              Map<String, String> filenamesToURL = parseFileURLs(response);
+              FileManager.setFilenameToURL(filenamesToURL);
             }
             if (callback != null) {
               OsHandler.getInstance().post(callback);

--- a/AndroidSDKCore/src/main/java/com/leanplum/Leanplum.java
+++ b/AndroidSDKCore/src/main/java/com/leanplum/Leanplum.java
@@ -852,6 +852,9 @@ public class Leanplum {
             FeatureFlagManager.INSTANCE.setEnabledFeatureFlags((enabledFeatureFlags));
             parseVariantDebugInfo(response);
 
+            Map<String, String> filenamesToURL = parseFileURLs(response);
+            FileManager.setFilenameToURL(filenamesToURL);
+
             // Allow bidirectional realtime variable updates.
             if (Constants.isDevelopmentModeEnabled) {
 
@@ -2301,6 +2304,13 @@ public class Leanplum {
             Constants.Keys.ENABLED_FEATURE_FLAGS);
     Set<String> featureFlagSet = toSet(enabledFeatureFlags);
     return featureFlagSet;
+  }
+
+  @VisibleForTesting
+  public static Map<String, String> parseFileURLs(JSONObject response) {
+    JSONObject filesObject = response.optJSONObject(
+            Constants.Keys.FILES);
+    return JsonConverter.mapFromJson(filesObject);
   }
 
   private static Set<String> toSet(JSONArray array) {

--- a/AndroidSDKCore/src/main/java/com/leanplum/Leanplum.java
+++ b/AndroidSDKCore/src/main/java/com/leanplum/Leanplum.java
@@ -2311,7 +2311,10 @@ public class Leanplum {
   public static Map<String, String> parseFilenameToURLs(JSONObject response) {
     JSONObject filesObject = response.optJSONObject(
             Constants.Keys.FILES);
-    return JsonConverter.mapFromJson(filesObject);
+    if (filesObject != null) {
+      return JsonConverter.mapFromJson(filesObject);
+    }
+    return null;
   }
 
   private static Set<String> toSet(JSONArray array) {

--- a/AndroidSDKCore/src/main/java/com/leanplum/Leanplum.java
+++ b/AndroidSDKCore/src/main/java/com/leanplum/Leanplum.java
@@ -811,6 +811,8 @@ public class Leanplum {
             if (variants == null) {
               Log.d("No variants received from the server.");
             }
+            Map<String, String> filenamesToURL = parseFileURLs(response);
+            FileManager.setFilenameToURL(filenamesToURL);
 
             if (BuildUtil.isNotificationChannelSupported(context)) {
               // Get notification channels and groups.
@@ -851,9 +853,6 @@ public class Leanplum {
             Set<String> enabledFeatureFlags = parseFeatureFlags(response);
             FeatureFlagManager.INSTANCE.setEnabledFeatureFlags((enabledFeatureFlags));
             parseVariantDebugInfo(response);
-
-            Map<String, String> filenamesToURL = parseFileURLs(response);
-            FileManager.setFilenameToURL(filenamesToURL);
 
             // Allow bidirectional realtime variable updates.
             if (Constants.isDevelopmentModeEnabled) {

--- a/AndroidSDKCore/src/main/java/com/leanplum/internal/Constants.java
+++ b/AndroidSDKCore/src/main/java/com/leanplum/internal/Constants.java
@@ -212,6 +212,7 @@ public class Constants {
     public static final String LOGGING_ENABLED = "loggingEnabled";
     public static final String ENABLED_COUNTERS = "enabledSdkCounters";
     public static final String ENABLED_FEATURE_FLAGS = "enabledFeatureFlags";
+    public static final String FILES = "files";
     public static final String TIMEZONE = "timezone";
     public static final String TIMEZONE_OFFSET_SECONDS = "timezoneOffsetSeconds";
     public static final String TITLE = "Title";

--- a/AndroidSDKCore/src/main/java/com/leanplum/internal/FileManager.java
+++ b/AndroidSDKCore/src/main/java/com/leanplum/internal/FileManager.java
@@ -66,6 +66,7 @@ public class FileManager {
   private static boolean initializing = false;
   static final Object initializingLock = new Object();
   public static Var<HashMap<String, Object>> resources = null;
+  public static Map<String, String> filenameToURL = null;
 
   public enum DownloadFileResult {
     NONE,
@@ -108,6 +109,9 @@ public class FileManager {
       if (!FileManager.fileExistsAtPath(realPath)) {
         realPath = FileManager.fileRelativeToDocuments(stringValue);
         if (!FileManager.fileExistsAtPath(realPath)) {
+          if (FileManager.filenameToURL.containsKey(stringValue) && urlValue == null) {
+            urlValue = FileManager.filenameToURL.get(stringValue);
+          }
           RequestOld downloadRequest = RequestOld.get(Constants.Methods.DOWNLOAD_FILE, null);
           downloadRequest.onResponse(new RequestOld.ResponseCallback() {
             @Override
@@ -183,6 +187,10 @@ public class FileManager {
 
   public static boolean fileExistsAtPath(String path) {
     return path != null && new File(path).exists();
+  }
+
+  public static void setFilenameToURL(Map<String, String> filenameToURL) {
+    FileManager.filenameToURL = filenameToURL;
   }
 
   @SuppressWarnings("SameReturnValue")

--- a/AndroidSDKCore/src/main/java/com/leanplum/internal/FileManager.java
+++ b/AndroidSDKCore/src/main/java/com/leanplum/internal/FileManager.java
@@ -109,7 +109,7 @@ public class FileManager {
       if (!FileManager.fileExistsAtPath(realPath)) {
         realPath = FileManager.fileRelativeToDocuments(stringValue);
         if (!FileManager.fileExistsAtPath(realPath)) {
-          if (FileManager.filenameToURL.containsKey(stringValue) && urlValue == null) {
+          if (FileManager.filenameToURL != null && FileManager.filenameToURL.containsKey(stringValue) && urlValue == null) {
             urlValue = FileManager.filenameToURL.get(stringValue);
           }
           RequestOld downloadRequest = RequestOld.get(Constants.Methods.DOWNLOAD_FILE, null);

--- a/AndroidSDKCore/src/main/java/com/leanplum/internal/FileManager.java
+++ b/AndroidSDKCore/src/main/java/com/leanplum/internal/FileManager.java
@@ -66,7 +66,7 @@ public class FileManager {
   private static boolean initializing = false;
   static final Object initializingLock = new Object();
   public static Var<HashMap<String, Object>> resources = null;
-  public static Map<String, String> filenameToURL = null;
+  public static Map<String, String> filenameToURLs = null;
 
   public enum DownloadFileResult {
     NONE,
@@ -109,8 +109,8 @@ public class FileManager {
       if (!FileManager.fileExistsAtPath(realPath)) {
         realPath = FileManager.fileRelativeToDocuments(stringValue);
         if (!FileManager.fileExistsAtPath(realPath)) {
-          if (FileManager.filenameToURL != null && FileManager.filenameToURL.containsKey(stringValue) && urlValue == null) {
-            urlValue = FileManager.filenameToURL.get(stringValue);
+          if (FileManager.filenameToURLs != null && FileManager.filenameToURLs.containsKey(stringValue) && urlValue == null) {
+            urlValue = FileManager.filenameToURLs.get(stringValue);
           }
           RequestOld downloadRequest = RequestOld.get(Constants.Methods.DOWNLOAD_FILE, null);
           downloadRequest.onResponse(new RequestOld.ResponseCallback() {
@@ -189,8 +189,8 @@ public class FileManager {
     return path != null && new File(path).exists();
   }
 
-  public static void setFilenameToURL(Map<String, String> filenameToURL) {
-    FileManager.filenameToURL = filenameToURL;
+  public static void setFilenameToURLs(Map<String, String> filenameToURLs) {
+    FileManager.filenameToURLs = filenameToURLs;
   }
 
   @SuppressWarnings("SameReturnValue")

--- a/AndroidSDKTests/src/test/java/com/leanplum/LeanplumTest.java
+++ b/AndroidSDKTests/src/test/java/com/leanplum/LeanplumTest.java
@@ -1358,6 +1358,31 @@ public class LeanplumTest extends AbstractTest {
     assertEquals(new HashSet<>(Arrays.asList("test")), parsedCounters);
   }
 
+  @Test
+  public void testParseFilenameToURLs() throws JSONException {
+    JSONObject response = new JSONObject();
+    JSONObject files = new JSONObject();
+    files.put("file.jpg", "https://www.domain.com/file.jpg");
+    response.put(Constants.Keys.FILES, files);
+
+    Map<String, String> parsedFiles= Leanplum.parseFileURLs(response);
+    assertEquals(JsonConverter.mapFromJson(files), parsedFiles);
+  }
+
+  /**
+   * Tests for parsing filenameToURLs
+   */
+  @Test
+  public void testStartResponseShouldParseFilenameToURLs() {
+    // Setup sdk.
+    setupSDK(mContext, "/responses/simple_start_response.json");
+
+    Map<String, String> files = new HashMap<>();
+    files.put("file1.jpg", "http://www.domain.com/file1.jpg");
+    files.put("file2.jpg", "http://www.domain.com/file2.jpg");
+
+    assertEquals(files, FileManager.filenameToURL);
+  }
 
   /**
    * Tests for parsing feature flags

--- a/AndroidSDKTests/src/test/java/com/leanplum/LeanplumTest.java
+++ b/AndroidSDKTests/src/test/java/com/leanplum/LeanplumTest.java
@@ -1365,7 +1365,7 @@ public class LeanplumTest extends AbstractTest {
     files.put("file.jpg", "https://www.domain.com/file.jpg");
     response.put(Constants.Keys.FILES, files);
 
-    Map<String, String> parsedFiles= Leanplum.parseFileURLs(response);
+    Map<String, String> parsedFiles= Leanplum.parseFilenameToURLs(response);
     assertEquals(JsonConverter.mapFromJson(files), parsedFiles);
   }
 
@@ -1381,7 +1381,7 @@ public class LeanplumTest extends AbstractTest {
     files.put("file1.jpg", "http://www.domain.com/file1.jpg");
     files.put("file2.jpg", "http://www.domain.com/file2.jpg");
 
-    assertEquals(files, FileManager.filenameToURL);
+    assertEquals(files, FileManager.filenameToURLs);
   }
 
   /**

--- a/AndroidSDKTests/src/test/resources/responses/simple_start_response.json
+++ b/AndroidSDKTests/src/test/resources/responses/simple_start_response.json
@@ -332,6 +332,10 @@
         "testFeatureFlag1",
         "testFeatureFlag2"
       ],
+      "files": {
+        "file1.jpg" : "http://www.domain.com/file1.jpg",
+        "file2.jpg" : "http://www.domain.com/file2.jpg"
+      },
       "syncNewsfeed": false,
       "success": true,
       "interfaceEvents": [


### PR DESCRIPTION
As per https://leanplum.atlassian.net/browse/E2-1815 (Proposal 1), we will be sending the files key with the URL for each file. If this exists, we want the SDK to use the URL directly to get these files.

