### PR TITLE
Variable default value if int value is string

### DIFF
--- a/AndroidSDKCore/src/main/java/com/leanplum/Var.java
+++ b/AndroidSDKCore/src/main/java/com/leanplum/Var.java
@@ -302,6 +302,22 @@ public class Var<T> {
         numberValue = Double.valueOf(stringValue);
       } catch (NumberFormatException e) {
         numberValue = null;
+        if (defaultValue instanceof Short) {
+          value = (T) (Short) ((Number) defaultValue).shortValue();
+          numberValue = Double.valueOf(((Number) defaultValue).shortValue());
+        } else if (defaultValue instanceof Integer) {
+          value = (T) (Integer) ((Number) defaultValue).intValue();
+          numberValue = Double.valueOf(((Number) defaultValue).intValue());
+        } else if (defaultValue instanceof Long) {
+          value = (T) (Long) ((Number) defaultValue).longValue();
+          numberValue = Double.valueOf(((Number) defaultValue).longValue());
+        } else if (defaultValue instanceof Float) {
+          value = (T) (Float) ((Number) defaultValue).floatValue();
+          numberValue = Double.valueOf(((Number) defaultValue).floatValue());
+        } else if (defaultValue instanceof Double) {
+          value = (T) (Double) ((Number) defaultValue).doubleValue();
+          numberValue = Double.valueOf(((Number) defaultValue).doubleValue());
+        }
       }
     } else if (value instanceof Number) {
       stringValue = "" + value;

--- a/AndroidSDKTests/src/test/java/com/leanplum/LeanplumTest.java
+++ b/AndroidSDKTests/src/test/java/com/leanplum/LeanplumTest.java
@@ -829,6 +829,7 @@ public class LeanplumTest extends AbstractTest {
     Var<Integer> colorVariable = Var.defineColor("test_color", 12345);
     Var<String> groupStringVariable = Var.define("groups.strings", "groups_string_test");
     Var<Integer> groupIntegerVariable = Var.define("groups.integers", 5);
+    Var<Integer> integerVariableString = Var.define("test_integer_string_invalid", 10);
 
     setupSDK(mContext, "/responses/simple_start_response.json");
 
@@ -844,6 +845,7 @@ public class LeanplumTest extends AbstractTest {
     assertEquals(listVariable.defaultValue(), VarCache.getVariable("test_list").value());
     assertEquals(dictionaryVariable.defaultValue(), VarCache.getVariable("test_dictionary")
             .value());
+    assertEquals(integerVariable.defaultValue(), VarCache.getVariable("test_integer_string_invalid").value());
 
     // Validate values.
     assertEquals(colorVariable.value(), VarCache.getVariable("test_color").value());

--- a/AndroidSDKTests/src/test/resources/responses/simple_start_response.json
+++ b/AndroidSDKTests/src/test/resources/responses/simple_start_response.json
@@ -308,7 +308,8 @@
         "floatVariable": 5,
         "integerVariable": 1,
         "fileVariable": "leanplum_watermark.jpg",
-        "stringVariable": "test_string"
+        "stringVariable": "test_string",
+        "integerVariableString": "test"
       },
       "latestVersion": "1.4.0.2",
       "vars": {


### PR DESCRIPTION
What              | Where/Who
------------------|----------------------------------------
JIRA Issue        | [LP-11069](https://leanplum.atlassian.net/browse/LP-11069)
People Involved   | @colleague1, @colleague2

[Notes on PR descriptions]

## Background
If a variable of Integer type has a String value assigned through dashboard. Then when cast exception happens, not to crash. And set defaultValue to value and numberValue.

## Implementation

## Testing steps

## Is this change backwards-compatible?
