### PR TITLE
Fixing DB not initialized when PN arrives

### DIFF
--- a/AndroidSDKCore/src/main/java/com/leanplum/Leanplum.java
+++ b/AndroidSDKCore/src/main/java/com/leanplum/Leanplum.java
@@ -625,7 +625,7 @@ public class Leanplum {
 
   private static void startHelper(
       String userId, final Map<String, ?> attributes, final boolean isBackground) {
-    LeanplumEventDataManager.init(context);
+    LeanplumEventDataManager.sharedInstance();
     checkAndStartNotificationsModules();
     Boolean limitAdTracking = null;
     String deviceId = RequestOld.deviceId();

--- a/AndroidSDKCore/src/main/java/com/leanplum/internal/RequestOld.java
+++ b/AndroidSDKCore/src/main/java/com/leanplum/internal/RequestOld.java
@@ -520,27 +520,17 @@ public class RequestOld implements Requesting {
 
     Leanplum.countAggregator().incrementCount("send_now");
 
-    // If we are running on main thread, fire the async task to execute the request async,
-    // otherwise send the request synchronously.
-    if (Looper.getMainLooper().getThread() == Thread.currentThread()) {
-      Util.executeAsyncTask(true, new AsyncTask<Void, Void, Void>() {
-        @Override
-        protected Void doInBackground(Void... params) {
-          try {
-            sendRequests();
-          } catch (Throwable t) {
-            Util.handleException(t);
-          }
-          return null;
+    Util.executeAsyncTask(true, new AsyncTask<Void, Void, Void>() {
+      @Override
+      protected Void doInBackground(Void... params) {
+        try {
+          sendRequests();
+        } catch (Throwable t) {
+          Util.handleException(t);
         }
-      });
-    } else {
-      try {
-        sendRequests();
-      } catch (Throwable t) {
-        Util.handleException(t);
+        return null;
       }
-    }
+    });
   }
 
   /**

--- a/AndroidSDKCore/src/main/java/com/leanplum/internal/RequestOld.java
+++ b/AndroidSDKCore/src/main/java/com/leanplum/internal/RequestOld.java
@@ -25,8 +25,12 @@ import android.content.Context;
 import android.content.SharedPreferences;
 import android.os.AsyncTask;
 import android.os.Build;
+
+import androidx.annotation.MainThread;
 import androidx.annotation.NonNull;
 import androidx.annotation.VisibleForTesting;
+
+import android.os.Looper;
 import android.text.TextUtils;
 
 import com.leanplum.Leanplum;
@@ -215,7 +219,7 @@ public class RequestOld implements Requesting {
     this.apiMethod = apiMethod;
     this.params = params != null ? params : new HashMap<String, Object>();
     // Check if it is error and here was SQLite exception.
-    if (Constants.Methods.LOG.equals(apiMethod) && LeanplumEventDataManager.willSendErrorLog) {
+    if (Constants.Methods.LOG.equals(apiMethod) && LeanplumEventDataManager.sharedInstance().willSendErrorLogs()) {
       localErrors.add(createArgsDictionary());
     }
     // Make sure the Handler is initialized on the main thread.
@@ -286,7 +290,7 @@ public class RequestOld implements Requesting {
         SharedPreferences preferences = context.getSharedPreferences(
             LEANPLUM, Context.MODE_PRIVATE);
         SharedPreferences.Editor editor = preferences.edit();
-        long count = LeanplumEventDataManager.getEventsCount();
+        long count = LeanplumEventDataManager.sharedInstance().getEventsCount();
         String uuid = preferences.getString(Constants.Defaults.UUID_KEY, null);
         if (uuid == null || count % MAX_EVENTS_PER_API_CALL == 0) {
           uuid = UUID.randomUUID().toString();
@@ -294,7 +298,7 @@ public class RequestOld implements Requesting {
           SharedPreferencesUtil.commitChanges(editor);
         }
         args.put(UUID_KEY, uuid);
-        LeanplumEventDataManager.insertEvent(JsonConverter.toJson(args));
+        LeanplumEventDataManager.sharedInstance().insertEvent(JsonConverter.toJson(args));
 
         dataBaseIndex = count;
         // Checks if here response and/or error callback for this request. We need to add callbacks to
@@ -370,9 +374,9 @@ public class RequestOld implements Requesting {
 
   public void sendIfConnected() {
     if (Util.isConnected()) {
-      this.sendNow();
+      sendNow();
     } else {
-      this.sendEventually();
+      sendEventually();
       Log.i("Device is offline, will send later");
       triggerErrorCallback(new Exception("Not connected to the Internet"));
     }
@@ -516,19 +520,28 @@ public class RequestOld implements Requesting {
 
     Leanplum.countAggregator().incrementCount("send_now");
 
-    Util.executeAsyncTask(true, new AsyncTask<Void, Void, Void>() {
-      @Override
-      protected Void doInBackground(Void... params) {
-        try {
-          sendRequests();
-        } catch (Throwable t) {
-          Util.handleException(t);
+    // If we are running on main thread, fire the async task to execute the request async,
+    // otherwise send the request synchronously.
+    if (Looper.getMainLooper().getThread() == Thread.currentThread()) {
+      Util.executeAsyncTask(true, new AsyncTask<Void, Void, Void>() {
+        @Override
+        protected Void doInBackground(Void... params) {
+          try {
+            sendRequests();
+          } catch (Throwable t) {
+            Util.handleException(t);
+          }
+          return null;
         }
-        return null;
+      });
+    } else {
+      try {
+        sendRequests();
+      } catch (Throwable t) {
+        Util.handleException(t);
       }
-    });
+    }
   }
-
 
   /**
    * This class wraps the unsent requests, requests that we need to send
@@ -697,7 +710,7 @@ public class RequestOld implements Requesting {
       return;
     }
 
-    if (LeanplumEventDataManager.willSendErrorLog) {
+    if (LeanplumEventDataManager.sharedInstance().willSendErrorLogs()) {
       return;
     }
 
@@ -714,7 +727,7 @@ public class RequestOld implements Requesting {
       return;
     }
     synchronized (RequestOld.class) {
-      LeanplumEventDataManager.deleteEvents(requestsCount);
+      LeanplumEventDataManager.sharedInstance().deleteEvents(requestsCount);
     }
   }
 
@@ -728,7 +741,7 @@ public class RequestOld implements Requesting {
               LEANPLUM, Context.MODE_PRIVATE);
       SharedPreferences.Editor editor = preferences.edit();
       int count = (int) (fraction * MAX_EVENTS_PER_API_CALL);
-      requestData = LeanplumEventDataManager.getEvents(count);
+      requestData = LeanplumEventDataManager.sharedInstance().getEvents(count);
       editor.remove(Constants.Defaults.UUID_KEY);
       SharedPreferencesUtil.commitChanges(editor);
       // if we send less than 100% of requests, we need to reset the batch

--- a/AndroidSDKFcm/src/main/java/com/leanplum/LeanplumPushFirebaseMessagingService.java
+++ b/AndroidSDKFcm/src/main/java/com/leanplum/LeanplumPushFirebaseMessagingService.java
@@ -42,14 +42,20 @@ import java.util.Map;
 public class LeanplumPushFirebaseMessagingService extends FirebaseMessagingService {
 
   @Override
+  public void onCreate() {
+    super.onCreate();
+    Leanplum.setApplicationContext(getApplicationContext());
+  }
+
+  @Override
   public void onNewToken(String token) {
     super.onNewToken(token);
 
     LeanplumPushService.setCloudMessagingProvider(new LeanplumFcmProvider());
-    LeanplumPushService.getCloudMessagingProvider().storePreferences(this.getApplicationContext(), token);
+    LeanplumPushService.getCloudMessagingProvider().storePreferences(getApplicationContext(), token);
 
     //send the new token to backend
-    LeanplumPushService.getCloudMessagingProvider().onRegistrationIdReceived(this.getApplicationContext(), token);
+    LeanplumPushService.getCloudMessagingProvider().onRegistrationIdReceived(getApplicationContext(), token);
   }
 
   /**
@@ -61,12 +67,9 @@ public class LeanplumPushFirebaseMessagingService extends FirebaseMessagingServi
   @Override
   public void onMessageReceived(RemoteMessage remoteMessage) {
     try {
-      if (Leanplum.getContext() == null) {
-        Leanplum.setApplicationContext(this);
-      }
       Map<String, String> messageMap = remoteMessage.getData();
       if (messageMap.containsKey(Constants.Keys.PUSH_MESSAGE_TEXT)) {
-        LeanplumPushService.handleNotification(this, getBundle(messageMap));
+        LeanplumPushService.handleNotification(getApplicationContext(), getBundle(messageMap));
       }
       Log.i("Received: " + messageMap.toString());
     } catch (Throwable t) {

--- a/AndroidSDKPush/src/main/java/com/leanplum/LeanplumPushService.java
+++ b/AndroidSDKPush/src/main/java/com/leanplum/LeanplumPushService.java
@@ -57,6 +57,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
+import java.util.concurrent.CountDownLatch;
 
 /**
  * Leanplum push notification service class, handling initialization, opening, showing, integration
@@ -367,6 +368,9 @@ public class LeanplumPushService {
       // Check if we have a chained message, and if it exists in var cache.
       if (ActionContext.shouldForceContentUpdateForChainedMessage(
           JsonConverter.fromJson(message.getString(Keys.PUSH_MESSAGE_ACTION)))) {
+
+        final CountDownLatch countDownLatch = new CountDownLatch(1);
+
         final int currentNotificationId = notificationId;
         final Notification.Builder currentNotificationBuilder = notificationBuilder;
         final NotificationCompat.Builder currentNotificationCompatBuilder = notificationCompatBuilder;
@@ -378,8 +382,10 @@ public class LeanplumPushService {
             } else {
               notificationManager.notify(currentNotificationId, currentNotificationCompatBuilder.build());
             }
+            countDownLatch.countDown();
           }
         });
+        countDownLatch.await();
       } else {
         if (notificationBuilder != null) {
           notificationManager.notify(notificationId, notificationBuilder.build());

--- a/AndroidSDKTests/src/test/java/com/leanplum/LeanplumTest.java
+++ b/AndroidSDKTests/src/test/java/com/leanplum/LeanplumTest.java
@@ -437,7 +437,7 @@ public class LeanplumTest extends AbstractTest {
 
     Context currentCotext = Leanplum.getContext();
     assertNotNull(currentCotext);
-    LeanplumEventDataManager.init(Leanplum.getContext());
+    LeanplumEventDataManager.sharedInstance();
 
     // Add two events to database.
     RequestOld request1 = new RequestOld("POST", Constants.Methods.GET_INBOX_MESSAGES, null);

--- a/AndroidSDKTests/src/test/java/com/leanplum/__setup/AbstractTest.java
+++ b/AndroidSDKTests/src/test/java/com/leanplum/__setup/AbstractTest.java
@@ -129,8 +129,8 @@ public abstract class AbstractTest {
     // Mock with our executor which will run on main thread.
     ReflectionHelpers.setStaticField(Util.class, "asyncExecutor", new SynchronousExecutor());
     ReflectionHelpers.setStaticField(Util.class, "singleThreadExecutor", new SynchronousExecutor());
-    ReflectionHelpers.setStaticField(LeanplumEventDataManager.class, "databaseManager", null);
-    ReflectionHelpers.setStaticField(LeanplumEventDataManager.class, "database", null);
+
+    ReflectionHelpers.setStaticField(LeanplumEventDataManager.class, "instance", null);
     // Get and set application context.
     mContext = RuntimeEnvironment.application;
     Leanplum.setApplicationContext(mContext);

--- a/AndroidSDKTests/src/test/java/com/leanplum/internal/LeanplumEventDataManagerTest.java
+++ b/AndroidSDKTests/src/test/java/com/leanplum/internal/LeanplumEventDataManagerTest.java
@@ -116,10 +116,7 @@ public class LeanplumEventDataManagerTest {
   }
 
   public static void setDatabaseToNull(){
-    ReflectionHelpers.setStaticField(LeanplumEventDataManager.class, "databaseManager",
-        null);
-    ReflectionHelpers.setStaticField(LeanplumEventDataManager.class, "database",
-        null);
+    ReflectionHelpers.setStaticField(LeanplumEventDataManager.class, "instance", null);
   }
 }
 

--- a/AndroidSDKTests/src/test/java/com/leanplum/internal/LeanplumEventDataManagerTest.java
+++ b/AndroidSDKTests/src/test/java/com/leanplum/internal/LeanplumEventDataManagerTest.java
@@ -67,10 +67,6 @@ public class LeanplumEventDataManagerTest {
     Leanplum.setApplicationContext(this.mContext);
   }
 
-  /**
-   * Test for {@link LeanplumEventDataManager.LeanplumDataBaseManager#migrateFromSharedPreferences(
-   *SQLiteDatabase)} that should migrate data from shared preferences to SQLite.
-   */
   @Test
   public void migrateFromSharedPreferencesTest() {
     setDatabaseToNull();
@@ -99,16 +95,16 @@ public class LeanplumEventDataManagerTest {
     assertEquals(3, count);
 
     // Create database. That should also migrate data from shared preferences.
-    LeanplumEventDataManager.init(mContext);
+    LeanplumEventDataManager.sharedInstance();
     // Assert in database after migration 3 events.
-    assertEquals(count, LeanplumEventDataManager.getEventsCount());
+    assertEquals(count, LeanplumEventDataManager.sharedInstance().getEventsCount());
 
     // Assert count 0 after data migration.
     count = preferences.getInt(Constants.Defaults.COUNT_KEY, 0);
     assertEquals(0, count);
 
     // Get list of events from SQLite.
-    List<Map<String, Object>> events = LeanplumEventDataManager.getEvents(3);
+    List<Map<String, Object>> events = LeanplumEventDataManager.sharedInstance().getEvents(3);
     assertNotNull(events);
     assertEquals(3, events.size());
     // Checks that all events inserted to SQLite in order.

--- a/AndroidSDKTests/src/test/java/com/leanplum/internal/RequestOldTest.java
+++ b/AndroidSDKTests/src/test/java/com/leanplum/internal/RequestOldTest.java
@@ -35,6 +35,7 @@ import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.RuntimeEnvironment;
 import org.robolectric.annotation.Config;
+import org.robolectric.util.ReflectionHelpers;
 
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
@@ -69,7 +70,11 @@ public class RequestOldTest extends TestCase {
   public void setUp() {
     Application context = RuntimeEnvironment.application;
     assertNotNull(context);
+
     Leanplum.setApplicationContext(context);
+
+    ReflectionHelpers.setStaticField(LeanplumEventDataManager.class, "instance", null);
+    LeanplumEventDataManager.sharedInstance();
   }
 
   /** Test that request include a generated request id **/
@@ -134,7 +139,6 @@ public class RequestOldTest extends TestCase {
   @Test
   public void testRemoveIrrelevantBackgroundStartRequests() throws NoSuchMethodException,
       InvocationTargetException, IllegalAccessException {
-    LeanplumEventDataManager.sharedInstance();
     // Prepare testable objects and method.
     RequestOld request = new RequestOld("POST", Constants.Methods.START, null);
     Method removeIrrelevantBackgroundStartRequests =
@@ -260,14 +264,13 @@ public class RequestOldTest extends TestCase {
   // we want to generate the requests to send
   // The list should try and get a smaller fraction of the available requests
   @Test
-  public void testJsonEncodeUnsentRequestsWithExceptionLargeNumbers() throws NoSuchMethodException,
-          InvocationTargetException, IllegalAccessException {
-    LeanplumEventDataManager.sharedInstance();
+  public void testJsonEncodeUnsentRequestsWithExceptionLargeNumbers() {
     RequestOld.RequestsWithEncoding requestsWithEncoding;
     // Prepare testable objects and method.
     RequestOld request = spy(new RequestOld("POST", Constants.Methods.START, null));
     request.sendEventually(); // first request added
-    for (int i = 0;i < 4999; i++) { // remaining requests to make up 5000
+
+    for (int i = 0;i < 5000; i++) { // remaining requests to make up 5000
       new RequestOld("POST", Constants.Methods.START, null).sendEventually();
     }
     // Expectation: 5000 requests returned.

--- a/AndroidSDKTests/src/test/java/com/leanplum/internal/RequestOldTest.java
+++ b/AndroidSDKTests/src/test/java/com/leanplum/internal/RequestOldTest.java
@@ -134,7 +134,7 @@ public class RequestOldTest extends TestCase {
   @Test
   public void testRemoveIrrelevantBackgroundStartRequests() throws NoSuchMethodException,
       InvocationTargetException, IllegalAccessException {
-    LeanplumEventDataManager.init(Leanplum.getContext());
+    LeanplumEventDataManager.sharedInstance();
     // Prepare testable objects and method.
     RequestOld request = new RequestOld("POST", Constants.Methods.START, null);
     Method removeIrrelevantBackgroundStartRequests =
@@ -262,7 +262,7 @@ public class RequestOldTest extends TestCase {
   @Test
   public void testJsonEncodeUnsentRequestsWithExceptionLargeNumbers() throws NoSuchMethodException,
           InvocationTargetException, IllegalAccessException {
-    LeanplumEventDataManager.init(Leanplum.getContext());
+    LeanplumEventDataManager.sharedInstance();
     RequestOld.RequestsWithEncoding requestsWithEncoding;
     // Prepare testable objects and method.
     RequestOld request = spy(new RequestOld("POST", Constants.Methods.START, null));

--- a/AndroidSDKTests/src/test/java/com/leanplum/internal/RequestOldUtilTest.java
+++ b/AndroidSDKTests/src/test/java/com/leanplum/internal/RequestOldUtilTest.java
@@ -43,7 +43,7 @@ public class RequestOldUtilTest extends TestCase {
 
     @Test
     public void testSetNewBatchUUID() {
-        LeanplumEventDataManager.init(Leanplum.getContext());
+        LeanplumEventDataManager.sharedInstance();
 
         RequestOld request1 = new RequestOld(this.POST, Constants.Methods.START, null);
         request1.sendEventually();


### PR DESCRIPTION
What              | Where/Who
------------------|----------------------------------------
JIRA Issue        | [JIRA_TICKET_ID](https://leanplum.atlassian.net/browse/E2-1970)
People Involved   | @milos1290, @hrishileanplum 

[Notes on PR descriptions](https://leanplum.atlassian.net/wiki/spaces/PR/pages/288424408/Creating+a+GitHub+Pull+Request)

## Background
This PR fixes 2 issues
1) when PN arrives and we need to pull new content, DB is not initialised because initialisation happens in `start` and app is not running.
2) when PN arrives we are offloading a network request from IntentService to an async task, service will be killed and kill our process.

## Implementation

1) Making DB manager singleton
2) conditionally decide whether to run task async or on current thread.

## Testing steps

* Install the app
* Kill the app from task manager
* Create IAM
* Send push that chains to IAM from previous step

## Is this change backwards-compatible?

Yes