### PR TITLE
RequestSender refactoring

### DIFF
--- a/AndroidSDKCore/src/main/java/com/leanplum/Leanplum.java
+++ b/AndroidSDKCore/src/main/java/com/leanplum/Leanplum.java
@@ -72,7 +72,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.TimeZone;
-import java.util.concurrent.ScheduledExecutorService;
 
 import androidx.annotation.VisibleForTesting;
 
@@ -110,7 +109,6 @@ public class Leanplum {
   private static String customAppVersion = null;
   private static boolean userSpecifiedDeviceId;
   private static boolean locationCollectionEnabled = true;
-  private static ScheduledExecutorService heartbeatExecutor = null;
   private static Context context;
 
   private static Runnable pushStartCallback;

--- a/AndroidSDKCore/src/main/java/com/leanplum/LeanplumInbox.java
+++ b/AndroidSDKCore/src/main/java/com/leanplum/LeanplumInbox.java
@@ -34,6 +34,7 @@ import com.leanplum.internal.Constants;
 import com.leanplum.internal.JsonConverter;
 import com.leanplum.internal.Log;
 import com.leanplum.internal.OperationQueue;
+import com.leanplum.internal.Request.RequestType;
 import com.leanplum.internal.RequestBuilder;
 import com.leanplum.internal.Request;
 import com.leanplum.internal.RequestSender;
@@ -350,7 +351,10 @@ public class LeanplumInbox {
       return;
     }
 
-    Request req = RequestBuilder.withGetInboxMessagesAction().create();
+    Request req = RequestBuilder
+        .withGetInboxMessagesAction()
+        .andType(RequestType.IMMEDIATE)
+        .create();
     req.onResponse(new Request.ResponseCallback() {
       @Override
       public void response(JSONObject response) {
@@ -420,7 +424,7 @@ public class LeanplumInbox {
         triggerInboxSyncedWithStatus(false);
       }
     });
-    RequestSender.getInstance().sendNow(req);
+    RequestSender.getInstance().send(req);
   }
 
   /**

--- a/AndroidSDKCore/src/main/java/com/leanplum/LeanplumInbox.java
+++ b/AndroidSDKCore/src/main/java/com/leanplum/LeanplumInbox.java
@@ -37,7 +37,6 @@ import com.leanplum.internal.OperationQueue;
 import com.leanplum.internal.RequestBuilder;
 import com.leanplum.internal.Request;
 import com.leanplum.internal.RequestSender;
-import com.leanplum.internal.Util;
 import com.leanplum.utils.SharedPreferencesUtil;
 
 import org.json.JSONObject;
@@ -421,7 +420,7 @@ public class LeanplumInbox {
         triggerInboxSyncedWithStatus(false);
       }
     });
-    RequestSender.getInstance().sendIfConnected(req);
+    RequestSender.getInstance().sendNow(req);
   }
 
   /**

--- a/AndroidSDKCore/src/main/java/com/leanplum/internal/CountAggregator.java
+++ b/AndroidSDKCore/src/main/java/com/leanplum/internal/CountAggregator.java
@@ -63,7 +63,7 @@ public class CountAggregator {
             Map<String, Object> params = makeParams(name, count);
             try {
                 Request request = RequestBuilder.withLogAction().andParams(params).create();
-                RequestSender.getInstance().sendEventually(request);
+                RequestSender.getInstance().send(request);
             } catch (Throwable t) {
                 android.util.Log.e("Leanplum", "Unable to send count.", t);
             }

--- a/AndroidSDKCore/src/main/java/com/leanplum/internal/LeanplumEventCallbackManager.java
+++ b/AndroidSDKCore/src/main/java/com/leanplum/internal/LeanplumEventCallbackManager.java
@@ -56,7 +56,7 @@ class LeanplumEventCallbackManager {
       return;
     }
 
-    callbacks.put(request.requestId(), new LeanplumEventCallbacks(responseCallback, errorCallback));
+    callbacks.put(request.getRequestId(), new LeanplumEventCallbacks(responseCallback, errorCallback));
   }
 
   /**

--- a/AndroidSDKCore/src/main/java/com/leanplum/internal/LeanplumInternal.java
+++ b/AndroidSDKCore/src/main/java/com/leanplum/internal/LeanplumInternal.java
@@ -346,7 +346,7 @@ public class LeanplumInternal {
     try {
       final Map<String, Object> requestParams = makeTrackArgs(event.getName(), value, info, params, args);
       Request request = RequestBuilder.withTrackGeofenceAction().andParams(requestParams).create();
-      RequestSender.getInstance().sendIfConnected(request);
+      RequestSender.getInstance().sendNow(request);
     } catch (Throwable t) {
       Log.exception(t);
     }

--- a/AndroidSDKCore/src/main/java/com/leanplum/internal/LeanplumInternal.java
+++ b/AndroidSDKCore/src/main/java/com/leanplum/internal/LeanplumInternal.java
@@ -33,6 +33,7 @@ import com.leanplum.LeanplumLocationAccuracyType;
 import com.leanplum.callbacks.ActionCallback;
 import com.leanplum.callbacks.StartCallback;
 import com.leanplum.callbacks.VariablesChangedCallback;
+import com.leanplum.internal.Request.RequestType;
 import com.leanplum.models.GeofenceEventType;
 
 import org.json.JSONException;
@@ -345,8 +346,12 @@ public class LeanplumInternal {
 
     try {
       final Map<String, Object> requestParams = makeTrackArgs(event.getName(), value, info, params, args);
-      Request request = RequestBuilder.withTrackGeofenceAction().andParams(requestParams).create();
-      RequestSender.getInstance().sendNow(request);
+      Request request = RequestBuilder
+          .withTrackGeofenceAction()
+          .andParams(requestParams)
+          .andType(RequestType.IMMEDIATE)
+          .create();
+      RequestSender.getInstance().send(request);
     } catch (Throwable t) {
       Log.exception(t);
     }

--- a/AndroidSDKCore/src/main/java/com/leanplum/internal/Log.java
+++ b/AndroidSDKCore/src/main/java/com/leanplum/internal/Log.java
@@ -105,7 +105,7 @@ public class Log {
           .andParam(Constants.Params.VERSION_NAME, versionName)
           .andParam(Constants.Params.MESSAGE, stringWriter.toString())
           .create();
-      RequestSender.getInstance().send(request);
+      RequestSender.getInstance().sendNow(request);
     } catch (Throwable t2) {
       Log.e("Unable to send error report: %s", t2.getMessage());
     }
@@ -164,7 +164,7 @@ public class Log {
           .andParam(Constants.Params.TYPE, Constants.Values.SDK_LOG)
           .andParam(Constants.Params.MESSAGE, tag + msg)
           .create();
-      RequestSender.getInstance().sendEventually(request);
+      RequestSender.getInstance().send(request);
     }
   }
 

--- a/AndroidSDKCore/src/main/java/com/leanplum/internal/Log.java
+++ b/AndroidSDKCore/src/main/java/com/leanplum/internal/Log.java
@@ -23,6 +23,7 @@ package com.leanplum.internal;
 
 
 import com.leanplum.LeanplumException;
+import com.leanplum.internal.Request.RequestType;
 import com.leanplum.monitoring.ExceptionHandler;
 
 import java.io.PrintWriter;
@@ -104,8 +105,9 @@ public class Log {
           .andParam(Constants.Params.TYPE, Constants.Values.SDK_LOG)
           .andParam(Constants.Params.VERSION_NAME, versionName)
           .andParam(Constants.Params.MESSAGE, stringWriter.toString())
+          .andType(RequestType.IMMEDIATE)
           .create();
-      RequestSender.getInstance().sendNow(request);
+      RequestSender.getInstance().send(request);
     } catch (Throwable t2) {
       Log.e("Unable to send error report: %s", t2.getMessage());
     }

--- a/AndroidSDKCore/src/main/java/com/leanplum/internal/OperationQueue.java
+++ b/AndroidSDKCore/src/main/java/com/leanplum/internal/OperationQueue.java
@@ -145,6 +145,15 @@ public class OperationQueue {
     }
 
     /**
+     * Removes pending operation from OperationQueue.
+     */
+    public void removeOperation(Runnable operation) {
+        if (operation != null && handler != null) {
+            handler.removeCallbacks(operation);
+        }
+    }
+
+    /**
      * Remove all pending Operations that are in OperationQueue
      */
     public void removeAllOperations() {

--- a/AndroidSDKCore/src/main/java/com/leanplum/internal/Registration.java
+++ b/AndroidSDKCore/src/main/java/com/leanplum/internal/Registration.java
@@ -21,7 +21,6 @@
 
 package com.leanplum.internal;
 
-import com.leanplum.Leanplum;
 import com.leanplum.callbacks.StartCallback;
 
 import org.json.JSONObject;
@@ -59,6 +58,6 @@ public class Registration {
         OperationQueue.sharedInstance().addUiOperation(callback);
       }
     });
-    RequestSender.getInstance().sendIfConnected(request);
+    RequestSender.getInstance().sendNow(request);
   }
 }

--- a/AndroidSDKCore/src/main/java/com/leanplum/internal/Registration.java
+++ b/AndroidSDKCore/src/main/java/com/leanplum/internal/Registration.java
@@ -23,6 +23,7 @@ package com.leanplum.internal;
 
 import com.leanplum.callbacks.StartCallback;
 
+import com.leanplum.internal.Request.RequestType;
 import org.json.JSONObject;
 
 public class Registration {
@@ -30,6 +31,7 @@ public class Registration {
     Request request = RequestBuilder
         .withRegisterForDevelopmentAction()
         .andParam(Constants.Params.EMAIL, email)
+        .andType(RequestType.IMMEDIATE)
         .create();
 
     request.onResponse(new Request.ResponseCallback() {
@@ -58,6 +60,6 @@ public class Registration {
         OperationQueue.sharedInstance().addUiOperation(callback);
       }
     });
-    RequestSender.getInstance().sendNow(request);
+    RequestSender.getInstance().send(request);
   }
 }

--- a/AndroidSDKCore/src/main/java/com/leanplum/internal/Request.java
+++ b/AndroidSDKCore/src/main/java/com/leanplum/internal/Request.java
@@ -45,10 +45,6 @@ public class Request {
   ErrorCallback error;
   private boolean sent;
 
-  public String requestId() {
-    return requestId;
-  }
-
   public Request(String httpMethod, String apiAction, Map<String, Object> params) {
     this.httpMethod = httpMethod;
     this.apiAction = apiAction;

--- a/AndroidSDKCore/src/main/java/com/leanplum/internal/Request.java
+++ b/AndroidSDKCore/src/main/java/com/leanplum/internal/Request.java
@@ -21,7 +21,7 @@
 
 package com.leanplum.internal;
 
-import com.leanplum.Leanplum;
+import androidx.annotation.VisibleForTesting;
 
 import org.json.JSONObject;
 
@@ -36,6 +36,11 @@ import java.util.UUID;
  */
 public class Request {
 
+  public enum RequestType {
+    DEFAULT,
+    IMMEDIATE
+  }
+
   private String requestId = UUID.randomUUID().toString();
 
   private final String httpMethod;
@@ -43,11 +48,16 @@ public class Request {
   private final Map<String, Object> params;
   ResponseCallback response;
   ErrorCallback error;
-  private boolean sent;
+  private RequestType type;
 
-  public Request(String httpMethod, String apiAction, Map<String, Object> params) {
+  public Request(
+      String httpMethod,
+      String apiAction,
+      RequestType type,
+      Map<String, Object> params) {
     this.httpMethod = httpMethod;
     this.apiAction = apiAction;
+    this.type = type;
     this.params = params != null ? params : new HashMap<>();
   }
 
@@ -67,14 +77,6 @@ public class Request {
     void error(Exception e);
   }
 
-  public void setSent(boolean sent) {
-    this.sent = sent;
-  }
-
-  public boolean isSent() {
-    return sent;
-  }
-
   public String getHttpMethod() {
     return httpMethod;
   }
@@ -89,5 +91,14 @@ public class Request {
 
   public Map<String, Object> getParams() {
     return params;
+  }
+
+  public RequestType getType() {
+    return type;
+  }
+
+  @VisibleForTesting
+  public void setType(RequestType type) {
+    this.type = type;
   }
 }

--- a/AndroidSDKCore/src/main/java/com/leanplum/internal/RequestBuilder.java
+++ b/AndroidSDKCore/src/main/java/com/leanplum/internal/RequestBuilder.java
@@ -22,7 +22,7 @@
 package com.leanplum.internal;
 
 import androidx.annotation.VisibleForTesting;
-import com.leanplum.Leanplum;
+import com.leanplum.internal.Request.RequestType;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -57,6 +57,7 @@ public class RequestBuilder {
 
   private String httpMethod;
   private String apiAction;
+  private RequestType type = RequestType.DEFAULT;
   private Map<String, Object> params;
 
   @VisibleForTesting
@@ -176,9 +177,14 @@ public class RequestBuilder {
     return this;
   }
 
+  public RequestBuilder andType(RequestType type) {
+    this.type = type;
+    return this;
+  }
+
   public Request create() {
     Log.d("Will call API method: %s with params: %s", apiAction, params);
-    return RequestFactory.getInstance().createRequest(httpMethod, apiAction, params);
+    return RequestFactory.getInstance().createRequest(httpMethod, apiAction, type, params);
   }
 
   @VisibleForTesting
@@ -194,5 +200,10 @@ public class RequestBuilder {
   @VisibleForTesting
   public Map<String, Object> getParams() {
     return params;
+  }
+
+  @VisibleForTesting
+  public RequestType getType() {
+    return type;
   }
 }

--- a/AndroidSDKCore/src/main/java/com/leanplum/internal/RequestFactory.java
+++ b/AndroidSDKCore/src/main/java/com/leanplum/internal/RequestFactory.java
@@ -21,7 +21,7 @@
 
 package com.leanplum.internal;
 
-import com.leanplum.Leanplum;
+import com.leanplum.internal.Request.RequestType;
 import java.util.Map;
 
 /**
@@ -39,8 +39,8 @@ public class RequestFactory {
     return defaultFactory;
   }
 
-  public Request createRequest(
-      String httpMethod, String apiMethod, Map<String, Object> params) {
-    return new Request(httpMethod, apiMethod, params);
+  public Request  createRequest(
+      String httpMethod, String apiMethod, RequestType type, Map<String, Object> params) {
+    return new Request(httpMethod, apiMethod, type, params);
   }
 }

--- a/AndroidSDKCore/src/main/java/com/leanplum/internal/RequestSender.java
+++ b/AndroidSDKCore/src/main/java/com/leanplum/internal/RequestSender.java
@@ -450,14 +450,17 @@ public class RequestSender {
   }
 
   private void sendRequestsDelayed(long delayMillis) {
-    OperationQueue.sharedInstance().addOperationAfterDelay(() -> {
-      try {
-        if (!Util.isConnected()) {
-          return;
+    OperationQueue.sharedInstance().addOperationAfterDelay(new Runnable() {
+      @Override
+      public void run() {
+        try {
+          if (!Util.isConnected()) {
+            return;
+          }
+          sendRequests();
+        } catch (Throwable t) {
+          Log.exception(t);
         }
-        sendRequests();
-      } catch (Throwable t) {
-        Log.exception(t);
       }
     }, delayMillis);
   }

--- a/AndroidSDKCore/src/main/java/com/leanplum/internal/RequestSenderTimer.java
+++ b/AndroidSDKCore/src/main/java/com/leanplum/internal/RequestSenderTimer.java
@@ -36,12 +36,15 @@ public class RequestSenderTimer {
   }
 
   private Runnable createTimerOperation() {
-    return () -> {
-      long eventsCount = LeanplumEventDataManager.sharedInstance().getEventsCount();
-      if (eventsCount > 0) { // TODO send heartbeat no matter eventsCount?
-        sendAllRequestsWithHeartbeat();
+    return new Runnable() {
+      @Override
+      public void run() {
+        long eventsCount = LeanplumEventDataManager.sharedInstance().getEventsCount();
+        if (eventsCount > 0) { // TODO send heartbeat no matter eventsCount?
+          sendAllRequestsWithHeartbeat();
+        }
+        OperationQueue.sharedInstance().addOperationAfterDelay(timerOperation, TIMER_MILLIS);
       }
-      OperationQueue.sharedInstance().addOperationAfterDelay(timerOperation, TIMER_MILLIS);
     };
   }
 

--- a/AndroidSDKCore/src/main/java/com/leanplum/internal/RequestSenderTimer.java
+++ b/AndroidSDKCore/src/main/java/com/leanplum/internal/RequestSenderTimer.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2020, Leanplum, Inc. All rights reserved.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.leanplum.internal;
+
+public class RequestSenderTimer {
+  private static final RequestSenderTimer INSTANCE = new RequestSenderTimer();
+  private static final long TIMER_MILLIS = 15 * 60 * 1000; // 15min
+
+  private Runnable timerOperation;
+
+  public static RequestSenderTimer get() {
+    return INSTANCE;
+  }
+
+  private void sendAllRequestsWithHeartbeat() {
+    Request request = RequestBuilder.withHeartbeatAction().create();
+    RequestSender.getInstance().sendNow(request);
+  }
+
+  private Runnable createTimerOperation() {
+    return () -> {
+      long eventsCount = LeanplumEventDataManager.sharedInstance().getEventsCount();
+      if (eventsCount > 0) { // TODO send heartbeat no matter eventsCount?
+        sendAllRequestsWithHeartbeat();
+      }
+      OperationQueue.sharedInstance().addOperationAfterDelay(timerOperation, TIMER_MILLIS);
+    };
+  }
+
+  public synchronized void start() {
+    if (timerOperation != null)
+      return;
+
+    timerOperation = createTimerOperation();
+    OperationQueue.sharedInstance().addOperationAfterDelay(timerOperation, TIMER_MILLIS);
+  }
+
+  public synchronized void stop() {
+    if (timerOperation == null)
+      return;
+
+     OperationQueue.sharedInstance().removeOperation(timerOperation);
+     timerOperation = null;
+  }
+}

--- a/AndroidSDKCore/src/main/java/com/leanplum/internal/RequestSenderTimer.java
+++ b/AndroidSDKCore/src/main/java/com/leanplum/internal/RequestSenderTimer.java
@@ -20,6 +20,8 @@
  */
 package com.leanplum.internal;
 
+import com.leanplum.internal.Request.RequestType;
+
 public class RequestSenderTimer {
   private static final RequestSenderTimer INSTANCE = new RequestSenderTimer();
   private static final long TIMER_MILLIS = 15 * 60 * 1000; // 15min
@@ -31,18 +33,18 @@ public class RequestSenderTimer {
   }
 
   private void sendAllRequestsWithHeartbeat() {
-    Request request = RequestBuilder.withHeartbeatAction().create();
-    RequestSender.getInstance().sendNow(request);
+    Request request = RequestBuilder
+        .withHeartbeatAction()
+        .andType(RequestType.IMMEDIATE)
+        .create();
+    RequestSender.getInstance().send(request);
   }
 
   private Runnable createTimerOperation() {
     return new Runnable() {
       @Override
       public void run() {
-        long eventsCount = LeanplumEventDataManager.sharedInstance().getEventsCount();
-        if (eventsCount > 0) { // TODO send heartbeat no matter eventsCount?
-          sendAllRequestsWithHeartbeat();
-        }
+        sendAllRequestsWithHeartbeat();
         OperationQueue.sharedInstance().addOperationAfterDelay(timerOperation, TIMER_MILLIS);
       }
     };

--- a/AndroidSDKCore/src/main/java/com/leanplum/internal/VarCache.java
+++ b/AndroidSDKCore/src/main/java/com/leanplum/internal/VarCache.java
@@ -30,6 +30,7 @@ import com.leanplum.Leanplum;
 import com.leanplum.LocationManager;
 import com.leanplum.Var;
 import com.leanplum.internal.FileManager.HashResults;
+import com.leanplum.internal.Request.RequestType;
 import com.leanplum.utils.SharedPreferencesUtil;
 
 import org.json.JSONArray;
@@ -620,8 +621,12 @@ public class VarCache {
         params.put(Constants.Params.ACTION_DEFINITIONS, JsonConverter.toJson(actionDefinitions));
       }
       params.put(Constants.Params.FILE_ATTRIBUTES, JsonConverter.toJson(fileAttributes));
-      Request request = RequestBuilder.withSetVarsAction().andParams(params).create();
-      RequestSender.getInstance().sendNow(request);
+      Request request = RequestBuilder
+          .withSetVarsAction()
+          .andParams(params)
+          .andType(RequestType.IMMEDIATE)
+          .create();
+      RequestSender.getInstance().send(request);
     }
 
     return changed;

--- a/AndroidSDKCore/src/main/java/com/leanplum/internal/VarCache.java
+++ b/AndroidSDKCore/src/main/java/com/leanplum/internal/VarCache.java
@@ -621,7 +621,7 @@ public class VarCache {
       }
       params.put(Constants.Params.FILE_ATTRIBUTES, JsonConverter.toJson(fileAttributes));
       Request request = RequestBuilder.withSetVarsAction().andParams(params).create();
-      RequestSender.getInstance().sendIfConnected(request);
+      RequestSender.getInstance().sendNow(request);
     }
 
     return changed;

--- a/AndroidSDKPush/src/main/java/com/leanplum/LeanplumPushService.java
+++ b/AndroidSDKPush/src/main/java/com/leanplum/LeanplumPushService.java
@@ -43,6 +43,7 @@ import com.leanplum.internal.Constants.Params;
 import com.leanplum.internal.JsonConverter;
 import com.leanplum.internal.LeanplumInternal;
 import com.leanplum.internal.Log;
+import com.leanplum.internal.Request.RequestType;
 import com.leanplum.internal.RequestBuilder;
 import com.leanplum.internal.Request;
 import com.leanplum.internal.RequestSender;
@@ -177,6 +178,7 @@ public class LeanplumPushService {
                 .withGetVarsAction()
                 .andParam(Params.INCLUDE_DEFAULTS, Boolean.toString(false))
                 .andParam(Params.INCLUDE_MESSAGE_ID, messageId)
+                .andType(RequestType.IMMEDIATE)
                 .create();
             req.onResponse(new Request.ResponseCallback() {
               @Override
@@ -217,7 +219,7 @@ public class LeanplumPushService {
                 onComplete.variablesChanged();
               }
             });
-            RequestSender.getInstance().sendNow(req);
+            RequestSender.getInstance().send(req);
           }
         } catch (Throwable t) {
           Log.exception(t);

--- a/AndroidSDKPush/src/main/java/com/leanplum/LeanplumPushService.java
+++ b/AndroidSDKPush/src/main/java/com/leanplum/LeanplumPushService.java
@@ -217,7 +217,7 @@ public class LeanplumPushService {
                 onComplete.variablesChanged();
               }
             });
-            RequestSender.getInstance().sendIfConnected(req);
+            RequestSender.getInstance().sendNow(req);
           }
         } catch (Throwable t) {
           Log.exception(t);

--- a/AndroidSDKTests/src/test/java/com/leanplum/LeanplumTest.java
+++ b/AndroidSDKTests/src/test/java/com/leanplum/LeanplumTest.java
@@ -45,6 +45,7 @@ import com.leanplum.internal.JsonConverter;
 import com.leanplum.internal.LeanplumEventDataManager;
 import com.leanplum.internal.LeanplumEventDataManagerTest;
 import com.leanplum.internal.Log;
+import com.leanplum.internal.Request.RequestType;
 import com.leanplum.internal.RequestBuilder;
 import com.leanplum.internal.Request;
 import com.leanplum.internal.RequestSender;
@@ -540,8 +541,9 @@ public class LeanplumTest extends AbstractTest {
     LeanplumEventDataManager.sharedInstance();
 
     // Add two events to database.
-    Request request1 = new Request("POST", RequestBuilder.ACTION_GET_INBOX_MESSAGES, null);
-    Request request2 = new Request("POST", RequestBuilder.ACTION_LOG, null);
+    Request request1 =
+        new Request("POST", RequestBuilder.ACTION_GET_INBOX_MESSAGES, RequestType.DEFAULT, null);
+    Request request2 = new Request("POST", RequestBuilder.ACTION_LOG, RequestType.DEFAULT, null);
 
     RequestSender.getInstance().send(request1);
     RequestSender.getInstance().send(request2);

--- a/AndroidSDKTests/src/test/java/com/leanplum/LeanplumTest.java
+++ b/AndroidSDKTests/src/test/java/com/leanplum/LeanplumTest.java
@@ -543,8 +543,8 @@ public class LeanplumTest extends AbstractTest {
     Request request1 = new Request("POST", RequestBuilder.ACTION_GET_INBOX_MESSAGES, null);
     Request request2 = new Request("POST", RequestBuilder.ACTION_LOG, null);
 
-    RequestSender.getInstance().sendEventually(request1);
-    RequestSender.getInstance().sendEventually(request2);
+    RequestSender.getInstance().send(request1);
+    RequestSender.getInstance().send(request2);
 
     final double fraction = 1.0;
     // Get a number of events in the database.

--- a/AndroidSDKTests/src/test/java/com/leanplum/__setup/LeanplumTestHelper.java
+++ b/AndroidSDKTests/src/test/java/com/leanplum/__setup/LeanplumTestHelper.java
@@ -153,11 +153,9 @@ public class LeanplumTestHelper {
     TestClassUtil.setField(Leanplum.class, "deviceIdMode", LeanplumDeviceIdMode.MD5_MAC_ADDRESS);
     TestClassUtil.setField(Leanplum.class, "customDeviceId", null);
     TestClassUtil.setField(Leanplum.class, "userSpecifiedDeviceId", false);
-    TestClassUtil.setField(Leanplum.class, "initializedMessageTemplates", false);
     LeanplumInternal.setStartedInBackground(false);
     TestClassUtil.setField(LeanplumInternal.class, "inForeground", false);
 
-    TestClassUtil.setField(Leanplum.class, "heartbeatExecutor", null);
     TestClassUtil.setField(Leanplum.class, "context", null);
     TestClassUtil.setField(Leanplum.class, "pushStartCallback", null);
 

--- a/AndroidSDKTests/src/test/java/com/leanplum/__setup/LeanplumTestHelper.java
+++ b/AndroidSDKTests/src/test/java/com/leanplum/__setup/LeanplumTestHelper.java
@@ -35,6 +35,7 @@ import com.leanplum.internal.ActionManager;
 import com.leanplum.internal.LeanplumInternal;
 import com.leanplum.internal.Log;
 import com.leanplum.internal.Request;
+import com.leanplum.internal.Request.RequestType;
 import com.leanplum.internal.RequestFactory;
 import com.leanplum.internal.RequestSender;
 import com.leanplum.internal.VarCache;
@@ -84,9 +85,12 @@ public class LeanplumTestHelper {
   public static void setUp() {
     RequestFactory.defaultFactory = new RequestFactory() {
       @Override
-      public Request createRequest(String httpMethod, String apiMethod,
-                                      Map<String, Object> params) {
-        return new RequestHelper(httpMethod, apiMethod, params);
+      public Request createRequest(
+          String httpMethod,
+          String apiMethod,
+          RequestType type,
+          Map<String, Object> params) {
+        return new RequestHelper(httpMethod, apiMethod, type, params);
       }
     };
     RequestSender.setInstance(new ImmediateRequestSender());

--- a/AndroidSDKTests/src/test/java/com/leanplum/_whitebox/utilities/ImmediateRequestSender.java
+++ b/AndroidSDKTests/src/test/java/com/leanplum/_whitebox/utilities/ImmediateRequestSender.java
@@ -32,13 +32,13 @@ public class ImmediateRequestSender extends RequestSender {
   private String currentRequestId;
 
   @Override
-  public void sendEventually(Request request) {
+  public void send(Request request) {
     currentRequestId = request.requestId();
 
     // immediately send current request
     if (!request.isSent()) {
-      super.sendEventually(request);
-      super.sendIfConnected(request);
+      super.send(request); // TODO remove this call?
+      super.sendNow(request);
     }
   }
 

--- a/AndroidSDKTests/src/test/java/com/leanplum/_whitebox/utilities/ImmediateRequestSender.java
+++ b/AndroidSDKTests/src/test/java/com/leanplum/_whitebox/utilities/ImmediateRequestSender.java
@@ -23,6 +23,7 @@ package com.leanplum._whitebox.utilities;
 
 import com.leanplum.internal.Constants.Params;
 import com.leanplum.internal.Request;
+import com.leanplum.internal.Request.RequestType;
 import com.leanplum.internal.RequestSender;
 import org.json.JSONArray;
 import org.json.JSONObject;
@@ -36,15 +37,8 @@ public class ImmediateRequestSender extends RequestSender {
     currentRequestId = request.getRequestId();
 
     // immediately send current request
-    if (!request.isSent()) {
-      super.sendNow(request);
-    }
-  }
-
-  @Override
-  public void sendNow(Request request) {
-    currentRequestId = request.getRequestId();
-    super.sendNow(request);
+    request.setType(RequestType.IMMEDIATE);
+    super.send(request);
   }
 
   @Override

--- a/AndroidSDKTests/src/test/java/com/leanplum/_whitebox/utilities/ImmediateRequestSender.java
+++ b/AndroidSDKTests/src/test/java/com/leanplum/_whitebox/utilities/ImmediateRequestSender.java
@@ -33,13 +33,18 @@ public class ImmediateRequestSender extends RequestSender {
 
   @Override
   public void send(Request request) {
-    currentRequestId = request.requestId();
+    currentRequestId = request.getRequestId();
 
     // immediately send current request
     if (!request.isSent()) {
-      super.send(request); // TODO remove this call?
       super.sendNow(request);
     }
+  }
+
+  @Override
+  public void sendNow(Request request) {
+    currentRequestId = request.getRequestId();
+    super.sendNow(request);
   }
 
   @Override

--- a/AndroidSDKTests/src/test/java/com/leanplum/_whitebox/utilities/RequestHelper.java
+++ b/AndroidSDKTests/src/test/java/com/leanplum/_whitebox/utilities/RequestHelper.java
@@ -30,8 +30,12 @@ import java.util.Map;
 public class RequestHelper extends Request {
   private static RequestHandler sRequestHandler = null;
 
-  public RequestHelper(String httpMethod, String apiMethod, Map<String, Object> params) {
-    super(httpMethod, apiMethod, params);
+  public RequestHelper(
+      String httpMethod,
+      String apiMethod,
+      RequestType type,
+      Map<String, Object> params) {
+    super(httpMethod, apiMethod, type, params);
 
     // execute handler with request params
     if (sRequestHandler != null) {

--- a/AndroidSDKTests/src/test/java/com/leanplum/internal/CountAggregatorTest.java
+++ b/AndroidSDKTests/src/test/java/com/leanplum/internal/CountAggregatorTest.java
@@ -23,6 +23,7 @@ package com.leanplum.internal;
 import com.google.common.collect.Sets;
 import com.leanplum.__setup.AbstractTest;
 
+import com.leanplum.internal.Request.RequestType;
 import org.junit.Test;
 import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
@@ -151,6 +152,7 @@ public class CountAggregatorTest extends AbstractTest {
         .withArguments(
             RequestBuilder.POST,
             RequestBuilder.ACTION_LOG,
+            RequestType.DEFAULT,
             expectedParams);
   }
 }

--- a/AndroidSDKTests/src/test/java/com/leanplum/internal/RequestBuilderTest.java
+++ b/AndroidSDKTests/src/test/java/com/leanplum/internal/RequestBuilderTest.java
@@ -21,6 +21,7 @@
 
 package com.leanplum.internal;
 
+import com.leanplum.internal.Request.RequestType;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.function.Supplier;
@@ -76,6 +77,22 @@ public class RequestBuilderTest {
 
     assertSame(builder, returnedBuilder);
     assertEquals(expectedParams, builder.getParams());
+  }
+
+  @Test
+  public void testAndParamAndType() {
+    String method = "get";
+    String action = "action";
+    RequestType type = RequestType.IMMEDIATE;
+    Map<String, Object> expectedParams = new HashMap<>();
+    expectedParams.put("param", "value");
+
+    RequestBuilder builder = new RequestBuilder(method, action);
+    RequestBuilder returnedBuilder = builder.andParam("param", "value").andType(type);
+
+    assertSame(builder, returnedBuilder);
+    assertEquals(expectedParams, builder.getParams());
+    assertEquals(type, builder.getType());
   }
 
   @Test

--- a/AndroidSDKTests/src/test/java/com/leanplum/internal/RequestSenderTest.java
+++ b/AndroidSDKTests/src/test/java/com/leanplum/internal/RequestSenderTest.java
@@ -112,7 +112,7 @@ public class RequestSenderTest extends TestCase {
       @Override
       public void run() {
         Request request = new Request(POST, RequestBuilder.ACTION_START, params);
-        RequestSender.getInstance().sendIfConnected(request);
+        RequestSender.getInstance().sendNow(request);
 
         latch.countDown();
       }
@@ -122,7 +122,7 @@ public class RequestSenderTest extends TestCase {
       @Override
       public void run() {
         Request request = new Request(POST, RequestBuilder.ACTION_START, params);
-        RequestSender.getInstance().sendIfConnected(request);
+        RequestSender.getInstance().sendNow(request);
 
         latch.countDown();
       }
@@ -162,7 +162,7 @@ public class RequestSenderTest extends TestCase {
 
     // Regular start request.
     // Expectation: One request returned.
-    RequestSender.getInstance().sendEventually(request);
+    RequestSender.getInstance().send(request);
 
     // loop to complete all tasks
     ShadowLooper.idleMainLooperConstantly(true);
@@ -178,13 +178,13 @@ public class RequestSenderTest extends TestCase {
       put(Constants.Params.BACKGROUND, Boolean.toString(false));
       put("fg", "1");
     }});
-    RequestSender.getInstance().sendEventually(req);
+    RequestSender.getInstance().send(req);
 
     req = new Request("POST", RequestBuilder.ACTION_START, new HashMap<String, Object>() {{
       put(Constants.Params.BACKGROUND, Boolean.toString(false));
       put("fg", "2");
     }});
-    RequestSender.getInstance().sendEventually(req);
+    RequestSender.getInstance().send(req);
 
     unsentRequests = RequestSender.getInstance().getUnsentRequests(1.0);
     assertNotNull(unsentRequests);
@@ -197,13 +197,13 @@ public class RequestSenderTest extends TestCase {
       put(Constants.Params.BACKGROUND, Boolean.toString(true));
       put("bg", "1");
     }});
-    RequestSender.getInstance().sendEventually(req);
+    RequestSender.getInstance().send(req);
 
     req = new Request("POST", RequestBuilder.ACTION_START, new HashMap<String, Object>() {{
       put(Constants.Params.BACKGROUND, Boolean.toString(false));
       put("fg", "1");
     }});
-    RequestSender.getInstance().sendEventually(req);
+    RequestSender.getInstance().send(req);
 
     unsentRequests = RequestSender.getInstance().getUnsentRequests(1.0);
     List unsentRequestsData =
@@ -219,19 +219,19 @@ public class RequestSenderTest extends TestCase {
       put(Constants.Params.BACKGROUND, Boolean.toString(true));
       put("bg", "1");
     }});
-    RequestSender.getInstance().sendEventually(req);
+    RequestSender.getInstance().send(req);
 
     req = new Request("POST", RequestBuilder.ACTION_START, new HashMap<String, Object>() {{
       put(Constants.Params.BACKGROUND, Boolean.toString(true));
       put("bg", "2");
     }});
-    RequestSender.getInstance().sendEventually(req);
+    RequestSender.getInstance().send(req);
 
     req = new Request("POST", RequestBuilder.ACTION_START, new HashMap<String, Object>() {{
       put(Constants.Params.BACKGROUND, Boolean.toString(false));
       put("fg", "1");
     }});
-    RequestSender.getInstance().sendEventually(req);
+    RequestSender.getInstance().send(req);
 
     unsentRequests = RequestSender.getInstance().getUnsentRequests(1.0);
 
@@ -248,19 +248,19 @@ public class RequestSenderTest extends TestCase {
       put(Constants.Params.BACKGROUND, Boolean.toString(false));
       put("fg", "1");
     }});
-    RequestSender.getInstance().sendEventually(req);
+    RequestSender.getInstance().send(req);
 
     req = new Request("POST", RequestBuilder.ACTION_START, new HashMap<String, Object>() {{
       put(Constants.Params.BACKGROUND, Boolean.toString(true));
       put("bg", "1");
     }});
-    RequestSender.getInstance().sendEventually(req);
+    RequestSender.getInstance().send(req);
 
     req = new Request("POST", RequestBuilder.ACTION_START, new HashMap<String, Object>() {{
       put(Constants.Params.BACKGROUND, Boolean.toString(true));
       put("bg", "2");
     }});
-    RequestSender.getInstance().sendEventually(req);
+    RequestSender.getInstance().send(req);
 
     unsentRequests = RequestSender.getInstance().getUnsentRequests(1.0);
     assertNotNull(unsentRequests);
@@ -276,19 +276,19 @@ public class RequestSenderTest extends TestCase {
       put(Constants.Params.BACKGROUND, Boolean.toString(false));
       put("fg", "1");
     }});
-    RequestSender.getInstance().sendEventually(req);
+    RequestSender.getInstance().send(req);
 
     req = new Request("POST", RequestBuilder.ACTION_START, new HashMap<String, Object>() {{
       put(Constants.Params.BACKGROUND, Boolean.toString(false));
       put("bg", "1");
     }});
-    RequestSender.getInstance().sendEventually(req);
+    RequestSender.getInstance().send(req);
 
     req = new Request("POST", RequestBuilder.ACTION_START, new HashMap<String, Object>() {{
       put(Constants.Params.BACKGROUND, Boolean.toString(true));
       put("bg", "2");
     }});
-    RequestSender.getInstance().sendEventually(req);
+    RequestSender.getInstance().send(req);
 
     unsentRequests = RequestSender.getInstance().getUnsentRequests(1.0);
     unsentRequestsData =
@@ -308,11 +308,11 @@ public class RequestSenderTest extends TestCase {
     // Prepare testable objects and method.
     RequestSender requestSender = spy(new RequestSender());
     Request request = new Request("POST", RequestBuilder.ACTION_START, null);
-    requestSender.sendEventually(request); // first request added
+    requestSender.send(request); // first request added
 
     for (int i = 0; i < 5000; i++) { // remaining requests to make up 5000
       Request startRequest = new Request("POST", RequestBuilder.ACTION_START, null);
-      requestSender.sendEventually(startRequest);
+      requestSender.send(startRequest);
     }
 
     // Expectation: 5000 requests returned.
@@ -439,7 +439,7 @@ public class RequestSenderTest extends TestCase {
     APIConfig.getInstance().setAppId("fskadfshdbfa", "wee5w4waer422323");
 
     // When the request is sent.
-    RequestSender.getInstance().sendIfConnected(request);
+    RequestSender.getInstance().sendNow(request);
 
     Leanplum.setApplicationContext(context);
   }

--- a/AndroidSDKTests/src/test/java/com/leanplum/internal/RequestSenderTest.java
+++ b/AndroidSDKTests/src/test/java/com/leanplum/internal/RequestSenderTest.java
@@ -204,7 +204,7 @@ public class RequestSenderTest extends TestCase {
 
     // One background start request followed by a foreground start request.
     // Expectation: Only one foreground start request returned.
-    req = new Request("POST", RequestBuilder.ACTION_START, , RequestType.DEFAULT,
+    req = new Request("POST", RequestBuilder.ACTION_START, RequestType.DEFAULT,
         new HashMap<String, Object>() {{
           put(Constants.Params.BACKGROUND, Boolean.toString(true));
           put("bg", "1");

--- a/AndroidSDKTests/src/test/java/com/leanplum/internal/RequestSenderTest.java
+++ b/AndroidSDKTests/src/test/java/com/leanplum/internal/RequestSenderTest.java
@@ -26,6 +26,7 @@ import android.content.Context;
 import com.leanplum.Leanplum;
 import com.leanplum.__setup.LeanplumTestApp;
 
+import com.leanplum.internal.Request.RequestType;
 import junit.framework.TestCase;
 
 import org.junit.Before;
@@ -91,7 +92,7 @@ public class RequestSenderTest extends TestCase {
   /** Test that request include a generated request id **/
   @Test
   public void testCreateArgsDictionaryShouldIncludeRequestId() {
-      Request request = new Request(POST, RequestBuilder.ACTION_START, null);
+      Request request = new Request(POST, RequestBuilder.ACTION_START, RequestType.DEFAULT, null);
       Map<String, Object> args = RequestSender.createArgsDictionary(request);
       assertTrue(args.containsKey(Constants.Params.REQUEST_ID));
   }
@@ -111,8 +112,12 @@ public class RequestSenderTest extends TestCase {
     operationQueue.addOperation(new Runnable() {
       @Override
       public void run() {
-        Request request = new Request(POST, RequestBuilder.ACTION_START, params);
-        RequestSender.getInstance().sendNow(request);
+        Request request = new Request(
+            POST,
+            RequestBuilder.ACTION_START,
+            RequestType.IMMEDIATE,
+            params);
+        RequestSender.getInstance().send(request);
 
         latch.countDown();
       }
@@ -121,8 +126,12 @@ public class RequestSenderTest extends TestCase {
     operationQueue.addOperation(new Runnable() {
       @Override
       public void run() {
-        Request request = new Request(POST, RequestBuilder.ACTION_START, params);
-        RequestSender.getInstance().sendNow(request);
+        Request request = new Request(
+            POST,
+            RequestBuilder.ACTION_START,
+            RequestType.IMMEDIATE,
+            params);
+        RequestSender.getInstance().send(request);
 
         latch.countDown();
       }
@@ -149,7 +158,7 @@ public class RequestSenderTest extends TestCase {
   @Test
   public void testRemoveIrrelevantBackgroundStartRequests() throws Exception {
     // Prepare testable objects and method.
-    Request request = new Request("POST", RequestBuilder.ACTION_START, null);
+    Request request = new Request("POST", RequestBuilder.ACTION_START, RequestType.DEFAULT, null);
     Method removeIrrelevantBackgroundStartRequests =
         RequestSender.class.getDeclaredMethod("removeIrrelevantBackgroundStartRequests", List.class);
     removeIrrelevantBackgroundStartRequests.setAccessible(true);
@@ -174,15 +183,17 @@ public class RequestSenderTest extends TestCase {
 
     // Two foreground start requests.
     // Expectation: Both foreground start request returned.
-    Request req = new Request("POST", RequestBuilder.ACTION_START, new HashMap<String, Object>() {{
-      put(Constants.Params.BACKGROUND, Boolean.toString(false));
-      put("fg", "1");
+    Request req = new Request("POST", RequestBuilder.ACTION_START, RequestType.DEFAULT,
+        new HashMap<String, Object>() {{
+          put(Constants.Params.BACKGROUND, Boolean.toString(false));
+          put("fg", "1");
     }});
     RequestSender.getInstance().send(req);
 
-    req = new Request("POST", RequestBuilder.ACTION_START, new HashMap<String, Object>() {{
-      put(Constants.Params.BACKGROUND, Boolean.toString(false));
-      put("fg", "2");
+    req = new Request("POST", RequestBuilder.ACTION_START, RequestType.DEFAULT,
+        new HashMap<String, Object>() {{
+          put(Constants.Params.BACKGROUND, Boolean.toString(false));
+          put("fg", "2");
     }});
     RequestSender.getInstance().send(req);
 
@@ -193,15 +204,17 @@ public class RequestSenderTest extends TestCase {
 
     // One background start request followed by a foreground start request.
     // Expectation: Only one foreground start request returned.
-    req = new Request("POST", RequestBuilder.ACTION_START, new HashMap<String, Object>() {{
-      put(Constants.Params.BACKGROUND, Boolean.toString(true));
-      put("bg", "1");
+    req = new Request("POST", RequestBuilder.ACTION_START, , RequestType.DEFAULT,
+        new HashMap<String, Object>() {{
+          put(Constants.Params.BACKGROUND, Boolean.toString(true));
+          put("bg", "1");
     }});
     RequestSender.getInstance().send(req);
 
-    req = new Request("POST", RequestBuilder.ACTION_START, new HashMap<String, Object>() {{
-      put(Constants.Params.BACKGROUND, Boolean.toString(false));
-      put("fg", "1");
+    req = new Request("POST", RequestBuilder.ACTION_START, RequestType.DEFAULT,
+        new HashMap<String, Object>() {{
+          put(Constants.Params.BACKGROUND, Boolean.toString(false));
+          put("fg", "1");
     }});
     RequestSender.getInstance().send(req);
 
@@ -215,21 +228,24 @@ public class RequestSenderTest extends TestCase {
 
     // Two background start request followed by a foreground start requests.
     // Expectation: Only one foreground start request returned.
-    req = new Request("POST", RequestBuilder.ACTION_START, new HashMap<String, Object>() {{
-      put(Constants.Params.BACKGROUND, Boolean.toString(true));
-      put("bg", "1");
+    req = new Request("POST", RequestBuilder.ACTION_START, RequestType.DEFAULT,
+        new HashMap<String, Object>() {{
+          put(Constants.Params.BACKGROUND, Boolean.toString(true));
+          put("bg", "1");
     }});
     RequestSender.getInstance().send(req);
 
-    req = new Request("POST", RequestBuilder.ACTION_START, new HashMap<String, Object>() {{
-      put(Constants.Params.BACKGROUND, Boolean.toString(true));
-      put("bg", "2");
+    req = new Request("POST", RequestBuilder.ACTION_START, RequestType.DEFAULT,
+        new HashMap<String, Object>() {{
+          put(Constants.Params.BACKGROUND, Boolean.toString(true));
+          put("bg", "2");
     }});
     RequestSender.getInstance().send(req);
 
-    req = new Request("POST", RequestBuilder.ACTION_START, new HashMap<String, Object>() {{
-      put(Constants.Params.BACKGROUND, Boolean.toString(false));
-      put("fg", "1");
+    req = new Request("POST", RequestBuilder.ACTION_START, RequestType.DEFAULT,
+        new HashMap<String, Object>() {{
+          put(Constants.Params.BACKGROUND, Boolean.toString(false));
+          put("fg", "1");
     }});
     RequestSender.getInstance().send(req);
 
@@ -244,21 +260,24 @@ public class RequestSenderTest extends TestCase {
 
     // A foreground start request followed by two background start requests.
     // Expectation: Should keep the foreground and the last background start request returned.
-    req = new Request("POST", RequestBuilder.ACTION_START, new HashMap<String, Object>() {{
-      put(Constants.Params.BACKGROUND, Boolean.toString(false));
-      put("fg", "1");
+    req = new Request("POST", RequestBuilder.ACTION_START, RequestType.DEFAULT,
+        new HashMap<String, Object>() {{
+          put(Constants.Params.BACKGROUND, Boolean.toString(false));
+          put("fg", "1");
     }});
     RequestSender.getInstance().send(req);
 
-    req = new Request("POST", RequestBuilder.ACTION_START, new HashMap<String, Object>() {{
-      put(Constants.Params.BACKGROUND, Boolean.toString(true));
-      put("bg", "1");
+    req = new Request("POST", RequestBuilder.ACTION_START, RequestType.DEFAULT,
+        new HashMap<String, Object>() {{
+          put(Constants.Params.BACKGROUND, Boolean.toString(true));
+          put("bg", "1");
     }});
     RequestSender.getInstance().send(req);
 
-    req = new Request("POST", RequestBuilder.ACTION_START, new HashMap<String, Object>() {{
-      put(Constants.Params.BACKGROUND, Boolean.toString(true));
-      put("bg", "2");
+    req = new Request("POST", RequestBuilder.ACTION_START, RequestType.DEFAULT,
+        new HashMap<String, Object>() {{
+          put(Constants.Params.BACKGROUND, Boolean.toString(true));
+          put("bg", "2");
     }});
     RequestSender.getInstance().send(req);
 
@@ -272,21 +291,24 @@ public class RequestSenderTest extends TestCase {
 
     // A foreground start request followed by two background start requests.
     // Expectation: Should keep the foreground and the last background start request returned.
-    req = new Request("POST", RequestBuilder.ACTION_START, new HashMap<String, Object>() {{
-      put(Constants.Params.BACKGROUND, Boolean.toString(false));
-      put("fg", "1");
+    req = new Request("POST", RequestBuilder.ACTION_START, RequestType.DEFAULT,
+        new HashMap<String, Object>() {{
+          put(Constants.Params.BACKGROUND, Boolean.toString(false));
+          put("fg", "1");
     }});
     RequestSender.getInstance().send(req);
 
-    req = new Request("POST", RequestBuilder.ACTION_START, new HashMap<String, Object>() {{
-      put(Constants.Params.BACKGROUND, Boolean.toString(false));
-      put("bg", "1");
+    req = new Request("POST", RequestBuilder.ACTION_START, RequestType.DEFAULT,
+        new HashMap<String, Object>() {{
+          put(Constants.Params.BACKGROUND, Boolean.toString(false));
+          put("bg", "1");
     }});
     RequestSender.getInstance().send(req);
 
-    req = new Request("POST", RequestBuilder.ACTION_START, new HashMap<String, Object>() {{
-      put(Constants.Params.BACKGROUND, Boolean.toString(true));
-      put("bg", "2");
+    req = new Request("POST", RequestBuilder.ACTION_START, RequestType.DEFAULT,
+        new HashMap<String, Object>() {{
+          put(Constants.Params.BACKGROUND, Boolean.toString(true));
+          put("bg", "2");
     }});
     RequestSender.getInstance().send(req);
 
@@ -307,11 +329,12 @@ public class RequestSenderTest extends TestCase {
     RequestSender.RequestsWithEncoding requestsWithEncoding;
     // Prepare testable objects and method.
     RequestSender requestSender = spy(new RequestSender());
-    Request request = new Request("POST", RequestBuilder.ACTION_START, null);
+    Request request = new Request("POST", RequestBuilder.ACTION_START, RequestType.DEFAULT, null);
     requestSender.send(request); // first request added
 
     for (int i = 0; i < 5000; i++) { // remaining requests to make up 5000
-      Request startRequest = new Request("POST", RequestBuilder.ACTION_START, null);
+      Request startRequest =
+          new Request("POST", RequestBuilder.ACTION_START, RequestType.DEFAULT, null);
       requestSender.send(startRequest);
     }
 
@@ -428,7 +451,7 @@ public class RequestSenderTest extends TestCase {
     Map<String, Object> params = new HashMap<>();
     params.put("data1", "value1");
     params.put("data2", "value2");
-    Request request = new Request(POST, RequestBuilder.ACTION_START, params);
+    Request request = new Request(POST, RequestBuilder.ACTION_START, RequestType.IMMEDIATE, params);
     request.onError(new Request.ErrorCallback() {
       @Override
       public void error(Exception e) {
@@ -439,7 +462,7 @@ public class RequestSenderTest extends TestCase {
     APIConfig.getInstance().setAppId("fskadfshdbfa", "wee5w4waer422323");
 
     // When the request is sent.
-    RequestSender.getInstance().sendNow(request);
+    RequestSender.getInstance().send(request);
 
     Leanplum.setApplicationContext(context);
   }

--- a/AndroidSDKTests/src/test/java/com/leanplum/internal/RequestUtilTest.java
+++ b/AndroidSDKTests/src/test/java/com/leanplum/internal/RequestUtilTest.java
@@ -48,9 +48,9 @@ public class RequestUtilTest extends TestCase {
         LeanplumEventDataManager.sharedInstance();
 
         Request request1 = new Request(this.POST, RequestBuilder.ACTION_START, null);
-        RequestSender.getInstance().sendEventually(request1);
+        RequestSender.getInstance().send(request1);
         Request request2 = new Request(this.POST, RequestBuilder.ACTION_TRACK, null);
-        RequestSender.getInstance().sendEventually(request2);
+        RequestSender.getInstance().send(request2);
         List<Map<String, Object>> unsentRequests1 = RequestSender.getInstance().getUnsentRequests(1.0);
         String oldUUID1 = (String) unsentRequests1.get(0).get(Constants.Params.UUID);
 

--- a/AndroidSDKTests/src/test/java/com/leanplum/internal/RequestUtilTest.java
+++ b/AndroidSDKTests/src/test/java/com/leanplum/internal/RequestUtilTest.java
@@ -5,6 +5,7 @@ import android.app.Application;
 import com.leanplum.Leanplum;
 import com.leanplum.__setup.LeanplumTestApp;
 
+import com.leanplum.internal.Request.RequestType;
 import junit.framework.TestCase;
 
 import org.junit.Before;
@@ -47,9 +48,11 @@ public class RequestUtilTest extends TestCase {
     public void testSetNewBatchUUID() {
         LeanplumEventDataManager.sharedInstance();
 
-        Request request1 = new Request(this.POST, RequestBuilder.ACTION_START, null);
+        Request request1 =
+            new Request(this.POST, RequestBuilder.ACTION_START, RequestType.DEFAULT, null);
         RequestSender.getInstance().send(request1);
-        Request request2 = new Request(this.POST, RequestBuilder.ACTION_TRACK, null);
+        Request request2 =
+            new Request(this.POST, RequestBuilder.ACTION_TRACK, RequestType.DEFAULT, null);
         RequestSender.getInstance().send(request2);
         List<Map<String, Object>> unsentRequests1 = RequestSender.getInstance().getUnsentRequests(1.0);
         String oldUUID1 = (String) unsentRequests1.get(0).get(Constants.Params.UUID);

--- a/AndroidSDKTests/src/test/java/com/leanplum/internal/ShadowOperationQueue.java
+++ b/AndroidSDKTests/src/test/java/com/leanplum/internal/ShadowOperationQueue.java
@@ -2,6 +2,8 @@ package com.leanplum.internal;
 
 public class ShadowOperationQueue extends OperationQueue {
 
+    private Runnable lastDelayedOperation;
+
     public ShadowOperationQueue() {
         super();
     }
@@ -20,5 +22,20 @@ public class ShadowOperationQueue extends OperationQueue {
     @Override
     public void addUiOperation(Runnable operation) {
         operation.run();
+    }
+
+    @Override
+    public boolean addOperationAfterDelay(Runnable operation, long delayMillis) {
+        /**
+         * Check if previous operation is the same to avoid stack overflow.
+         * Mainly because of the RequestSender timer implementation.
+         */
+        if (operation.equals(lastDelayedOperation)) {
+            lastDelayedOperation = null;
+            return true;
+        }
+        lastDelayedOperation = operation;
+        operation.run();
+        return true;
     }
 }


### PR DESCRIPTION
What              | Where/Who
------------------|----------------------------------------
JIRA Issue        | [SDK-52](https://leanplum.atlassian.net/browse/SDK-52)
People Involved   | @hborisoff 

## Implementation
`RequestSender` is refactored to provide only one public methods:
- `RequestSender.send` - It saves the request and based on the internal type of the request (default or immediate) it will send all of the requests. When in development mode it will send all the requests too.

`RequestSenderTimer` is introduced to cycle every 15min and send the collected requests including the 'heartbeat' request:
- `RequestSenderTimer.start` - called when SDK is started or when activity is resumed
- `RequestSenderTimer.stop` - called when activity is stopped

If there is a database exception it is added to `RequestSender.localErrors` list and send on next sync of saved requests instead of the real requests. Currently no logic for recovery or dropping the db table.

