### PR TITLE
Fix Util.handleException to rethrow exceptions during unit testing.

### DIFF
--- a/AndroidSDKTests/src/test/java/com/leanplum/__setup/LeanplumTestHelper.java
+++ b/AndroidSDKTests/src/test/java/com/leanplum/__setup/LeanplumTestHelper.java
@@ -134,6 +134,10 @@ public class LeanplumTestHelper {
     List onceNoDownloadsHandlers = (List) TestClassUtil.getField(Leanplum.class,
         "onceNoDownloadsHandlers");
     onceNoDownloadsHandlers.clear();
+    List messageDisplayedHandlers =
+        (List) TestClassUtil.getField(Leanplum.class, "messageDisplayedHandlers");
+    messageDisplayedHandlers.clear();
+
     LeanplumInternal.getActionHandlers().clear();
     LeanplumInternal.getUserAttributeChanges().clear();
     Leanplum.countAggregator().getAndClearCounts();

--- a/AndroidSDKTests/src/test/java/com/leanplum/internal/FileManagerTest.java
+++ b/AndroidSDKTests/src/test/java/com/leanplum/internal/FileManagerTest.java
@@ -77,7 +77,7 @@ public class FileManagerTest extends AbstractTest {
     FileManager.maybeDownloadFile(false, "test.png", "test_default.png", null, new Runnable() {
       @Override
       public void run() {
-        String path = FileManager.fileRelativeToAppBundle("test.png");
+        String path = FileManager.fileRelativeToDocuments("test.png");
         assertTrue(FileManager.fileExistsAtPath(path));
       }
     });

--- a/AndroidSDKTests/src/test/java/com/leanplum/internal/UtilTest.java
+++ b/AndroidSDKTests/src/test/java/com/leanplum/internal/UtilTest.java
@@ -1,15 +1,11 @@
 package com.leanplum.internal;
 
-import com.leanplum.__setup.LeanplumTestApp;
+import com.leanplum.__setup.AbstractTest;
 import com.leanplum._whitebox.utilities.ResponseHelper;
 
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.powermock.core.classloader.annotations.PowerMockIgnore;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.robolectric.RobolectricTestRunner;
-import org.robolectric.annotation.Config;
 
 import java.net.HttpURLConnection;
 
@@ -22,20 +18,7 @@ import static org.powermock.api.mockito.PowerMockito.when;
  *
  * @author Hrishi Amravatkar
  */
-@RunWith(RobolectricTestRunner.class)
-@Config(
-    sdk = 16,
-    application = LeanplumTestApp.class
-)
-@PowerMockIgnore({
-    "org.mockito.*",
-    "org.robolectric.*",
-    "org.json.*",
-    "org.powermock.*",
-    "android.*"
-})
-@PrepareForTest({Util.class})
-public class UtilTest {
+public class UtilTest extends AbstractTest {
 
   /**
    * Runs before every test case.
@@ -79,6 +62,25 @@ public class UtilTest {
     when(mockHttpUrlConnection.getResponseCode()).thenReturn(403);
     when(mockHttpUrlConnection.getHeaderField("content-encoding")).thenReturn("gzip");
     assertNotNull(Util.getJsonResponse(mockHttpUrlConnection));
+  }
+
+  /**
+   * Test that {@link Util#handleException(Throwable)} is successfully mocked to rethrow the
+   * argument exception.
+   */
+  @Test
+  public void testHandleExceptionMocked() {
+    Assert.assertThrows(Throwable.class, () -> Util.handleException(new Exception()));
+  }
+
+  /**
+   * Test that {@link AbstractTest#resumeLeanplumExceptionHandling()} is returning the default
+   * behaviour of {@link Util#handleException(Throwable)}.
+   */
+  @Test
+  public void testHandleExceptionDefault() throws Exception {
+    resumeLeanplumExceptionHandling();
+    Util.handleException(new Exception());
   }
 
 }


### PR DESCRIPTION
What              | Where/Who
------------------|----------------------------------------
People Involved   | @hborisoff 

## Background
There is a lot of source code that is surrounded by try-catch block and the uncaught exceptions are passed to `Util.handleException`. This could hide potential issues when running the unit tests because there are a lot of cases where a callback is set in the SDK and an assert statement is executed in the callback, but that assertion exception is handled in `Util.handleException` and never thrown again and the test is false positive.

To fix that I've introduced two methods:

- `AbstractTest.stopLeanplumExceptionHandling()` - mocks the Util.handleException to rethrow the passed exception
- `AbstractTest.resumeLeanplumExceptionHandling()` - returns the default behaviour of `Util.handleException` if you need that logic during a test

Also fixed several tests that started failing.
