### PR TITLE
Sanitize value of User-Agent header

### DIFF
--- a/AndroidSDKCore/src/main/java/com/leanplum/internal/http/LeanplumHttpConnection.java
+++ b/AndroidSDKCore/src/main/java/com/leanplum/internal/http/LeanplumHttpConnection.java
@@ -91,11 +91,31 @@ public abstract class LeanplumHttpConnection {
       Must include the phrase `gzip` in the `User-Agent` header
       https://cloud.google.com/appengine/kb/
     */
-    urlConnection.setRequestProperty("User-Agent", createUserAgentValue());
+    urlConnection.setRequestProperty("User-Agent", createUserAgent());
     urlConnection.setRequestProperty("Accept-Encoding", Constants.LEANPLUM_SUPPORTED_ENCODING);
   }
 
-  private String createUserAgentValue() {
+  /**
+   * Currently Android uses OkHttp as an HTTP client. We need to remove invalid characters from
+   * the User-Agent value according to checkValue(String, String) from:
+   *
+   * https://github.com/square/okhttp/blob/dabbd56572089cfef00d358edcc87b3f5c73e580/okhttp/src/main/kotlin/okhttp3/Headers.kt#L431
+   */
+  private String createUserAgent() {
+    String userAgentString = createUserAgentString();
+    StringBuilder result = new StringBuilder();
+
+    // Removing invalid characters
+    for (int i = 0; i < userAgentString.length(); i++) {
+      char c = userAgentString.charAt(i);
+      if (c == '\t' || ('\u0020' <= c && c <= '\u007e')) {
+        result.append(c);
+      }
+    }
+    return result.toString();
+  }
+
+  private String createUserAgentString() {
     Context context = Leanplum.getContext();
 
     return Util.getApplicationName(context)


### PR DESCRIPTION
What              | Where/Who
------------------|----------------------------------------
JIRA Issue        | [SDK-133](https://leanplum.atlassian.net/browse/SDK-133)
People Involved   | @hborisoff 

## Background
Didn't find the exact information in the HTTP specification on how to validate User-Agent header value. Some sources say that it should comply to ISO-8859-1. Unfortunately the implementation in OkHttp does not cover some of the symbols in that ISO.
Solution is to copy the supported symbols from [OkHttp source](https://github.com/square/okhttp/blob/dabbd56572089cfef00d358edcc87b3f5c73e580/okhttp/src/main/kotlin/okhttp3/Headers.kt#L431).