### PR TITLE
Fix VarCache.fileStreams

### DIFF
--- a/AndroidSDKCore/src/main/java/com/leanplum/Var.java
+++ b/AndroidSDKCore/src/main/java/com/leanplum/Var.java
@@ -111,9 +111,12 @@ public class Var<T> {
       var.cacheComputedValues();
       VarCache.registerVariable(var);
       if (Constants.Kinds.FILE.equals(var.kind)) {
-        VarCache.registerFile(var.stringValue,
-            var.defaultValue() == null ? null : var.defaultValue().toString(),
-            var.defaultStream(), var.isResource, var.hash, var.size);
+        if (var.isResource) {
+          VarCache.registerFile(var.stringValue, var::defaultStream, var.hash, var.size);
+        } else {
+          String defaultVal = var.defaultValue() == null ? null : var.defaultValue().toString();
+          VarCache.registerFile(var.stringValue, defaultVal, var::defaultStream);
+        }
       }
       var.update();
     } catch (Throwable t) {

--- a/AndroidSDKCore/src/main/java/com/leanplum/internal/ActionArg.java
+++ b/AndroidSDKCore/src/main/java/com/leanplum/internal/ActionArg.java
@@ -69,16 +69,14 @@ public class ActionArg<T> {
       defaultFilename = "";
     }
     ActionArg<String> arg = argNamed(name, defaultFilename, Constants.Kinds.FILE);
-    VarCache.registerFile(arg.defaultValue, arg.defaultValue,
-        arg.defaultStream(), false, null, 0);
+    VarCache.registerFile(arg.defaultValue, arg.defaultValue, arg::defaultStream);
     return arg;
   }
 
   public static ActionArg<String> assetArgNamed(String name, String defaultFilename) {
     ActionArg<String> arg = argNamed(name, defaultFilename, Constants.Kinds.FILE);
     arg.isAsset = true;
-    VarCache.registerFile(arg.defaultValue, arg.defaultValue,
-        arg.defaultStream(), false, null, 0);
+    VarCache.registerFile(arg.defaultValue, arg.defaultValue, arg::defaultStream);
     return arg;
   }
 


### PR DESCRIPTION
What              | Where/Who
------------------|----------------------------------------
JIRA Issue        | [SDK-152](https://leanplum.atlassian.net/browse/SDK-152)
People Involved   | @hborisoff 

## Background
There is a caching of `InputStream` instances in `VarCache.fileStreams` and a usage of them on several places. This produces a lot of bugs because when you use an `InputStream` you read it and close it, but `InputStream` cannot be read after it had been closed.

The stream cache cannot be easily removed because streams could come from several places - file system, bytes array, resource from `ContentProvider`, resource from the zipped res folder, etc.

Solution minimizes the changes to the codebase. Several changes are introduced:

1. Replaced the `InputStream` with `StreamProvider`, which is not holding an `InputStream` instance but creating a new one when you call `openStream()`.

2. Separated `VarCache.registerFile` into two different `registerFile` methods to remove the `isResource` parameter.

3. Some minor readability improvements.
