### PR TITLE
Provide app keys from xml file

### DIFF
--- a/AndroidSDKCore/src/main/java/com/leanplum/Leanplum.java
+++ b/AndroidSDKCore/src/main/java/com/leanplum/Leanplum.java
@@ -34,6 +34,7 @@ import com.leanplum.callbacks.StartCallback;
 import com.leanplum.callbacks.VariablesChangedCallback;
 import com.leanplum.internal.APIConfig;
 import com.leanplum.internal.ActionManager;
+import com.leanplum.internal.ApiConfigLoader;
 import com.leanplum.internal.Constants;
 import com.leanplum.internal.CountAggregator;
 import com.leanplum.internal.FeatureFlagManager;
@@ -275,6 +276,16 @@ public class Leanplum {
 
     Constants.isDevelopmentModeEnabled = false;
     APIConfig.getInstance().setAppId(appId, accessKey);
+  }
+
+  /**
+   * Loads appId and accessKey from Android resources.
+   */
+  private static void loadApiConfigFromResources() {
+    ApiConfigLoader loader = new ApiConfigLoader(getContext());
+    loader.loadFromResources(
+        Leanplum::setAppIdForProductionMode,
+        Leanplum::setAppIdForDevelopmentMode);
   }
 
   /**
@@ -521,6 +532,11 @@ public class Leanplum {
   static synchronized void start(final Context context, final String userId,
       final Map<String, ?> attributes, StartCallback response, final Boolean isBackground) {
     try {
+      boolean appIdNotSet = TextUtils.isEmpty(APIConfig.getInstance().appId());
+      if (appIdNotSet) {
+        loadApiConfigFromResources();
+      }
+
       LeanplumActivityHelper.setCurrentActivity(context);
 
       // Detect if app is in background automatically if isBackground is not set.

--- a/AndroidSDKCore/src/main/java/com/leanplum/internal/ApiConfigLoader.java
+++ b/AndroidSDKCore/src/main/java/com/leanplum/internal/ApiConfigLoader.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2020, Leanplum, Inc. All rights reserved.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.leanplum.internal;
+
+import android.content.Context;
+import android.text.TextUtils;
+
+/**
+ * Loads appId, accessKey and type of environment from the Android string resources.
+ */
+public class ApiConfigLoader {
+  private static final String STRING_APPID = "leanplum_app_id";
+  private static final String STRING_PROD_KEY = "leanplum_prod_key";
+  private static final String STRING_DEV_KEY = "leanplum_dev_key";
+  private static final String STRING_ENV = "leanplum_environment";
+
+  private static final String ENV_DEV = "development";
+  private static final String ENV_PROD = "production";
+
+  private Context context;
+
+  @FunctionalInterface
+  public interface KeyListener {
+    void onKeysLoaded(String appId, String accessKey);
+  }
+
+  public ApiConfigLoader(Context context) {
+    this.context = context;
+  }
+
+  private String getStringResource(String key) {
+    try {
+      String packageName = context.getPackageName();
+      int id = context.getResources().getIdentifier(key, "string", packageName);
+      return context.getString(id);
+    } catch (Throwable t) { // Resources.NotFoundException
+      Log.e("Cannot load string for key = %s. Message = %s", key, t.getMessage());
+      return null;
+    }
+  }
+
+  public void loadFromResources(KeyListener prodKeyListener, KeyListener devKeyListener) {
+    String appId = getStringResource(STRING_APPID);
+    String prodKey = getStringResource(STRING_PROD_KEY);
+    String devKey = getStringResource(STRING_DEV_KEY);
+    String environment = getStringResource(STRING_ENV);
+
+    if (TextUtils.isEmpty(appId))
+      return;
+
+    boolean devEnv = ENV_DEV.equals(environment);
+    boolean hasProdKey = !TextUtils.isEmpty(prodKey);
+    boolean hasDevKey = !TextUtils.isEmpty(devKey);
+
+    if (devEnv && hasDevKey) {
+      devKeyListener.onKeysLoaded(appId, devKey);
+      Log.i("Using appId and accessKey from Android resources for development environment.");
+    }
+    else if (!devEnv && hasProdKey) {
+      prodKeyListener.onKeysLoaded(appId, prodKey);
+      Log.i("Using appId and accessKey from Android resources for production environment.");
+    }
+  }
+}

--- a/AndroidSDKTests/src/test/java/com/leanplum/internal/ApiConfigLoaderTest.java
+++ b/AndroidSDKTests/src/test/java/com/leanplum/internal/ApiConfigLoaderTest.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright 2020, Leanplum, Inc. All rights reserved.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.leanplum.internal;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import android.content.Context;
+import android.content.res.Resources;
+import java.util.Random;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
+
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.when;
+
+@RunWith(RobolectricTestRunner.class)
+@Config(
+    sdk = 16
+)
+public class ApiConfigLoaderTest {
+  private String appId;
+  private String accessKey;
+  private boolean prodEnvironment;
+  private boolean devEnvironment;
+
+  private Context context;
+  private Resources resources;
+
+  @Before
+  public void setup() {
+    appId = null;
+    accessKey = null;
+    prodEnvironment = false;
+    devEnvironment = false;
+
+    resources = Mockito.mock(Resources.class);
+    context = Mockito.mock(Context.class);
+    when(context.getResources()).thenReturn(resources);
+  }
+
+  private void mockStringResource(String key, String value) {
+    int resourceId = new Random().nextInt();
+    when(resources.getIdentifier(eq(key), eq("string"), anyString())).thenReturn(resourceId);
+    when(context.getString(resourceId)).thenReturn(value);
+  }
+
+  private void callLoadMethod(ApiConfigLoader loader) {
+    loader.loadFromResources(
+        (appId, prodKey) -> {
+          this.appId = appId;
+          this.accessKey = prodKey;
+          this.prodEnvironment = true;
+        },
+        (appId, devKey) -> {
+          this.appId = appId;
+          this.accessKey = devKey;
+          this.devEnvironment = true;
+        }
+    );
+  }
+
+  @Test
+  public void testProdEnvironment() {
+    String wantedAppId = "app_id";
+    String wantedAccessKey = "access_key";
+
+    mockStringResource("leanplum_app_id", wantedAppId);
+    mockStringResource("leanplum_prod_key", wantedAccessKey);
+    mockStringResource("leanplum_environment", "production");
+
+    ApiConfigLoader loader = new ApiConfigLoader(context);
+    callLoadMethod(loader);
+
+    assertTrue(prodEnvironment);
+    assertEquals(appId, wantedAppId);
+    assertEquals(accessKey, wantedAccessKey);
+  }
+
+  @Test
+  public void testDevEnvironment() {
+    String wantedAppId = "app_id";
+    String wantedAccessKey = "access_key";
+
+    mockStringResource("leanplum_app_id", wantedAppId);
+    mockStringResource("leanplum_dev_key", wantedAccessKey);
+    mockStringResource("leanplum_environment", "development");
+
+    ApiConfigLoader loader = new ApiConfigLoader(context);
+    callLoadMethod(loader);
+
+    assertTrue(devEnvironment);
+    assertEquals(appId, wantedAppId);
+    assertEquals(accessKey, wantedAccessKey);
+  }
+
+  @Test
+  public void testAccessKeyMissing() {
+    String wantedAppId = "app_id";
+
+    mockStringResource("leanplum_app_id", wantedAppId);
+    mockStringResource("leanplum_environment", "development");
+
+    ApiConfigLoader loader = new ApiConfigLoader(context);
+    callLoadMethod(loader);
+
+    assertFalse(prodEnvironment);
+    assertFalse(devEnvironment);
+  }
+}


### PR DESCRIPTION
What              | Where/Who
------------------|----------------------------------------
JIRA Issue        | [SDK-36](https://leanplum.atlassian.net/browse/SDK-36)
People Involved   | @hborisoff 

## Background
This PR adds functionality to provide app keys by xml file.

## Implementation
If client hasn't set the app keys before calling `Leanplum.start` they are loaded from Android string resources.

You can provide them by creating  `app/src/main/res/values/leanplum-app.xml` containing:
```xml
<?xml version="1.0" encoding="utf-8"?>
<resources>
  <string name="leanplum_app_id">APP_ID</string>
  <string name="leanplum_prod_key">PROD_KEY</string>
  <string name="leanplum_dev_key">DEV_KEY</string>
  <!-- Environment is 'production' or 'development' -->
  <string name="leanplum_environment">ENVIRONMENT</string>
</resources>
```

Note that using another approach like external file (json or xml) adds a lot of complication to the codebase because you must do all I/O operations on a background thread but `Leanplum.start` is running partially on the UI thread.