### PR TITLE
Remove build number suffix from SDK version parameter

### DIFF
--- a/AndroidSDKCore/src/main/java/com/leanplum/internal/Constants.java
+++ b/AndroidSDKCore/src/main/java/com/leanplum/internal/Constants.java
@@ -36,7 +36,7 @@ public class Constants {
   public static int SOCKET_PORT = 443;
   public static int NETWORK_TIMEOUT_SECONDS = 10;
   public static int NETWORK_TIMEOUT_SECONDS_FOR_DOWNLOADS = 10;
-  public static String LEANPLUM_VERSION = BuildConfig.SDK_VERSION + '.' + BuildConfig.BUILD_NUMBER;
+  public static String LEANPLUM_VERSION = BuildConfig.SDK_VERSION;
   public static String CLIENT = "android";
   public static String LEANPLUM_SUPPORTED_ENCODING = "gzip";
 

--- a/AndroidSDKTests/src/test/java/com/leanplum/internal/BuildConfigTest.java
+++ b/AndroidSDKTests/src/test/java/com/leanplum/internal/BuildConfigTest.java
@@ -39,12 +39,12 @@ public class BuildConfigTest extends AbstractTest {
 
     String[] parts = version.split("\\.");
 
-    assertEquals(4, parts.length);
+    assertEquals(3, parts.length);
     // Ensure we can parse and do not go down in major version.
     int major = Integer.parseInt(parts[0]);
     assert(major >= 4);
 
-    // Ensure minor and patch versions are parseable.
+    // Ensure minor and patch versions are parsable.
     int minor = Integer.parseInt(parts[1]);
     assert(minor >= 0);
 


### PR DESCRIPTION
What              | Where/Who
------------------|----------------------------------------
JIRA Issue        | [SDK-12](https://leanplum.atlassian.net/browse/SDK-12)
People Involved   | @hborisoff 

## Background
SDK is sending version number with appended build number. For example sending 5.4.0.0 instead of 5.4.0.

The reason for adding that suffix is not clear.
You can check PR #234.
