### PR TITLE
Fix VarCache.variants thread-safety

### DIFF
--- a/AndroidSDKCore/src/main/java/com/leanplum/internal/VarCache.java
+++ b/AndroidSDKCore/src/main/java/com/leanplum/internal/VarCache.java
@@ -76,7 +76,7 @@ public class VarCache {
   private static Map<String, Object> devModeValuesFromServer;
   private static Map<String, Object> devModeFileAttributesFromServer;
   private static Map<String, Object> devModeActionDefinitionsFromServer;
-  private static List<Map<String, Object>> variants = new ArrayList<>();
+  private static volatile List<Map<String, Object>> variants = new ArrayList<>();
   private static CacheUpdateBlock updateBlock;
   private static boolean hasReceivedDiffs = false;
   private static Map<String, Object> messages = new HashMap<>();
@@ -874,7 +874,7 @@ public class VarCache {
 
   public static void clearUserContent() {
     vars.clear();
-    variants.clear();
+    variants = null;
     variantDebugInfo.clear();
 
     diffs.clear();
@@ -905,7 +905,7 @@ public class VarCache {
     devModeValuesFromServer = null;
     devModeFileAttributesFromServer = null;
     devModeActionDefinitionsFromServer = null;
-    variants.clear();
+    variants = null;
     updateBlock = null;
     hasReceivedDiffs = false;
     messages = null;


### PR DESCRIPTION
What              | Where/Who
------------------|----------------------------------------
JIRA Issue        | [SDK-342](https://leanplum.atlassian.net/browse/SDK-342)
People Involved   | @hborisoff 

VarCache.variants is practically read only. Making the reference `volatile` will make it immediately visible from all threads, if changed.
No need for other synchronisation, because iterating over the elements from multiple threads won't produce any exception.