### PR TITLE
Allow usage of custom FirebaseMessagingService

### DIFF
--- a/AndroidSDKFcm/src/main/java/com/leanplum/LeanplumFcmProvider.java
+++ b/AndroidSDKFcm/src/main/java/com/leanplum/LeanplumFcmProvider.java
@@ -25,8 +25,8 @@ import android.text.TextUtils;
 
 import com.google.android.gms.tasks.OnCompleteListener;
 import com.google.android.gms.tasks.Task;
-import com.google.firebase.iid.FirebaseInstanceId;
-import com.google.firebase.iid.InstanceIdResult;
+import com.google.firebase.installations.FirebaseInstallations;
+import com.google.firebase.messaging.FirebaseMessaging;
 import com.leanplum.internal.Log;
 
 import androidx.annotation.NonNull;
@@ -45,17 +45,17 @@ class LeanplumFcmProvider extends LeanplumCloudMessagingProvider {
 
   @Override
   public void getCurrentRegistrationIdAndUpdateBackend() {
-    FirebaseInstanceId.getInstance().getInstanceId()
-        .addOnCompleteListener(new OnCompleteListener<InstanceIdResult>() {
+    FirebaseMessaging.getInstance().getToken()
+        .addOnCompleteListener(new OnCompleteListener<String>() {
           @Override
-          public void onComplete(@NonNull Task<InstanceIdResult> task) {
+          public void onComplete(@NonNull Task<String> task) {
             if (!task.isSuccessful()) {
               Exception exc = task.getException();
               Log.e("getInstanceId failed:\n" + Log.getStackTraceString(exc));
               return;
             }
             // Get new Instance ID token
-            String tokenId = task.getResult().getToken();
+            String tokenId = task.getResult();
             if (!TextUtils.isEmpty(tokenId)) {
                 onRegistrationIdReceived(Leanplum.getContext(), tokenId);
               }
@@ -71,7 +71,8 @@ class LeanplumFcmProvider extends LeanplumCloudMessagingProvider {
   @Override
   public void unregister() {
     try {
-      FirebaseInstanceId.getInstance().deleteInstanceId();
+      FirebaseInstallations.getInstance().delete();
+      FirebaseMessaging.getInstance().deleteToken();
       Log.i("Application was unregistered from FCM.");
     } catch (Exception e) {
       Log.e("Failed to unregister from FCM.");

--- a/AndroidSDKFcm/src/main/java/com/leanplum/LeanplumFcmProvider.java
+++ b/AndroidSDKFcm/src/main/java/com/leanplum/LeanplumFcmProvider.java
@@ -25,8 +25,8 @@ import android.text.TextUtils;
 
 import com.google.android.gms.tasks.OnCompleteListener;
 import com.google.android.gms.tasks.Task;
-import com.google.firebase.installations.FirebaseInstallations;
-import com.google.firebase.messaging.FirebaseMessaging;
+import com.google.firebase.iid.FirebaseInstanceId;
+import com.google.firebase.iid.InstanceIdResult;
 import com.leanplum.internal.Log;
 
 import androidx.annotation.NonNull;
@@ -45,17 +45,17 @@ class LeanplumFcmProvider extends LeanplumCloudMessagingProvider {
 
   @Override
   public void getCurrentRegistrationIdAndUpdateBackend() {
-    FirebaseMessaging.getInstance().getToken()
-        .addOnCompleteListener(new OnCompleteListener<String>() {
+    FirebaseInstanceId.getInstance().getInstanceId()
+        .addOnCompleteListener(new OnCompleteListener<InstanceIdResult>() {
           @Override
-          public void onComplete(@NonNull Task<String> task) {
+          public void onComplete(@NonNull Task<InstanceIdResult> task) {
             if (!task.isSuccessful()) {
               Exception exc = task.getException();
               Log.e("getInstanceId failed:\n" + Log.getStackTraceString(exc));
               return;
             }
             // Get new Instance ID token
-            String tokenId = task.getResult();
+            String tokenId = task.getResult().getToken();
             if (!TextUtils.isEmpty(tokenId)) {
                 onRegistrationIdReceived(Leanplum.getContext(), tokenId);
               }
@@ -71,8 +71,7 @@ class LeanplumFcmProvider extends LeanplumCloudMessagingProvider {
   @Override
   public void unregister() {
     try {
-      FirebaseInstallations.getInstance().delete();
-      FirebaseMessaging.getInstance().deleteToken();
+      FirebaseInstanceId.getInstance().deleteInstanceId();
       Log.i("Application was unregistered from FCM.");
     } catch (Exception e) {
       Log.e("Failed to unregister from FCM.");

--- a/AndroidSDKFcm/src/main/java/com/leanplum/LeanplumFcmProvider.java
+++ b/AndroidSDKFcm/src/main/java/com/leanplum/LeanplumFcmProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016, Leanplum, Inc. All rights reserved.
+ * Copyright 2020, Leanplum, Inc. All rights reserved.
  *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
@@ -21,19 +21,13 @@
 
 package com.leanplum;
 
-import android.content.Context;
-import android.nfc.Tag;
 import android.text.TextUtils;
 
 import com.google.android.gms.tasks.OnCompleteListener;
 import com.google.android.gms.tasks.Task;
 import com.google.firebase.iid.FirebaseInstanceId;
 import com.google.firebase.iid.InstanceIdResult;
-import com.leanplum.internal.LeanplumManifestHelper;
 import com.leanplum.internal.Log;
-import com.leanplum.internal.Util;
-
-import java.util.Collections;
 
 import androidx.annotation.NonNull;
 
@@ -72,41 +66,6 @@ class LeanplumFcmProvider extends LeanplumCloudMessagingProvider {
   @Override
   public boolean isInitialized() {
     return true;
-  }
-
-  @Override
-  public boolean isManifestSetup() {
-    Context context = Leanplum.getContext();
-    if (context == null) {
-      return false;
-    }
-
-    try {
-      boolean hasPushReceiver = LeanplumManifestHelper.checkComponent(LeanplumManifestHelper.ApplicationComponent.RECEIVER,
-          LeanplumManifestHelper.LP_PUSH_RECEIVER, false, null,
-          Collections.singletonList(LeanplumManifestHelper.LP_PUSH_FCM_MESSAGING_SERVICE), context.getPackageName());
-
-      boolean hasPushFirebaseMessagingService = LeanplumManifestHelper.checkComponent(
-          LeanplumManifestHelper.ApplicationComponent.SERVICE,
-          LeanplumManifestHelper.LP_PUSH_FCM_MESSAGING_SERVICE, false, null,
-          Collections.singletonList(LeanplumManifestHelper.FCM_MESSAGING_EVENT), context.getPackageName());
-
-      boolean hasRegistrationService = LeanplumManifestHelper.checkComponent(
-          LeanplumManifestHelper.ApplicationComponent.SERVICE,
-          LeanplumPushRegistrationService.class.getName(), false, null, null, context.getPackageName());
-
-      boolean hasServices = hasPushFirebaseMessagingService &&
-          hasRegistrationService;
-
-      if (hasPushReceiver && hasServices) {
-        Log.i("Firebase Messaging is setup correctly.");
-        return true;
-      }
-    } catch (Throwable t) {
-      Log.exception(t);
-    }
-    Log.e("Failed to setup Firebase Messaging, check your manifest configuration.");
-    return false;
   }
 
   @Override

--- a/AndroidSDKFcm/src/main/java/com/leanplum/LeanplumFirebaseServiceHandler.java
+++ b/AndroidSDKFcm/src/main/java/com/leanplum/LeanplumFirebaseServiceHandler.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2020, Leanplum, Inc. All rights reserved.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.leanplum;
+
+import android.content.Context;
+import android.os.Bundle;
+import com.google.firebase.messaging.FirebaseMessagingService;
+import com.google.firebase.messaging.RemoteMessage;
+import com.leanplum.internal.Constants;
+import com.leanplum.internal.Log;
+import java.util.Map;
+
+/**
+ * This class encapsulates functionality for handling data messages from FCM. Needs to be called
+ * from your instance of {@link FirebaseMessagingService}.
+ */
+public final class LeanplumFirebaseServiceHandler {
+
+  /**
+   * Call from your implementation of {@link FirebaseMessagingService#onCreate()}
+   */
+  public void onCreate(Context context) {
+    Leanplum.setApplicationContext(context);
+  }
+
+  /**
+   * Call from your implementation of {@link FirebaseMessagingService#onNewToken(String)}
+   */
+  public void onNewToken(String token, Context context) {
+    LeanplumPushService.setCloudMessagingProvider(new LeanplumFcmProvider());
+    LeanplumPushService.getCloudMessagingProvider().storePreferences(context, token);
+
+    //send the new token to backend
+    LeanplumPushService.getCloudMessagingProvider().onRegistrationIdReceived(context, token);
+  }
+
+  /**
+   * Call from your implementation of
+   * {@link FirebaseMessagingService#onMessageReceived(RemoteMessage)}
+   */
+  public void onMessageReceived(RemoteMessage remoteMessage, Context context) {
+    try {
+      Map<String, String> messageMap = remoteMessage.getData();
+      if (messageMap.containsKey(Constants.Keys.PUSH_MESSAGE_TEXT)) {
+        LeanplumPushService.handleNotification(context, getBundle(messageMap));
+      }
+      Log.d("Received push notification message: %s", messageMap.toString());
+    } catch (Throwable t) {
+      Log.exception(t);
+    }
+  }
+
+  /**
+   * @param messageMap {@link RemoteMessage}'s data map.
+   */
+  private Bundle getBundle(Map<String, String> messageMap) {
+    Bundle bundle = new Bundle();
+    if (messageMap != null) {
+      for (Map.Entry<String, String> entry : messageMap.entrySet()) {
+        bundle.putString(entry.getKey(), entry.getValue());
+      }
+    }
+    return bundle;
+  }
+}

--- a/AndroidSDKFcm/src/main/java/com/leanplum/LeanplumPushFirebaseMessagingService.java
+++ b/AndroidSDKFcm/src/main/java/com/leanplum/LeanplumPushFirebaseMessagingService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016, Leanplum, Inc. All rights reserved.
+ * Copyright 2020, Leanplum, Inc. All rights reserved.
  *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
@@ -21,41 +21,29 @@
 
 package com.leanplum;
 
-import android.annotation.SuppressLint;
-import android.os.Build;
-import android.os.Bundle;
-
+import androidx.annotation.NonNull;
 import com.google.firebase.messaging.FirebaseMessagingService;
 import com.google.firebase.messaging.RemoteMessage;
-import com.leanplum.internal.Constants;
-import com.leanplum.internal.Log;
-import com.leanplum.internal.Util;
-
-import java.util.Map;
 
 /**
  * FCM listener service, which enables handling messages on the app's behalf.
  *
  * @author Anna Orlova
  */
-@SuppressLint("Registered")
 public class LeanplumPushFirebaseMessagingService extends FirebaseMessagingService {
+
+  private final LeanplumFirebaseServiceHandler handler = new LeanplumFirebaseServiceHandler();
 
   @Override
   public void onCreate() {
     super.onCreate();
-    Leanplum.setApplicationContext(getApplicationContext());
+    handler.onCreate(getApplicationContext());
   }
 
   @Override
-  public void onNewToken(String token) {
+  public void onNewToken(@NonNull String token) {
     super.onNewToken(token);
-
-    LeanplumPushService.setCloudMessagingProvider(new LeanplumFcmProvider());
-    LeanplumPushService.getCloudMessagingProvider().storePreferences(getApplicationContext(), token);
-
-    //send the new token to backend
-    LeanplumPushService.getCloudMessagingProvider().onRegistrationIdReceived(getApplicationContext(), token);
+    handler.onNewToken(token, getApplicationContext());
   }
 
   /**
@@ -65,28 +53,7 @@ public class LeanplumPushFirebaseMessagingService extends FirebaseMessagingServi
    * @param remoteMessage Object representing the message received from Firebase Cloud Messaging.
    */
   @Override
-  public void onMessageReceived(RemoteMessage remoteMessage) {
-    try {
-      Map<String, String> messageMap = remoteMessage.getData();
-      if (messageMap.containsKey(Constants.Keys.PUSH_MESSAGE_TEXT)) {
-        LeanplumPushService.handleNotification(getApplicationContext(), getBundle(messageMap));
-      }
-      Log.d("Received push notification message: %s", messageMap.toString());
-    } catch (Throwable t) {
-      Log.exception(t);
-    }
-  }
-
-  /**
-   * @param messageMap {@link RemoteMessage}'s data map.
-   */
-  private Bundle getBundle(Map<String, String> messageMap) {
-    Bundle bundle = new Bundle();
-    if (messageMap != null) {
-      for (Map.Entry<String, String> entry : messageMap.entrySet()) {
-        bundle.putString(entry.getKey(), entry.getValue());
-      }
-    }
-    return bundle;
+  public void onMessageReceived(@NonNull RemoteMessage remoteMessage) {
+    handler.onMessageReceived(remoteMessage, getApplicationContext());
   }
 }

--- a/AndroidSDKPush/src/main/java/com/leanplum/LeanplumCloudMessagingProvider.java
+++ b/AndroidSDKPush/src/main/java/com/leanplum/LeanplumCloudMessagingProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016, Leanplum, Inc. All rights reserved.
+ * Copyright 2020, Leanplum, Inc. All rights reserved.
  *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
@@ -72,13 +72,6 @@ abstract class LeanplumCloudMessagingProvider {
    * @return True if provider is initialized, false otherwise.
    */
   public abstract boolean isInitialized();
-
-  /**
-   * Whether app manifest is setup correctly.
-   *
-   * @return True if manifest is setup, false otherwise.
-   */
-  public abstract boolean isManifestSetup();
 
   /**
    * Unregister from cloud messaging.

--- a/AndroidSDKPush/src/main/java/com/leanplum/LeanplumManualProvider.java
+++ b/AndroidSDKPush/src/main/java/com/leanplum/LeanplumManualProvider.java
@@ -49,11 +49,6 @@ public class LeanplumManualProvider extends LeanplumCloudMessagingProvider {
   }
 
   @Override
-  public boolean isManifestSetup() {
-    return true;
-  }
-
-  @Override
   public void unregister() {
   }
 }

--- a/AndroidSDKPush/src/main/java/com/leanplum/LeanplumPushService.java
+++ b/AndroidSDKPush/src/main/java/com/leanplum/LeanplumPushService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014, Leanplum, Inc. All rights reserved.
+ * Copyright 2020, Leanplum, Inc. All rights reserved.
  *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
@@ -684,7 +684,7 @@ public class LeanplumPushService {
    * Initialize push service.
    */
   static void initPushService() {
-    if (!provider.isInitialized() || !provider.isManifestSetup()) {
+    if (!provider.isInitialized()) {
       return;
     }
     if (hasAppIDChanged(APIConfig.getInstance().appId())) {

--- a/AndroidSDKPush/src/main/java/com/leanplum/internal/LeanplumManifestHelper.java
+++ b/AndroidSDKPush/src/main/java/com/leanplum/internal/LeanplumManifestHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017, Leanplum, Inc. All rights reserved.
+ * Copyright 2020, Leanplum, Inc. All rights reserved.
  *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
@@ -25,15 +25,11 @@ import android.content.ComponentName;
 import android.content.Context;
 import android.content.Intent;
 import android.content.pm.ApplicationInfo;
-import android.content.pm.ComponentInfo;
 import android.content.pm.PackageManager;
-import android.content.pm.ResolveInfo;
 import android.os.Bundle;
 
 import com.leanplum.Leanplum;
 import com.leanplum.LeanplumPushService;
-
-import java.util.List;
 
 /**
  * LeanplumManifestHelper class to work with AndroidManifest components.
@@ -41,17 +37,6 @@ import java.util.List;
  * @author Anna Orlova
  */
 public class LeanplumManifestHelper {
-
-  // Firebase
-  public static final String FCM_INSTANCE_ID_EVENT = "com.google.firebase.INSTANCE_ID_EVENT";
-  public static final String FCM_MESSAGING_EVENT = "com.google.firebase.MESSAGING_EVENT";
-
-  // Leanplum
-  public static final String LP_PUSH_INSTANCE_ID_SERVICE = "com.leanplum.LeanplumPushInstanceIDService";
-  public static final String LP_PUSH_LISTENER_SERVICE = "com.leanplum.LeanplumPushListenerService";
-  public static final String LP_PUSH_FCM_MESSAGING_SERVICE = "com.leanplum.LeanplumPushFirebaseMessagingService";
-  public static final String LP_PUSH_REGISTRATION_SERVICE = "com.leanplum.LeanplumPushRegistrationService";
-  public static final String LP_PUSH_RECEIVER = "com.leanplum.LeanplumPushReceiver";
 
   /**
    * Gets Class for name.
@@ -172,134 +157,4 @@ public class LeanplumManifestHelper {
     }
     return null;
   }
-
-  public static boolean checkPermission(String permission, boolean definesPermission,
-      boolean logError) {
-    Context context = Leanplum.getContext();
-    if (context == null) {
-      return false;
-    }
-    int result = context.checkCallingOrSelfPermission(permission);
-    if (result != PackageManager.PERMISSION_GRANTED) {
-      String definition;
-      if (definesPermission) {
-        definition = "<permission android:name=\"" + permission +
-            "\" android:protectionLevel=\"signature\" />\n";
-      } else {
-        definition = "";
-      }
-      if (logError) {
-        Log.e("In order to use push notifications, you need to enable " +
-            "the " + permission + " permission in your AndroidManifest.xml file. " +
-            "Add this within the <manifest> section:\n" +
-            definition + "<uses-permission android:name=\"" + permission + "\" />");
-      }
-      return false;
-    }
-    return true;
-  }
-
-  /**
-   * Verifies that a certain component (receiver or sender) is implemented in the
-   * AndroidManifest.xml file or the application, in order to make sure that push notifications
-   * work.
-   *
-   * @param componentType A receiver or a service.
-   * @param name The name of the class.
-   * @param exported What the exported option should be.
-   * @param permission Whether we need any permission.
-   * @param actions What actions we need to check for in the intent-filter.
-   * @param packageName The package name for the category tag, if we require one.
-   * @return true if the respective component is in the manifest file, and false otherwise.
-   */
-  public static boolean checkComponent(ApplicationComponent componentType, String name,
-      boolean exported, String permission, List<String> actions, String packageName) {
-    Context context = Leanplum.getContext();
-    if (context == null) {
-      return false;
-    }
-    if (actions != null) {
-      for (String action : actions) {
-        List<ResolveInfo> components = (componentType == ApplicationComponent.RECEIVER)
-            ? context.getPackageManager().queryBroadcastReceivers(new Intent(action), 0)
-            : context.getPackageManager().queryIntentServices(new Intent(action), 0);
-        if (components == null) {
-          return false;
-        }
-        boolean foundComponent = false;
-        for (ResolveInfo component : components) {
-          if (component == null) {
-            continue;
-          }
-          ComponentInfo componentInfo = (componentType == ApplicationComponent.RECEIVER)
-              ? component.activityInfo : component.serviceInfo;
-          if (componentInfo != null && componentInfo.name.equals(name)) {
-            // Only check components from our package.
-            if (componentInfo.packageName != null && componentInfo.packageName.equals(packageName)) {
-              foundComponent = true;
-            }
-          }
-        }
-        if (!foundComponent) {
-          Log.e(getComponentError(componentType, name, exported,
-              permission, actions, packageName));
-          return false;
-        }
-      }
-    } else {
-      try {
-        if (componentType == ApplicationComponent.RECEIVER) {
-          context.getPackageManager().getReceiverInfo(
-              new ComponentName(context.getPackageName(), name), 0);
-        } else {
-          context.getPackageManager().getServiceInfo(
-              new ComponentName(context.getPackageName(), name), 0);
-        }
-      } catch (PackageManager.NameNotFoundException e) {
-        Log.e(getComponentError(componentType, name, exported,
-            permission, actions, packageName));
-        return false;
-      }
-    }
-    return true;
-  }
-
-  /**
-   * Formats error if component isn't found in app's manifest.
-   *
-   * @param componentType The component type to format.
-   * @param name Name of the component to format.
-   * @param exported Whether component is exported.
-   * @param permission Permission to format.
-   * @param actions Actions to format.
-   * @param packageName Package name to format
-   * @return Formatted error message to be printed to console.
-   */
-  private static String getComponentError(ApplicationComponent componentType, String name,
-      boolean exported, String permission, List<String> actions, String packageName) {
-    StringBuilder errorMessage = new StringBuilder("Push notifications requires you to add the " +
-        componentType.name().toLowerCase() + " " + name + " to your AndroidManifest.xml file." +
-        "Add this code within the <application> section:\n");
-    errorMessage.append("<").append(componentType.name().toLowerCase()).append("\n");
-    errorMessage.append("    ").append("android:name=\"").append(name).append("\"\n");
-    errorMessage.append("    android:exported=\"").append(Boolean.toString(exported)).append("\"");
-    if (permission != null) {
-      errorMessage.append("\n    android:permission=\"").append(permission).append("\"");
-    }
-    errorMessage.append(">\n");
-    if (actions != null) {
-      errorMessage.append("    <intent-filter>\n");
-      for (String action : actions) {
-        errorMessage.append("        <action android:name=\"").append(action).append("\" />\n");
-      }
-      if (packageName != null) {
-        errorMessage.append("        <category android:name=\"").append(packageName).append("\" />\n");
-      }
-      errorMessage.append("    </intent-filter>\n");
-    }
-    errorMessage.append("</").append(componentType.name().toLowerCase()).append(">");
-    return errorMessage.toString();
-  }
-
-  public enum ApplicationComponent {SERVICE, RECEIVER}
 }

--- a/AndroidSDKTests/src/test/java/com/leanplum/LeanplumCloudMessagingProviderTest.java
+++ b/AndroidSDKTests/src/test/java/com/leanplum/LeanplumCloudMessagingProviderTest.java
@@ -110,11 +110,6 @@ public class LeanplumCloudMessagingProviderTest {
       }
 
       @Override
-      public boolean isManifestSetup() {
-        return false;
-      }
-
-      @Override
       public void unregister() {
 
       }

--- a/AndroidSDKTests/src/test/java/com/leanplum/LeanplumPushServiceTest.java
+++ b/AndroidSDKTests/src/test/java/com/leanplum/LeanplumPushServiceTest.java
@@ -152,15 +152,7 @@ public class LeanplumPushServiceTest {
 
     LeanplumPushService.setCloudMessagingProvider(fcmProviderMock);
 
-    // Test if Manifest is not set up and provider is initialized.
-    doReturn(false).when(fcmProviderMock).isManifestSetup();
-    doReturn(true).when(fcmProviderMock).isInitialized();
-    initPushServiceMethod.invoke(pushService);
-    assertNotNull(initPushServiceMethod);
-    verifyPrivate(LeanplumPushService.class, times(0)).invoke("registerInBackground");
-
     // Test if Manifest is set up and provider is initialized.
-    doReturn(true).when(fcmProviderMock).isManifestSetup();
     doReturn(true).when(fcmProviderMock).isInitialized();
     initPushServiceMethod.invoke(pushService);
     assertNotNull(initPushServiceMethod);
@@ -189,15 +181,7 @@ public class LeanplumPushServiceTest {
     initPushServiceMethod.setAccessible(true);
     LeanplumPushService.setCloudMessagingProvider(fcmProviderMock);
 
-    // Test if Manifest is not set up and provider is initialized.
-    doReturn(false).when(fcmProviderMock).isManifestSetup();
-    doReturn(true).when(fcmProviderMock).isInitialized();
-    initPushServiceMethod.invoke(pushService);
-    assertNotNull(initPushServiceMethod);
-    verifyPrivate(LeanplumPushService.class, times(0)).invoke("registerInBackground");
-
     // Test if Manifest is set up and provider is initialized.
-    doReturn(true).when(fcmProviderMock).isManifestSetup();
     doReturn(true).when(fcmProviderMock).isInitialized();
     initPushServiceMethod.invoke(pushService);
     assertNotNull(initPushServiceMethod);
@@ -386,7 +370,6 @@ public class LeanplumPushServiceTest {
 
     LeanplumFcmProvider fcmProviderMock = spy(new LeanplumFcmProvider());
     whenNew(LeanplumFcmProvider.class).withNoArguments().thenReturn(fcmProviderMock);
-    doReturn(true).when(fcmProviderMock).isManifestSetup();
     doReturn(true).when(fcmProviderMock).isInitialized();
 
     LeanplumPushService.setCloudMessagingProvider(fcmProviderMock);


### PR DESCRIPTION
What              | Where/Who
------------------|----------------------------------------
JIRA Issue        | [SDK-201](https://leanplum.atlassian.net/browse/SDK-201)
People Involved   | @hborisoff 

## Background
1. Extracted Leanplum specific code from `LeanplumPushFirebaseMessagingService` into `LeanplumFirebaseServiceHandler` containing:
- `onCreate`
- `onNewToken`
- `onMessageReceived`

2. To implement custom `FirebaseMessagingService` you have to copy `LeanplumPushFirebaseMessagingService` and include the following code in your manifest file:
```
<!-- Disable the default Leanplum FCM message handling service -->
<service
  xmlns:tools="http://schemas.android.com/tools"
  android:name="com.leanplum.LeanplumPushFirebaseMessagingService"
  android:enabled="false"
  tools:replace="android:enabled"/>

<!-- Add your custom FCM message handling service -->
<service
  android:name="your.package.Copy_of_LeanplumPushFirebaseMessagingService"
  android:enabled="true"
  android:exported="false">
    <intent-filter>
        <action android:name="com.google.firebase.MESSAGING_EVENT"/>
    </intent-filter>
</service>
```

3. Removed `LeanplumCloudMessagingProvider.isManifestSetup` functionality as it is not necessary anymore because receivers and services are added to library's manifest file which is merged into the project's manifest.

4. Replaced deprecated usage of Firebase API with the recommendations by Google
