### PR TITLE
Fix Leanplum.hasStarted to be true when device is offline

### DIFF
--- a/AndroidSDKCore/src/main/java/com/leanplum/internal/RequestSender.java
+++ b/AndroidSDKCore/src/main/java/com/leanplum/internal/RequestSender.java
@@ -228,7 +228,7 @@ public class RequestSender {
 
     if (Constants.isDevelopmentModeEnabled || RequestType.IMMEDIATE.equals(request.getType())) {
       try {
-        if (validateConfig()) {
+        if (validateConfig(request)) {
           sendRequests();
         }
       } catch (Throwable t) {
@@ -237,7 +237,7 @@ public class RequestSender {
     }
   }
 
-  private boolean validateConfig() {
+  private boolean validateConfig(@NonNull Request request) {
     if (APIConfig.getInstance().appId() == null) {
       Log.e("Cannot send request. appId is not set.");
       return false;
@@ -250,6 +250,9 @@ public class RequestSender {
 
     if (!Util.isConnected()) {
       Log.d("Device is offline, will try sending requests again later.");
+      if (request.error != null) {
+        request.error.error(new Exception("Leanplum: device is offline"));
+      }
       return false;
     }
 

--- a/AndroidSDKTests/src/test/java/com/leanplum/LeanplumTest.java
+++ b/AndroidSDKTests/src/test/java/com/leanplum/LeanplumTest.java
@@ -1654,48 +1654,41 @@ public class LeanplumTest extends AbstractTest {
     assertEquals(4, VarCache.variants().size());
   }
 
-//  TODO: Currently hasStarted flag is not set if network is down.
-//   This must be discussed and fixed as well.
-//
-//  @Test
-//  public void testStartChangeCallBackForOffline() throws Exception {
-//    final Semaphore semaphore = new Semaphore(1);
-//    semaphore.acquire();
-//
-//    //Offline Mode.
-//     ResponseHelper.seedResponseNull();
-//
-//    // Expected request params.
-//    final HashMap<String, Object> expectedRequestParams = CollectionUtil.newHashMap(
-//        "city", "(detect)",
-//        "country", "(detect)",
-//        "location", "(detect)",
-//        "region", "(detect)",
-//        "locale", "en_US"
-//    );
-//
-//    // Validate request.
-//    // Validate request.
-//    RequestHelper.addRequestHandler(new RequestHelper.RequestHandler() {
-//      @Override
-//      public void onRequest(String httpMethod, String apiMethod, Map<String, Object> params) {
-//        assertEquals(RequestBuilder.ACTION_START, apiMethod);
-//        assertTrue(params.keySet().containsAll(expectedRequestParams.keySet()));
-//        assertTrue(params.values().containsAll(expectedRequestParams.values()));
-//      }
-//    });
-//
-//
-//    Leanplum.start(mContext, new StartCallback() {
-//      @Override
-//      public void onResponse(boolean success) {
-//        assertTrue(success);
-//        semaphore.release();
-//      }
-//    });
-//    assertTrue(Leanplum.hasStarted());
-//
-//  }
+  @Test
+  public void testStartChangeCallBackForOffline() throws Exception {
+    //Offline Mode.
+     ResponseHelper.seedResponseNull();
+
+    // Expected request params.
+    final HashMap<String, Object> expectedRequestParams = CollectionUtil.newHashMap(
+        "city", "(detect)",
+        "country", "(detect)",
+        "location", "(detect)",
+        "region", "(detect)",
+        "locale", "en_US"
+    );
+
+    // Validate request.
+    // Validate request.
+    RequestHelper.addRequestHandler(new RequestHelper.RequestHandler() {
+      @Override
+      public void onRequest(String httpMethod, String apiMethod, Map<String, Object> params) {
+        assertEquals(RequestBuilder.ACTION_START, apiMethod);
+        assertTrue(params.keySet().containsAll(expectedRequestParams.keySet()));
+        assertTrue(params.values().containsAll(expectedRequestParams.values()));
+      }
+    });
+
+
+    Leanplum.start(mContext, new StartCallback() {
+      @Override
+      public void onResponse(boolean success) {
+        assertFalse(success); // in offline mode the success flag is false and isStarted is true
+      }
+    });
+    assertTrue(Leanplum.hasStarted());
+
+  }
 
   @Test
   public void testVariableChangeCallBacksForOffline() throws Exception {


### PR DESCRIPTION
What              | Where/Who
------------------|----------------------------------------
JIRA Issue        | [SDK-148](https://leanplum.atlassian.net/browse/SDK-148)
People Involved   | @hborisoff 

## Background
`Leanplum.hasStarted()` was always false if device is offline. Now it will become true when start sequence is executed.
Note that StartCallback objects will receive false success flag when `Util.isConnected()` fails. This behaviour is the same in iOS.
