### PR TITLE
Add dialog customizer to allow window flags

### DIFF
--- a/AndroidSDKCore/src/main/java/com/leanplum/messagetemplates/DialogCustomizer.java
+++ b/AndroidSDKCore/src/main/java/com/leanplum/messagetemplates/DialogCustomizer.java
@@ -1,0 +1,59 @@
+package com.leanplum.messagetemplates;
+
+import android.app.Dialog;
+import android.view.View;
+
+/**
+ * Interface that provides access to the view and dialog objects of the main templates before
+ * drawing them. Called just before
+ * {@link Dialog#setContentView(android.view.View, android.view.ViewGroup.LayoutParams)}.
+ *
+ * You can use it to change window flags.
+ */
+public interface DialogCustomizer {
+
+  /**
+   * Customize "Center Popup" template.
+   *
+   * @param messageDialog Dialog container of this message
+   * @param messageContent Content view of the Dialog object
+   */
+  default void customizeCenterPopup(Dialog messageDialog, View messageContent) {
+  }
+
+  /**
+   * Customize "Interstitial" template.
+   *
+   * @param messageDialog Dialog container of this message
+   * @param messageContent Content view of the Dialog object
+   */
+  default void customizeInterstitial(Dialog messageDialog, View messageContent) {
+  }
+
+  /**
+   * Customize "Web Interstitial" template.
+   *
+   * @param messageDialog Dialog container of this message
+   * @param messageContent Content view of the Dialog object
+   */
+  default void customizeWebInterstitial(Dialog messageDialog, View messageContent) {
+  }
+
+  /**
+   * Customize "Rich Interstitial" template.
+   *
+   * @param messageDialog Dialog container of this message
+   * @param messageContent Content view of the Dialog object
+   */
+  default void customizeRichInterstitial(Dialog messageDialog, View messageContent) {
+  }
+
+  /**
+   * Customize "Banner" template.
+   *
+   * @param messageDialog Dialog container of this message
+   * @param messageContent Content view of the Dialog object
+   */
+  default void customizeBanner(Dialog messageDialog, View messageContent) {
+  }
+}

--- a/AndroidSDKCore/src/main/java/com/leanplum/messagetemplates/MessageTemplates.java
+++ b/AndroidSDKCore/src/main/java/com/leanplum/messagetemplates/MessageTemplates.java
@@ -23,6 +23,7 @@ package com.leanplum.messagetemplates;
 
 import android.content.Context;
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 import com.leanplum.ActionArgs;
 import com.leanplum.ActionContext;
 import com.leanplum.Leanplum;
@@ -46,6 +47,7 @@ import com.leanplum.messagetemplates.actions.OpenUrlAction;
 public class MessageTemplates {
 
   private static boolean registered = false;
+  private static DialogCustomizer customizer;
 
   private static ActionCallback createCallback(@NonNull MessageTemplate template) {
     return new ActionCallback() {
@@ -83,6 +85,26 @@ public class MessageTemplates {
         return true;
       }
     };
+  }
+
+  /**
+   * Registers customizer to use when creating the message templates.
+   * Call this method before Leanplum.start.
+   *
+   * @param customizer Dialog customizer
+   */
+  public static void setCustomizer(DialogCustomizer customizer) {
+    MessageTemplates.customizer = customizer;
+  }
+
+  /**
+   * Returns the registered customizer.
+   *
+   * @return Dialog customizer
+   */
+  @Nullable
+  public static DialogCustomizer getCustomizer() {
+    return customizer;
   }
 
   /**

--- a/AndroidSDKCore/src/main/java/com/leanplum/messagetemplates/controllers/BaseController.java
+++ b/AndroidSDKCore/src/main/java/com/leanplum/messagetemplates/controllers/BaseController.java
@@ -24,13 +24,17 @@ package com.leanplum.messagetemplates.controllers;
 import android.app.Activity;
 import android.app.Dialog;
 import android.graphics.Color;
+import android.os.Build;
 import android.view.View;
 import android.view.ViewGroup.LayoutParams;
+import android.view.WindowManager;
 import android.view.animation.Animation;
 import android.widget.RelativeLayout;
 
 import androidx.annotation.VisibleForTesting;
 import com.leanplum.core.R;
+import com.leanplum.messagetemplates.DialogCustomizer;
+import com.leanplum.messagetemplates.MessageTemplates;
 import com.leanplum.utils.SizeUtil;
 import com.leanplum.views.CloseButton;
 import com.leanplum.views.ViewUtils;
@@ -62,11 +66,12 @@ abstract class BaseController extends Dialog {
       CloseButton closeButton = createCloseButton(messageView);
       contentView.addView(closeButton);
     }
+
+    applyWindowDecoration();
+
     setContentView(contentView, contentView.getLayoutParams());
 
     contentView.setAnimation(ViewUtils.createFadeInAnimation(350));
-
-    applyWindowDecoration();
   }
 
   private RelativeLayout createContentView() {

--- a/AndroidSDKCore/src/main/java/com/leanplum/messagetemplates/controllers/CenterPopupController.java
+++ b/AndroidSDKCore/src/main/java/com/leanplum/messagetemplates/controllers/CenterPopupController.java
@@ -27,6 +27,8 @@ import android.os.Build;
 import android.view.Window;
 import android.view.WindowManager;
 import android.widget.RelativeLayout;
+import com.leanplum.messagetemplates.DialogCustomizer;
+import com.leanplum.messagetemplates.MessageTemplates;
 import com.leanplum.messagetemplates.options.CenterPopupOptions;
 import com.leanplum.utils.SizeUtil;
 
@@ -55,6 +57,10 @@ public class CenterPopupController extends AbstractPopupController {
     window.addFlags(WindowManager.LayoutParams.FLAG_DIM_BEHIND);
     if (Build.VERSION.SDK_INT >= 14) {
       window.setDimAmount(0.7f);
+    }
+    DialogCustomizer customizer = MessageTemplates.getCustomizer();
+    if (customizer != null) {
+      customizer.customizeCenterPopup(this, contentView);
     }
   }
 

--- a/AndroidSDKCore/src/main/java/com/leanplum/messagetemplates/controllers/InterstitialController.java
+++ b/AndroidSDKCore/src/main/java/com/leanplum/messagetemplates/controllers/InterstitialController.java
@@ -24,6 +24,8 @@ package com.leanplum.messagetemplates.controllers;
 import android.app.Activity;
 import android.view.ViewGroup.LayoutParams;
 import android.widget.RelativeLayout;
+import com.leanplum.messagetemplates.DialogCustomizer;
+import com.leanplum.messagetemplates.MessageTemplates;
 import com.leanplum.messagetemplates.options.InterstitialOptions;
 
 /**
@@ -44,7 +46,10 @@ public class InterstitialController extends AbstractPopupController {
 
   @Override
   void applyWindowDecoration() {
-    // no implementation
+    DialogCustomizer customizer = MessageTemplates.getCustomizer();
+    if (customizer != null) {
+      customizer.customizeInterstitial(this, contentView);
+    }
   }
 
   @Override

--- a/AndroidSDKCore/src/main/java/com/leanplum/messagetemplates/controllers/RichHtmlController.java
+++ b/AndroidSDKCore/src/main/java/com/leanplum/messagetemplates/controllers/RichHtmlController.java
@@ -43,6 +43,8 @@ import android.widget.RelativeLayout;
 import androidx.annotation.NonNull;
 import com.leanplum.ActionContext;
 import com.leanplum.Leanplum;
+import com.leanplum.messagetemplates.DialogCustomizer;
+import com.leanplum.messagetemplates.MessageTemplates;
 import com.leanplum.messagetemplates.options.RichHtmlOptions;
 import com.leanplum.utils.SizeUtil;
 import java.io.UnsupportedEncodingException;
@@ -116,6 +118,16 @@ public class RichHtmlController extends BaseController {
         contentView.setGravity(Gravity.BOTTOM);
       }
     }
+
+    DialogCustomizer customizer = MessageTemplates.getCustomizer();
+    if (customizer != null) {
+      if (richOptions.isBanner()) {
+        customizer.customizeBanner(this, contentView);
+      } else {
+        customizer.customizeRichInterstitial(this, contentView);
+      }
+    }
+
   }
 
   @Override

--- a/AndroidSDKCore/src/main/java/com/leanplum/messagetemplates/controllers/WebInterstitialController.java
+++ b/AndroidSDKCore/src/main/java/com/leanplum/messagetemplates/controllers/WebInterstitialController.java
@@ -32,6 +32,8 @@ import android.webkit.WebViewClient;
 import android.widget.RelativeLayout;
 import androidx.annotation.NonNull;
 import com.leanplum.Leanplum;
+import com.leanplum.messagetemplates.DialogCustomizer;
+import com.leanplum.messagetemplates.MessageTemplates;
 import com.leanplum.messagetemplates.options.WebInterstitialOptions;
 
 /**
@@ -61,7 +63,10 @@ public class WebInterstitialController extends BaseController {
 
   @Override
   void applyWindowDecoration() {
-    // no implementation
+    DialogCustomizer customizer = MessageTemplates.getCustomizer();
+    if (customizer != null) {
+      customizer.customizeWebInterstitial(this, contentView);
+    }
   }
 
   @Override

--- a/AndroidSDKCore/src/main/java/com/leanplum/messagetemplates/options/RichHtmlOptions.java
+++ b/AndroidSDKCore/src/main/java/com/leanplum/messagetemplates/options/RichHtmlOptions.java
@@ -356,6 +356,11 @@ public class RichHtmlOptions {
     public String type;
   }
 
+  public boolean isBanner() {
+    String templateName = getActionContext().getArgs().get(Values.HTML_TEMPLATE_PREFIX).toString();
+    return templateName.toLowerCase().contains("banner");
+  }
+
   /**
    * Banners with property TabOutsideToClose = false need to be treated differently
    * so they do not block interaction with other dialogs and the keyboard.


### PR DESCRIPTION
What              | Where/Who
------------------|----------------------------------------
JIRA Issue        | [SDK-289](https://leanplum.atlassian.net/browse/SDK-289)
People Involved   | @hborisoff 

## Background
Provide interface to customise the Dialog and content View before showing a message.
This will allow easy support of devices with notch by providing several lines of code.

## Testing steps
Solution was tested with several versions before and after Android O.

The following is an example how to draw fullscreen and behind the notch for **Interstitial** and **Banner** templates.
You can override each of the methods to support different types of templates.
```
MessageTemplates.setCustomizer(new DialogCustomizer() {

    @Override
    public void customizeInterstitial(Dialog messageDialog, View messageContent) {
        Window window = messageDialog.getWindow();
        if (window == null) {
            return;
        }

        // hide status bar
        window.addFlags(WindowManager.LayoutParams.FLAG_FULLSCREEN);

        // draw view fullscreen
        messageContent.setSystemUiVisibility(View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN);

        // draw under notch
        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P){
            window.getAttributes().layoutInDisplayCutoutMode =
                WindowManager.LayoutParams.LAYOUT_IN_DISPLAY_CUTOUT_MODE_SHORT_EDGES;
        }
    }

    @Override
    public void customizeBanner(Dialog messageDialog, View messageContent) {
        customizeInterstitial(messageDialog, messageContent);
    }
});
```
