### PR TITLE
Fix compilation issue in FCM module

### DIFF
--- a/AndroidSDKFcm/build.gradle
+++ b/AndroidSDKFcm/build.gradle
@@ -35,7 +35,7 @@ dependencies {
     releaseApi project(':AndroidSDKPush')
 
     // Provided dependencies are optional dependencies and will not show up in pom file.
-    compileOnly('com.google.firebase:firebase-messaging:[17.3.4,)') {
+    compileOnly('com.google.firebase:firebase-messaging:[17.3.4, 21.1.0]') {
         exclude module: 'support-v4'
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.6.3'
+        classpath 'com.android.tools.build:gradle:4.2.0'
     }
 }
 

--- a/common-methods.gradle
+++ b/common-methods.gradle
@@ -1,6 +1,6 @@
 // Export methods by turning them into closures
 ext {
-    COMPILE_SDK_VERSION = 29
+    COMPILE_SDK_VERSION = 30
     APPCOMPAT_LIBRARY_VERSION = '1.2.0'
     MIN_SDK_VERSION = 14
     JAVA_VERSION = JavaVersion.VERSION_1_8

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.4.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.7.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
What              | Where/Who
------------------|----------------------------------------
People Involved   | @hborisoff 

Description of the changes:

1. Increased Gradle plugin version because of issues in Android Studio 4.2

2. Put upper bound to `firebase-messaging` dependency, because `22.0.0` removes some deprecated classes and causes compilation errors.

Recommended change for supporting `22.0.0` is to use
```
FirebaseMessaging.getInstance().getToken()
instead of
FirebaseInstanceId.getInstance().getInstanceId()
```
and
```
FirebaseMessaging.getInstance().deleteToken() or FirebaseInstallations.getInstance().delete()
instead of
FirebaseInstanceId.getInstance().deleteInstanceId()
```

but these methods are added in `20.3.0` and we need to wait a little before updating dependency to `[20.3.0,)`, because it is released in Oct 2020, half a year ago.

[List](https://maven.google.com/web/index.html#com.google.firebase:firebase-messaging:22.0.0) with all `firebase-messaging` versions.