### PR TITLE
Add method for downloading inbox messages

### DIFF
--- a/AndroidSDKCore/src/main/java/com/leanplum/Leanplum.java
+++ b/AndroidSDKCore/src/main/java/com/leanplum/Leanplum.java
@@ -25,12 +25,8 @@ import android.content.Context;
 import android.location.Location;
 import android.text.TextUtils;
 
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
 import com.leanplum.ActionContext.ContextualValues;
 import com.leanplum.callbacks.ActionCallback;
-import com.leanplum.callbacks.InboxChangedCallback;
-import com.leanplum.callbacks.InboxSyncedCallback;
 import com.leanplum.callbacks.MessageDisplayedCallback;
 import com.leanplum.callbacks.RegisterDeviceCallback;
 import com.leanplum.callbacks.RegisterDeviceFinishedCallback;
@@ -2082,24 +2078,6 @@ public class Leanplum {
     } catch (Throwable t) {
       Log.exception(t);
     }
-  }
-
-  /**
-   * Forces downloading of inbox messages from the server. After messages are downloaded the
-   * appropriate callbacks will fire.
-   */
-  public static void downloadInboxMessages() {
-    downloadInboxMessages(null);
-  }
-
-  /**
-   * Forces downloading of inbox messages from the server. After messages are downloaded the
-   * appropriate callbacks will fire.
-   *
-   * @param callback The callback to invoke when messages are downloaded.
-   */
-  public static void downloadInboxMessages(@Nullable InboxSyncedCallback callback) {
-    LeanplumInbox.getInstance().downloadMessages(callback);
   }
 
   /**

--- a/AndroidSDKCore/src/main/java/com/leanplum/Leanplum.java
+++ b/AndroidSDKCore/src/main/java/com/leanplum/Leanplum.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016, Leanplum, Inc. All rights reserved.
+ * Copyright 2020, Leanplum, Inc. All rights reserved.
  *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
@@ -25,8 +25,12 @@ import android.content.Context;
 import android.location.Location;
 import android.text.TextUtils;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 import com.leanplum.ActionContext.ContextualValues;
 import com.leanplum.callbacks.ActionCallback;
+import com.leanplum.callbacks.InboxChangedCallback;
+import com.leanplum.callbacks.InboxSyncedCallback;
 import com.leanplum.callbacks.MessageDisplayedCallback;
 import com.leanplum.callbacks.RegisterDeviceCallback;
 import com.leanplum.callbacks.RegisterDeviceFinishedCallback;
@@ -2078,6 +2082,24 @@ public class Leanplum {
     } catch (Throwable t) {
       Log.exception(t);
     }
+  }
+
+  /**
+   * Forces downloading of inbox messages from the server. After messages are downloaded the
+   * appropriate callbacks will fire.
+   */
+  public static void downloadInboxMessages() {
+    downloadInboxMessages(null);
+  }
+
+  /**
+   * Forces downloading of inbox messages from the server. After messages are downloaded the
+   * appropriate callbacks will fire.
+   *
+   * @param callback The callback to invoke when messages are downloaded.
+   */
+  public static void downloadInboxMessages(@Nullable InboxSyncedCallback callback) {
+    LeanplumInbox.getInstance().downloadMessages(callback);
   }
 
   /**

--- a/AndroidSDKCore/src/main/java/com/leanplum/LeanplumInbox.java
+++ b/AndroidSDKCore/src/main/java/com/leanplum/LeanplumInbox.java
@@ -360,11 +360,21 @@ public class LeanplumInbox {
     SharedPreferencesUtil.commitChanges(editor);
   }
 
-  void downloadMessages() {
+  /**
+   * Forces downloading of inbox messages from the server. After messages are downloaded the
+   * appropriate callbacks will fire.
+   */
+  public void downloadMessages() {
     downloadMessages(null);
   }
 
-  void downloadMessages(@Nullable InboxSyncedCallback callback) {
+  /**
+   * Forces downloading of inbox messages from the server. After messages are downloaded the
+   * appropriate callbacks will fire.
+   *
+   * @param callback The callback to invoke when messages are downloaded.
+   */
+  public void downloadMessages(@Nullable InboxSyncedCallback callback) {
     if (Constants.isNoop()) {
       return;
     }

--- a/AndroidSDKCore/src/main/java/com/leanplum/callbacks/InboxSyncedCallback.java
+++ b/AndroidSDKCore/src/main/java/com/leanplum/callbacks/InboxSyncedCallback.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017, Leanplum, Inc. All rights reserved.
+ * Copyright 2020, Leanplum, Inc. All rights reserved.
  *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
@@ -22,7 +22,7 @@
 package com.leanplum.callbacks;
 
 /**
- * Callback that gets run when forceContentUpdate was called.
+ * Callback that gets run when inbox finishes syncing of messages.
  *
  * @author Anna Orlova
  */
@@ -38,7 +38,7 @@ public abstract class InboxSyncedCallback implements Runnable {
   }
 
   /**
-   * Call when forceContentUpdate was called.
+   * Called when inbox finishes syncing of messages.
    * @param success True if syncing was successful.
    */
   public abstract void onForceContentUpdate(boolean success);

--- a/AndroidSDKTests/src/test/java/com/leanplum/LeanplumInboxTest.java
+++ b/AndroidSDKTests/src/test/java/com/leanplum/LeanplumInboxTest.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2020, Leanplum, Inc. All rights reserved.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.leanplum;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import com.leanplum.__setup.AbstractTest;
+import com.leanplum._whitebox.utilities.ResponseHelper;
+import com.leanplum.callbacks.InboxSyncedCallback;
+import org.junit.Test;
+
+/**
+ * Unit tests for {@link LeanplumInbox}.
+ */
+public class LeanplumInboxTest extends AbstractTest {
+
+  /**
+   * Test for {@link LeanplumInbox#downloadMessages()}.
+   */
+  @Test
+  public void testDownloadMessages() {
+    setupSDK(mContext, "/responses/simple_start_response.json");
+
+    ResponseHelper.seedResponse("/responses/newsfeed_response.json");
+    Boolean[] inboxSyncResult = new Boolean[1]; // boolean holder
+
+    LeanplumInbox.getInstance().addSyncedHandler(new InboxSyncedCallback() {
+      @Override
+      public void onForceContentUpdate(boolean success) {
+        inboxSyncResult[0] = success;
+      }
+    });
+    LeanplumInbox.getInstance().downloadMessages();
+
+    assertNotNull(inboxSyncResult[0]);
+    assertTrue(inboxSyncResult[0]);
+  }
+
+  /**
+   * Test for {@link LeanplumInbox#downloadMessages(InboxSyncedCallback)}.
+   */
+  @Test
+  public void testDownloadMessagesWithCallback() {
+    setupSDK(mContext, "/responses/simple_start_response.json");
+
+    ResponseHelper.seedResponse("/responses/newsfeed_response.json");
+    Boolean[] inboxSyncResult = new Boolean[1]; // boolean holder
+
+    LeanplumInbox.getInstance().downloadMessages(new InboxSyncedCallback() {
+      @Override
+      public void onForceContentUpdate(boolean success) {
+        inboxSyncResult[0] = success;
+      }
+    });
+    assertNotNull(inboxSyncResult[0]);
+    assertTrue(inboxSyncResult[0]);
+  }
+
+}

--- a/AndroidSDKTests/src/test/java/com/leanplum/LeanplumTest.java
+++ b/AndroidSDKTests/src/test/java/com/leanplum/LeanplumTest.java
@@ -32,7 +32,6 @@ import com.leanplum._whitebox.utilities.RequestHelper;
 import com.leanplum._whitebox.utilities.ResponseHelper;
 import com.leanplum._whitebox.utilities.VariablesTestClass;
 import com.leanplum.annotations.Parser;
-import com.leanplum.callbacks.InboxSyncedCallback;
 import com.leanplum.callbacks.MessageDisplayedCallback;
 import com.leanplum.callbacks.StartCallback;
 import com.leanplum.callbacks.VariablesChangedCallback;
@@ -1338,48 +1337,6 @@ public class LeanplumTest extends AbstractTest {
       }
     });
     countDownLatch.await();
-  }
-
-  /**
-   * Test for {@link Leanplum#downloadInboxMessages()}.
-   */
-  @Test
-  public void testDownloadInboxMessages() {
-    setupSDK(mContext, "/responses/simple_start_response.json");
-
-    ResponseHelper.seedResponse("/responses/newsfeed_response.json");
-    Boolean[] inboxSyncResult = new Boolean[1]; // boolean holder
-
-    LeanplumInbox.getInstance().addSyncedHandler(new InboxSyncedCallback() {
-      @Override
-      public void onForceContentUpdate(boolean success) {
-        inboxSyncResult[0] = success;
-      }
-    });
-    Leanplum.downloadInboxMessages();
-
-    assertNotNull(inboxSyncResult[0]);
-    assertTrue(inboxSyncResult[0]);
-  }
-
-  /**
-   * Test for {@link Leanplum#downloadInboxMessages(InboxSyncedCallback)}.
-   */
-  @Test
-  public void testDownloadInboxMessagesWithCallback() {
-    setupSDK(mContext, "/responses/simple_start_response.json");
-
-    ResponseHelper.seedResponse("/responses/newsfeed_response.json");
-    Boolean[] inboxSyncResult = new Boolean[1]; // boolean holder
-
-    Leanplum.downloadInboxMessages(new InboxSyncedCallback() {
-      @Override
-      public void onForceContentUpdate(boolean success) {
-        inboxSyncResult[0] = success;
-      }
-    });
-    assertNotNull(inboxSyncResult[0]);
-    assertTrue(inboxSyncResult[0]);
   }
 
   /**

--- a/AndroidSDKTests/src/test/java/com/leanplum/LeanplumTest.java
+++ b/AndroidSDKTests/src/test/java/com/leanplum/LeanplumTest.java
@@ -32,6 +32,7 @@ import com.leanplum._whitebox.utilities.RequestHelper;
 import com.leanplum._whitebox.utilities.ResponseHelper;
 import com.leanplum._whitebox.utilities.VariablesTestClass;
 import com.leanplum.annotations.Parser;
+import com.leanplum.callbacks.InboxSyncedCallback;
 import com.leanplum.callbacks.MessageDisplayedCallback;
 import com.leanplum.callbacks.StartCallback;
 import com.leanplum.callbacks.VariablesChangedCallback;
@@ -1337,6 +1338,48 @@ public class LeanplumTest extends AbstractTest {
       }
     });
     countDownLatch.await();
+  }
+
+  /**
+   * Test for {@link Leanplum#downloadInboxMessages()}.
+   */
+  @Test
+  public void testDownloadInboxMessages() {
+    setupSDK(mContext, "/responses/simple_start_response.json");
+
+    ResponseHelper.seedResponse("/responses/newsfeed_response.json");
+    Boolean[] inboxSyncResult = new Boolean[1]; // boolean holder
+
+    LeanplumInbox.getInstance().addSyncedHandler(new InboxSyncedCallback() {
+      @Override
+      public void onForceContentUpdate(boolean success) {
+        inboxSyncResult[0] = success;
+      }
+    });
+    Leanplum.downloadInboxMessages();
+
+    assertNotNull(inboxSyncResult[0]);
+    assertTrue(inboxSyncResult[0]);
+  }
+
+  /**
+   * Test for {@link Leanplum#downloadInboxMessages(InboxSyncedCallback)}.
+   */
+  @Test
+  public void testDownloadInboxMessagesWithCallback() {
+    setupSDK(mContext, "/responses/simple_start_response.json");
+
+    ResponseHelper.seedResponse("/responses/newsfeed_response.json");
+    Boolean[] inboxSyncResult = new Boolean[1]; // boolean holder
+
+    Leanplum.downloadInboxMessages(new InboxSyncedCallback() {
+      @Override
+      public void onForceContentUpdate(boolean success) {
+        inboxSyncResult[0] = success;
+      }
+    });
+    assertNotNull(inboxSyncResult[0]);
+    assertTrue(inboxSyncResult[0]);
   }
 
   /**


### PR DESCRIPTION
What              | Where/Who
------------------|----------------------------------------
JIRA Issue        | [SDK-232](https://leanplum.atlassian.net/browse/SDK-232)
People Involved   | @hborisoff 

## Implementation
Adding method to allow clients to download inbox messages without the need to call `forceContentUpdate`.

Two methods are added to public interface:

`LeanplumInbox.downloadMessages()` - Triggers downloading of messages. `LeanplumInbox.syncedCallbacks` will be invoked when operation is done.

`LeanplumInbox.downloadMessages(InboxSyncedCallback)` - Triggers downloading of messages and adds the callback to `LeanplumInbox.syncedCallbacks`. When downloading is complete the callback is removed from the list.
