### PR TITLE
Run queued actions when activity is set

### DIFF
--- a/AndroidSDKCore/src/main/java/com/leanplum/Leanplum.java
+++ b/AndroidSDKCore/src/main/java/com/leanplum/Leanplum.java
@@ -501,15 +501,12 @@ public class Leanplum {
       final Map<String, ?> attributes, StartCallback response, final Boolean isBackground) {
     try {
       OsHandler.getInstance();
-
-      if (context instanceof Activity) {
-        LeanplumActivityHelper.currentActivity = (Activity) context;
-      }
+      LeanplumActivityHelper.setCurrentActivity(context);
 
       // Detect if app is in background automatically if isBackground is not set.
       final boolean actuallyInBackground;
       if (isBackground == null) {
-        actuallyInBackground = LeanplumActivityHelper.currentActivity == null ||
+        actuallyInBackground = LeanplumActivityHelper.getCurrentActivity() == null ||
             LeanplumActivityHelper.isActivityPaused();
       } else {
         actuallyInBackground = isBackground;
@@ -858,9 +855,9 @@ public class Leanplum {
             if (Constants.isDevelopmentModeEnabled) {
 
               final Context currentContext = (
-                  LeanplumActivityHelper.currentActivity != context &&
-                      LeanplumActivityHelper.currentActivity != null) ?
-                  LeanplumActivityHelper.currentActivity
+                  LeanplumActivityHelper.getCurrentActivity() != context &&
+                      LeanplumActivityHelper.getCurrentActivity() != null) ?
+                  LeanplumActivityHelper.getCurrentActivity()
                   : context;
 
               // Register device.

--- a/AndroidSDKCore/src/main/java/com/leanplum/LeanplumActivityHelper.java
+++ b/AndroidSDKCore/src/main/java/com/leanplum/LeanplumActivityHelper.java
@@ -24,6 +24,7 @@ package com.leanplum;
 import android.app.Activity;
 import android.app.Application;
 import android.app.Application.ActivityLifecycleCallbacks;
+import android.content.Context;
 import android.content.res.Resources;
 import android.os.Build;
 import android.os.Bundle;
@@ -60,7 +61,7 @@ public class LeanplumActivityHelper {
    */
   private static boolean registeredCallbacks;
 
-  static Activity currentActivity;
+  private static Activity currentActivity;
 
   private final Activity activity;
   private LeanplumResources res;
@@ -78,6 +79,18 @@ public class LeanplumActivityHelper {
     this.activity = activity;
     Leanplum.setApplicationContext(activity.getApplicationContext());
     Parser.parseVariables(activity);
+  }
+
+  /**
+   * Set activity and run pending actions
+   */
+  public static void setCurrentActivity(Context context) {
+    if (context instanceof Activity) {
+      currentActivity = (Activity) context;
+
+      // run pending actions if any upon start
+      LeanplumInternal.addStartIssuedHandler(runPendingActionsRunnable);
+    }
   }
 
   /**
@@ -158,6 +171,8 @@ public class LeanplumActivityHelper {
 
     });
     registeredCallbacks = true;
+    // run pending actions if any upon start
+    LeanplumInternal.addStartIssuedHandler(runPendingActionsRunnable);
   }
 
   public LeanplumResources getLeanplumResources() {

--- a/AndroidSDKCore/src/main/java/com/leanplum/internal/RequestOld.java
+++ b/AndroidSDKCore/src/main/java/com/leanplum/internal/RequestOld.java
@@ -477,6 +477,12 @@ public class RequestOld implements Requesting {
     if (Constants.isTestMode) {
       return;
     }
+
+    // always save request first
+    sendEventually();
+
+    // in case appId and accessKey are set later, request is already saved and will be
+    // sent when variables are set.
     if (appId == null) {
       Log.e("Cannot send request. appId is not set.");
       return;
@@ -485,9 +491,6 @@ public class RequestOld implements Requesting {
       Log.e("Cannot send request. accessKey is not set.");
       return;
     }
-
-    // We need to save request first.
-    sendEventually();
 
     Leanplum.countAggregator().incrementCount("send_now");
 

--- a/AndroidSDKPush/src/main/java/com/leanplum/LeanplumPushService.java
+++ b/AndroidSDKPush/src/main/java/com/leanplum/LeanplumPushService.java
@@ -239,7 +239,7 @@ public class LeanplumPushService {
   }
 
   static void handleNotification(final Context context, final Bundle message) {
-    if (LeanplumActivityHelper.currentActivity != null
+    if (LeanplumActivityHelper.getCurrentActivity() != null
         && !LeanplumActivityHelper.isActivityPaused
         && (message.containsKey(Keys.PUSH_MESSAGE_ID_MUTE_WITH_ACTION)
         || message.containsKey(Keys.PUSH_MESSAGE_ID_MUTE))) {
@@ -418,7 +418,7 @@ public class LeanplumPushService {
     // Start activity.
     Class<? extends Activity> callbackClass = LeanplumPushService.getCallbackClass();
     boolean shouldStartActivity = true;
-    Activity currentActivity = LeanplumActivityHelper.currentActivity;
+    Activity currentActivity = LeanplumActivityHelper.getCurrentActivity();
     if (currentActivity != null && !LeanplumActivityHelper.isActivityPaused) {
       if (callbackClass == null) {
         shouldStartActivity = false;

--- a/AndroidSDKPush/src/main/java/com/leanplum/LeanplumPushService.java
+++ b/AndroidSDKPush/src/main/java/com/leanplum/LeanplumPushService.java
@@ -33,7 +33,6 @@ import android.content.pm.ResolveInfo;
 import android.graphics.Bitmap;
 import android.net.Uri;
 import android.os.Bundle;
-import androidx.core.app.NotificationCompat;
 
 import com.leanplum.callbacks.VariablesChangedCallback;
 import com.leanplum.internal.ActionManager;
@@ -58,6 +57,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.Random;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import androidx.core.app.NotificationCompat;
 
 /**
  * Leanplum push notification service class, handling initialization, opening, showing, integration
@@ -369,30 +371,26 @@ public class LeanplumPushService {
       if (ActionContext.shouldForceContentUpdateForChainedMessage(
           JsonConverter.fromJson(message.getString(Keys.PUSH_MESSAGE_ACTION)))) {
 
+        // try to fetch referenced chained message and wait a bit for result
         final CountDownLatch countDownLatch = new CountDownLatch(1);
-
-        final int currentNotificationId = notificationId;
-        final Notification.Builder currentNotificationBuilder = notificationBuilder;
-        final NotificationCompat.Builder currentNotificationCompatBuilder = notificationCompatBuilder;
         Leanplum.forceContentUpdate(new VariablesChangedCallback() {
           @Override
           public void variablesChanged() {
-            if (currentNotificationBuilder != null) {
-              notificationManager.notify(currentNotificationId, currentNotificationBuilder.build());
-            } else {
-              notificationManager.notify(currentNotificationId, currentNotificationCompatBuilder.build());
-            }
             countDownLatch.countDown();
           }
         });
-        countDownLatch.await();
-      } else {
-        if (notificationBuilder != null) {
-          notificationManager.notify(notificationId, notificationBuilder.build());
-        } else {
-          notificationManager.notify(notificationId, notificationCompatBuilder.build());
-        }
+
+        // continue after 3 seconds and post the notification
+        countDownLatch.await(3, TimeUnit.SECONDS);
       }
+
+      // always post notification
+      if (notificationBuilder != null) {
+        notificationManager.notify(notificationId, notificationBuilder.build());
+      } else {
+        notificationManager.notify(notificationId, notificationCompatBuilder.build());
+      }
+
     } catch (NullPointerException e) {
       Log.e("Unable to show push notification.", e);
     } catch (Throwable t) {

--- a/AndroidSDKTests/src/test/java/com/leanplum/LeanplumActivityHelperTest.java
+++ b/AndroidSDKTests/src/test/java/com/leanplum/LeanplumActivityHelperTest.java
@@ -56,7 +56,7 @@ public class LeanplumActivityHelperTest extends TestCase {
     assertTrue(isRunnableQueued(runnable));
 
     FakeActivity fakeActivity = new FakeActivity();
-    LeanplumActivityHelper.currentActivity = fakeActivity;
+    LeanplumActivityHelper.setCurrentActivity(fakeActivity);
 
     // Test activity is finishing.
     final CountDownLatch latch2 = new CountDownLatch(1);


### PR DESCRIPTION
What              | Where/Who
------------------|----------------------------------------
JIRA Issue        | [LP-11106](https://leanplum.atlassian.net/browse/LP-11106)
People Involved   | @milos1290

[Notes on PR descriptions](https://leanplum.atlassian.net/wiki/spaces/PR/pages/288424408/Creating+a+GitHub+Pull+Request)

## Background
When running chained actions on cold start after notification is tapped, the action will be queued but won't be triggered unless activity lifecycle callbacks are set before activity is started. This fix triggers the actions to be run when SDK is run and as soon as activity is set.

