### PR TITLE
Support IAM caps

### DIFF
--- a/AndroidSDKCore/src/main/java/com/leanplum/ActionContext.java
+++ b/AndroidSDKCore/src/main/java/com/leanplum/ActionContext.java
@@ -388,7 +388,17 @@ public class ActionContext extends BaseActionContext implements Comparable<Actio
           @Override
           public void variablesChanged() {
             try {
+              // We do not want to count occurrences for action kind, because in multi message
+              // campaigns the Open URL action is not a message. Also if the user has defined
+              // actions of type Action we do not want to count them.
+              int actionKind = VarCache.getActionDefinitionType(actionContext.name);
+              if (actionKind == Leanplum.ACTION_KIND_ACTION) {
+                ActionManager.getInstance().recordChainedActionImpression(messageId);
+              } else {
+                ActionManager.getInstance().recordMessageImpression(messageId);
+              }
               Leanplum.triggerMessageDisplayed(actionContext);
+
             } catch (Throwable t) {
               Log.exception(t);
             }

--- a/AndroidSDKCore/src/main/java/com/leanplum/Leanplum.java
+++ b/AndroidSDKCore/src/main/java/com/leanplum/Leanplum.java
@@ -970,6 +970,7 @@ public class Leanplum {
         || !values.equals(VarCache.getDiffs())
         || !messages.equals(VarCache.getMessageDiffs())
         || !variants.equals(VarCache.variants())
+        || !localCaps.equals(VarCache.localCaps())
         || !regions.equals(VarCache.regions())) {
       VarCache.applyVariableDiffs(
           values,

--- a/AndroidSDKCore/src/main/java/com/leanplum/Leanplum.java
+++ b/AndroidSDKCore/src/main/java/com/leanplum/Leanplum.java
@@ -552,6 +552,7 @@ public class Leanplum {
             new HashMap<>(),
             new HashMap<>(),
             new ArrayList<>(),
+            new ArrayList<>(),
             new HashMap<>(),
             "",
             "");
@@ -957,6 +958,8 @@ public class Leanplum {
         response.optJSONObject(Constants.Keys.REGIONS));
     List<Map<String, Object>> variants = JsonConverter.listFromJsonOrDefault(
         response.optJSONArray(Constants.Keys.VARIANTS));
+    List<Map<String, Object>> localCaps = JsonConverter.listFromJsonOrDefault(
+        response.optJSONArray(Constants.Keys.LOCAL_CAPS));
     Map<String, Object> variantDebugInfo = JsonConverter.mapFromJsonOrDefault(
             response.optJSONObject(Constants.Keys.VARIANT_DEBUG_INFO));
     JSONObject varsJsonObj = response.optJSONObject(Constants.Keys.VARS);
@@ -973,6 +976,7 @@ public class Leanplum {
           messages,
           regions,
           variants,
+          localCaps,
           variantDebugInfo,
           varsJson,
           varsSignature);

--- a/AndroidSDKCore/src/main/java/com/leanplum/Leanplum.java
+++ b/AndroidSDKCore/src/main/java/com/leanplum/Leanplum.java
@@ -1305,7 +1305,6 @@ public class Leanplum {
   }
 
   public static void triggerMessageDisplayed(ActionContext actionContext) {
-    ActionManager.getInstance().recordMessageImpression(actionContext.getMessageId());
     synchronized (messageDisplayedHandlers) {
       for (MessageDisplayedCallback callback : messageDisplayedHandlers) {
         MessageArchiveData messageArchiveData = messageArchiveDataFromContext(actionContext);

--- a/AndroidSDKCore/src/main/java/com/leanplum/internal/ActionManager.java
+++ b/AndroidSDKCore/src/main/java/com/leanplum/internal/ActionManager.java
@@ -485,6 +485,16 @@ public class ActionManager {
   }
 
   /**
+   * Tracks the event for local push notification.
+   * Do not want to track impression occurrence in such case.
+   *
+   * @param messageId The ID of the action
+   */
+  public void recordLocalPushImpression(String messageId) {
+    trackImpressionEvent(messageId);
+  }
+
+  /**
    * Tracks the correct held back event.
    *
    * @param originalMessageId The original message ID of the held back message.

--- a/AndroidSDKCore/src/main/java/com/leanplum/internal/Clock.java
+++ b/AndroidSDKCore/src/main/java/com/leanplum/internal/Clock.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2021, Leanplum, Inc. All rights reserved.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.leanplum.internal;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.VisibleForTesting;
+import java.util.Date;
+
+/**
+ * Use this interface instead of the system utilities to get current time and Date instance for easy
+ * mock in unit tests.
+ */
+public abstract class Clock {
+
+  public static final Clock SYSTEM = new Clock() {
+    @Override
+    long currentTimeMillis() {
+      return System.currentTimeMillis();
+    }
+
+    @NonNull
+    @Override
+    Date newDate() {
+      return new Date();
+    }
+  };
+
+  private static Clock INSTANCE = SYSTEM;
+
+  public static Clock getInstance() {
+    return INSTANCE;
+  }
+
+  @VisibleForTesting
+  static void setInstance(Clock clock) {
+    INSTANCE = clock;
+  }
+
+  /**
+   * Gets current time in milliseconds.
+   *
+   * @return The current time in milliseconds.
+   */
+  abstract long currentTimeMillis();
+
+  /**
+   * Creates instance of type Date.
+   *
+   * @return New instance of Date.
+   */
+  @NonNull
+  abstract Date newDate();
+}

--- a/AndroidSDKCore/src/main/java/com/leanplum/internal/Constants.java
+++ b/AndroidSDKCore/src/main/java/com/leanplum/internal/Constants.java
@@ -211,6 +211,7 @@ public class Constants {
     public static final String DATA = "Data";
     public static final String TOKEN = "token";
     public static final String VARIANTS = "variants";
+    public static final String LOCAL_CAPS = "localCaps";
     public static final String VARS = "vars";
     public static final String VARS_SIGNATURE = "varsSignature";
     public static final String VARS_FROM_CODE = "varsFromCode";

--- a/AndroidSDKCore/src/main/java/com/leanplum/internal/LeanplumInternal.java
+++ b/AndroidSDKCore/src/main/java/com/leanplum/internal/LeanplumInternal.java
@@ -25,6 +25,7 @@ import android.location.Address;
 import android.location.Geocoder;
 import android.location.Location;
 
+import androidx.annotation.NonNull;
 import com.leanplum.ActionContext;
 import com.leanplum.Leanplum;
 import com.leanplum.LeanplumActivityHelper;
@@ -285,11 +286,19 @@ public class LeanplumInternal {
     }
   }
 
-  private static boolean shouldSuppressMessage(ActionContext context) {
-    // TODO do not suppress local push
+  /**
+   * Checks if message should be suppressed based on the local IAM caps.
+   *
+   * @param context The message context to check.
+   * @return True if message should  be suppressed, false otherwise.
+   */
+  private static boolean shouldSuppressMessage(@NonNull ActionContext context) {
+    if (ActionManager.PUSH_NOTIFICATION_ACTION_NAME.equals(context.actionName())) {
+      // do not suppress local push
+      return false;
+    }
 
-    // [done] check if message caps are reached
-
+    // checks if message caps are reached
     return ActionManager.getInstance().shouldSuppressMessages();
   }
 

--- a/AndroidSDKCore/src/main/java/com/leanplum/internal/LeanplumInternal.java
+++ b/AndroidSDKCore/src/main/java/com/leanplum/internal/LeanplumInternal.java
@@ -275,7 +275,12 @@ public class LeanplumInternal {
             public void variablesChanged() {
               try {
                 // record impression if we have at least one handler
-                ActionManager.getInstance().recordMessageImpression(actionContext.getMessageId());
+                if (ActionManager.PUSH_NOTIFICATION_ACTION_NAME.equals(actionContext.actionName())) {
+                  // Special case for local push notification. Do not want to count impression.
+                  ActionManager.getInstance().recordLocalPushImpression(actionContext.getMessageId());
+                } else {
+                  ActionManager.getInstance().recordMessageImpression(actionContext.getMessageId());
+                }
                 Leanplum.triggerMessageDisplayed(actionContext);
               } catch (Throwable t) {
                 Log.exception(t);

--- a/AndroidSDKCore/src/main/java/com/leanplum/internal/LeanplumInternal.java
+++ b/AndroidSDKCore/src/main/java/com/leanplum/internal/LeanplumInternal.java
@@ -265,9 +265,10 @@ public class LeanplumInternal {
           ActionManager.getInstance().recordHeldBackImpression(
               actionContext.getMessageId(), actionContext.getOriginalMessageId());
         } else {
-//          if (shouldSuppressMessage(actionContext)) { TODO uncomment when done
-//            continue;
-//          }
+          if (shouldSuppressMessage(actionContext)) {
+            Log.d("Local IAM caps reached, suppressing messageId=" + actionContext.getMessageId());
+            continue;
+          }
 
           LeanplumInternal.triggerAction(actionContext, new VariablesChangedCallback() {
             @Override

--- a/AndroidSDKCore/src/main/java/com/leanplum/internal/LeanplumInternal.java
+++ b/AndroidSDKCore/src/main/java/com/leanplum/internal/LeanplumInternal.java
@@ -264,10 +264,16 @@ public class LeanplumInternal {
           ActionManager.getInstance().recordHeldBackImpression(
               actionContext.getMessageId(), actionContext.getOriginalMessageId());
         } else {
+//          if (shouldSuppressMessage(actionContext)) { TODO uncomment when done
+//            continue;
+//          }
+
           LeanplumInternal.triggerAction(actionContext, new VariablesChangedCallback() {
             @Override
             public void variablesChanged() {
               try {
+                // record impression if we have at least one handler
+                ActionManager.getInstance().recordMessageImpression(actionContext.getMessageId());
                 Leanplum.triggerMessageDisplayed(actionContext);
               } catch (Throwable t) {
                 Log.exception(t);
@@ -277,6 +283,14 @@ public class LeanplumInternal {
         }
       }
     }
+  }
+
+  private static boolean shouldSuppressMessage(ActionContext context) {
+    // TODO do not suppress local push
+
+    // [done] check if message caps are reached
+
+    return ActionManager.getInstance().shouldSuppressMessages();
   }
 
   private static int fetchCountDown(ActionContext context, Map<String, Object> messages) {

--- a/AndroidSDKCore/src/main/java/com/leanplum/internal/LeanplumInternal.java
+++ b/AndroidSDKCore/src/main/java/com/leanplum/internal/LeanplumInternal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016, Leanplum, Inc. All rights reserved.
+ * Copyright 2021, Leanplum, Inc. All rights reserved.
  *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/AndroidSDKCore/src/main/java/com/leanplum/internal/Socket.java
+++ b/AndroidSDKCore/src/main/java/com/leanplum/internal/Socket.java
@@ -301,7 +301,7 @@ public class Socket {
         return;
       }
       VarCache.applyVariableDiffs(
-          JsonConverter.mapFromJson(object), null, null, null, null, null, null);
+          JsonConverter.mapFromJson(object), null, null, null, null, null, null, null);
     } catch (JSONException e) {
       Log.e("Couldn't applyVars for preview.", e);
     } catch (Throwable e) {

--- a/AndroidSDKCore/src/main/java/com/leanplum/internal/Socket.java
+++ b/AndroidSDKCore/src/main/java/com/leanplum/internal/Socket.java
@@ -225,6 +225,7 @@ public class Socket {
         ((BaseActionContext) context).setIsPreview(true);
         context.update();
         LeanplumInternal.triggerAction(context);
+        ActionManager.getInstance().recordMessageImpression(context.getMessageId());
         Leanplum.triggerMessageDisplayed(context);
       }
     } catch (JSONException e) {

--- a/AndroidSDKCore/src/main/java/com/leanplum/internal/VarCache.java
+++ b/AndroidSDKCore/src/main/java/com/leanplum/internal/VarCache.java
@@ -82,6 +82,7 @@ public class VarCache {
   private static Map<String, Object> devModeFileAttributesFromServer;
   private static Map<String, Object> devModeActionDefinitionsFromServer;
   private static volatile List<Map<String, Object>> variants = new ArrayList<>();
+  private static volatile List<Map<String, Object>> localCaps = new ArrayList<>();
   private static CacheUpdateBlock updateBlock;
   private static boolean hasReceivedDiffs = false;
   private static Map<String, Object> messages = new HashMap<>();
@@ -480,6 +481,8 @@ public class VarCache {
       Log.e("Error converting " + variants + " to JSON.\n" + Log.getStackTraceString(e1));
     }
 
+    // TODO write localCaps
+
     if (variantDebugInfo != null) {
       editor.putString(
           Constants.Keys.VARIANT_DEBUG_INFO,
@@ -611,6 +614,8 @@ public class VarCache {
     if (variants != null) {
       VarCache.variants = variants;
     }
+
+    // TODO init localCaps
 
     if (variantDebugInfo != null) {
       VarCache.setVariantDebugInfo(variantDebugInfo);
@@ -809,6 +814,10 @@ public class VarCache {
     return variants;
   }
 
+  public static List<Map<String, Object>> localCaps() {
+    return localCaps;
+  }
+
   public static Map<String, Object> actionDefinitions() {
     return actionDefinitions;
   }
@@ -901,9 +910,21 @@ public class VarCache {
     return new SecuredVars(varsJson, varsSignature);
   }
 
+  public static int getActionDefinitionType(String actionName) {
+    Object actionDef = actionDefinitions().get(actionName);
+    if (actionDef instanceof Map<?, ?>) {
+      Integer kind = (Integer) ((Map<?, ?>) actionDef).get("kind");
+      if (kind != null) {
+        return kind;
+      }
+    }
+    return 0;
+  }
+
   public static void clearUserContent() {
     vars.clear();
     variants = new ArrayList<>();
+    localCaps = new ArrayList<>();
     variantDebugInfo.clear();
     varsJson = null;
     varsSignature = null;
@@ -937,6 +958,7 @@ public class VarCache {
     devModeFileAttributesFromServer = null;
     devModeActionDefinitionsFromServer = null;
     variants = new ArrayList<>();
+    localCaps = new ArrayList<>();
     updateBlock = null;
     hasReceivedDiffs = false;
     messages = null;

--- a/AndroidSDKCore/src/main/java/com/leanplum/internal/VarCache.java
+++ b/AndroidSDKCore/src/main/java/com/leanplum/internal/VarCache.java
@@ -485,7 +485,7 @@ public class VarCache {
     }
 
     try {
-      if (localCaps != null && !localCaps.isEmpty()) {
+      if (localCaps != null) {
         String json = JsonConverter.listToJsonArray(localCaps).toString();
         editor.putString(Constants.Keys.LOCAL_CAPS, aesContext.encrypt(json));
       }

--- a/AndroidSDKPush/src/main/java/com/leanplum/LeanplumPushService.java
+++ b/AndroidSDKPush/src/main/java/com/leanplum/LeanplumPushService.java
@@ -192,6 +192,8 @@ public class LeanplumPushService {
                         response.optJSONObject(Constants.Keys.REGIONS));
                     List<Map<String, Object>> variants = JsonConverter.listFromJson(
                         response.optJSONArray(Constants.Keys.VARIANTS));
+                    List<Map<String, Object>> localCaps = JsonConverter.listFromJson(
+                        response.optJSONArray(Constants.Keys.LOCAL_CAPS));
 
                     JSONObject varsJsonObj = response.optJSONObject(Constants.Keys.VARS);
                     String varsJson = (varsJsonObj != null) ? varsJsonObj.toString() : null;
@@ -212,6 +214,7 @@ public class LeanplumPushService {
                           messages,
                           regions,
                           variants,
+                          localCaps,
                           null,
                           varsJson,
                           varsSignature);

--- a/AndroidSDKTests/src/test/java/com/leanplum/LeanplumActionContextTest.java
+++ b/AndroidSDKTests/src/test/java/com/leanplum/LeanplumActionContextTest.java
@@ -308,7 +308,7 @@ public class LeanplumActionContextTest extends AbstractTest {
         // Add chained message to VarCache.
         VarCache.applyVariableDiffs(null, new HashMap<>(
                 ImmutableMap.<String, Object>of(Long.toString(chainedMessageId),
-                ImmutableMap.<String, Object>of())), null, null, null, null, null);
+                ImmutableMap.<String, Object>of())), null, null, null, null, null, null);
         // Since it now exists locally, we should return false for forceContentUpdate.
         Assert.assertFalse(ActionContext.shouldForceContentUpdateForChainedMessage(
                 JsonConverter.fromJson(jsonData)));

--- a/AndroidSDKTests/src/test/java/com/leanplum/LeanplumTest.java
+++ b/AndroidSDKTests/src/test/java/com/leanplum/LeanplumTest.java
@@ -528,7 +528,7 @@ public class LeanplumTest extends AbstractTest {
       }});
     }};
 
-    VarCache.applyVariableDiffs(null, messages, null, variants, null, null, null);
+    VarCache.applyVariableDiffs(null, messages, null, variants, null, null, null, null);
     assertEquals(variants, Leanplum.variants());
     assertEquals(messages, Leanplum.messageMetadata());
   }

--- a/AndroidSDKTests/src/test/java/com/leanplum/LocalCapsTest.java
+++ b/AndroidSDKTests/src/test/java/com/leanplum/LocalCapsTest.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2021, Leanplum, Inc. All rights reserved.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.leanplum;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import com.leanplum.__setup.AbstractTest;
+import com.leanplum._whitebox.utilities.ResponseHelper;
+import com.leanplum.internal.VarCache;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.Test;
+
+public class LocalCapsTest extends AbstractTest {
+
+  @Test
+  public void testParseSessionLimit() {
+    ResponseHelper.seedResponse("/responses/local_caps_session_response.json");
+    Leanplum.start(mContext);
+    assertTrue(Leanplum.hasStarted());
+
+    Map<String, Object> session = new HashMap<>();
+    session.put("channel", "IN_APP");
+    session.put("limit", 3);
+    session.put("type", "SESSION");
+
+    List<Map<String, Object>> caps = VarCache.localCaps();
+    assertEquals(caps.size(), 1);
+    assertTrue(caps.contains(session));
+  }
+
+  @Test
+  public void testParseDayLimit() {
+    ResponseHelper.seedResponse("/responses/local_caps_day_response.json");
+    Leanplum.start(mContext);
+    assertTrue(Leanplum.hasStarted());
+
+    Map<String, Object> day = new HashMap<>();
+    day.put("channel", "IN_APP");
+    day.put("limit", 3);
+    day.put("type", "DAY");
+
+    List<Map<String, Object>> caps = VarCache.localCaps();
+    assertEquals(caps.size(), 1);
+    assertTrue(caps.contains(day));
+  }
+
+  @Test
+  public void testParseWeekLimit() {
+    ResponseHelper.seedResponse("/responses/local_caps_week_response.json");
+    Leanplum.start(mContext);
+    assertTrue(Leanplum.hasStarted());
+
+    Map<String, Object> week = new HashMap<>();
+    week.put("channel", "IN_APP");
+    week.put("limit", 3);
+    week.put("type", "WEEK");
+
+    List<Map<String, Object>> caps = VarCache.localCaps();
+    assertEquals(caps.size(), 1);
+    assertTrue(caps.contains(week));
+  }
+
+  @Test
+  public void testParseAll() {
+    Map<String, Object> session = new HashMap<>();
+    session.put("channel", "IN_APP");
+    session.put("limit", 1);
+    session.put("type", "SESSION");
+
+    Map<String, Object> day = new HashMap<>();
+    day.put("channel", "IN_APP");
+    day.put("limit", 2);
+    day.put("type", "DAY");
+
+    Map<String, Object> week = new HashMap<>();
+    week.put("channel", "IN_APP");
+    week.put("limit", 3);
+    week.put("type", "WEEK");
+
+    ResponseHelper.seedResponse("/responses/local_caps_response.json");
+    Leanplum.start(mContext);
+    assertTrue(Leanplum.hasStarted());
+
+    List<Map<String, Object>> caps = VarCache.localCaps();
+
+    assertEquals(caps.size(), 3);
+    assertTrue(caps.contains(session));
+    assertTrue(caps.contains(day));
+    assertTrue(caps.contains(week));
+  }
+
+}

--- a/AndroidSDKTests/src/test/java/com/leanplum/internal/LeanplumActionManagerTest.java
+++ b/AndroidSDKTests/src/test/java/com/leanplum/internal/LeanplumActionManagerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016, Leanplum, Inc. All rights reserved.
+ * Copyright 2021, Leanplum, Inc. All rights reserved.
  *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
@@ -20,27 +20,85 @@
  */
 package com.leanplum.internal;
 
+import androidx.annotation.NonNull;
+import com.leanplum.Leanplum;
 import com.leanplum.__setup.AbstractTest;
 
+import com.leanplum._whitebox.utilities.ResponseHelper;
+import java.util.Date;
+import java.util.HashMap;
+import org.junit.After;
 import org.junit.Test;
 
 import java.util.Map;
 
+import static org.junit.Assert.assertFalse;
+import static org.mockito.Mockito.*;
+
+import static org.powermock.api.mockito.PowerMockito.spy;
+import static org.powermock.api.mockito.PowerMockito.verifyStatic;
+
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 /**
  * @author Milos Jakovljevic
  */
 public class LeanplumActionManagerTest extends AbstractTest {
+  private static final long DAY_MILLIS = 24 * 60 * 60 * 1000;
+
+  private static class DayAheadClock extends Clock {
+    @Override
+    long currentTimeMillis() {
+      return System.currentTimeMillis() + DAY_MILLIS;
+    }
+
+    @NonNull
+    @Override
+    Date newDate() {
+      Date date = new Date();
+      date.setTime(date.getTime() + DAY_MILLIS);
+      return date;
+    }
+  }
+
+  private static class WeekAheadClock extends Clock {
+    @Override
+    long currentTimeMillis() {
+      return System.currentTimeMillis() + 7 * DAY_MILLIS;
+    }
+
+    @NonNull
+    @Override
+    Date newDate() {
+      Date date = new Date();
+      date.setTime(date.getTime() + 7 * DAY_MILLIS);
+      return date;
+    }
+  }
+
+  @After
+  public void tearDown() {
+    Clock.setInstance(Clock.SYSTEM);
+  }
 
   @Test
   public void testImpressions() {
-    ActionManager.getInstance().recordMessageImpression("message##id");
-    ActionManager.getInstance().recordMessageImpression("message##id");
-    Map<String, Number> impressions = ActionManager.getInstance().getMessageImpressionOccurrences("message##id");
+    spy(LeanplumInternal.class);
+
+    String messageId = "message##id";
+    Map<String, String> trackArgs = new HashMap<>();
+    trackArgs.put("messageId", messageId);
+
+    ActionManager.getInstance().recordMessageImpression(messageId);
+    ActionManager.getInstance().recordMessageImpression(messageId);
+    Map<String, Number> impressions = ActionManager.getInstance().getMessageImpressionOccurrences(messageId);
     assertEquals(4, impressions.size());
     assertEquals(0, impressions.get("min").intValue());
     assertEquals(1, impressions.get("max").intValue());
+
+    verifyStatic(times(2));
+    LeanplumInternal.track(eq(null), eq(0.0), eq(null), eq(null), eq(trackArgs));
   }
 
   @Test
@@ -49,4 +107,140 @@ public class LeanplumActionManagerTest extends AbstractTest {
     int occurences = ActionManager.getInstance().getMessageTriggerOccurrences("message##id");
     assertEquals(5, occurences);
   }
+
+  @Test
+  public void testRecordChainedActionImpression() {
+    spy(LeanplumInternal.class);
+
+    String actionId = "action##id";
+    Map<String, String> trackArgs = new HashMap<>();
+    trackArgs.put("messageId", actionId);
+
+    ActionManager.getInstance().recordChainedActionImpression(actionId);
+    Map<String, Number> impressions =
+        ActionManager.getInstance().getMessageImpressionOccurrences(actionId);
+    assertTrue(impressions.isEmpty());
+
+    verifyStatic(times(1));
+    LeanplumInternal.track(eq(null), eq(0.0), eq(null), eq(null), eq(trackArgs));
+  }
+
+  @Test
+  public void testDailyOccurrences() {
+    ResponseHelper.seedResponse("/responses/local_caps_response.json");
+    Leanplum.start(mContext);
+    assertTrue(Leanplum.hasStarted());
+
+    ActionManager.getInstance().recordMessageImpression("message#1");
+    ActionManager.getInstance().recordMessageImpression("message#2");
+    ActionManager.getInstance().recordMessageImpression("message#3");
+    assertEquals(3, ActionManager.getInstance().dailyOccurrencesCount());
+
+    Clock.setInstance(new DayAheadClock());
+    assertEquals(0, ActionManager.getInstance().dailyOccurrencesCount());
+
+  }
+
+  @Test
+  public void testWeeklyOccurrences() {
+    ResponseHelper.seedResponse("/responses/local_caps_response.json");
+    Leanplum.start(mContext);
+    assertTrue(Leanplum.hasStarted());
+
+    ActionManager.getInstance().recordMessageImpression("message#1");
+    ActionManager.getInstance().recordMessageImpression("message#2");
+    assertEquals(2, ActionManager.getInstance().weeklyOccurrencesCount());
+
+    Clock.setInstance(new DayAheadClock());
+    ActionManager.getInstance().recordMessageImpression("message#3");
+    assertEquals(3, ActionManager.getInstance().weeklyOccurrencesCount());
+
+    Clock.setInstance(new WeekAheadClock());
+    ActionManager.getInstance().recordMessageImpression("message#4");
+    assertEquals(2, ActionManager.getInstance().weeklyOccurrencesCount());
+  }
+
+  @Test
+  public void testOccurrencesCounting() {
+    ResponseHelper.seedResponse("/responses/local_caps_response.json");
+    Leanplum.start(mContext);
+    assertTrue(Leanplum.hasStarted());
+
+    ActionManager.getInstance().recordMessageImpression("message#1");
+    ActionManager.getInstance().recordMessageImpression("message#2");
+    ActionManager.getInstance().recordMessageImpression("message#3");
+    ActionManager.getInstance().recordMessageImpression("message#1");
+    ActionManager.getInstance().recordMessageImpression("message#2");
+    ActionManager.getInstance().recordMessageImpression("message#3");
+
+    assertEquals(6, ActionManager.getInstance().sessionOccurrencesCount());
+    assertEquals(6, ActionManager.getInstance().dailyOccurrencesCount());
+    assertEquals(6, ActionManager.getInstance().weeklyOccurrencesCount());
+  }
+
+  @Test
+  public void testMaxOccurrencesPerMessage() {
+    ResponseHelper.seedResponse("/responses/local_caps_response.json");
+    Leanplum.start(mContext);
+    assertTrue(Leanplum.hasStarted());
+
+    int maxOccurrences = 100;
+    int occurrences = maxOccurrences + 5;
+
+    for (int i = 0; i < occurrences; i++) {
+      ActionManager.getInstance().recordMessageImpression("message#00");
+    }
+
+    assertEquals(maxOccurrences, ActionManager.getInstance().dailyOccurrencesCount());
+    assertEquals(maxOccurrences, ActionManager.getInstance().weeklyOccurrencesCount());
+  }
+
+  @Test
+  public void testShouldSuppressMessagesSessionLimit() {
+    ResponseHelper.seedResponse("/responses/local_caps_session_response.json");
+    Leanplum.start(mContext);
+    assertTrue(Leanplum.hasStarted());
+
+    ActionManager.getInstance().recordMessageImpression("message#1");
+    ActionManager.getInstance().recordMessageImpression("message#2");
+    assertFalse(ActionManager.getInstance().shouldSuppressMessages());
+
+    ActionManager.getInstance().recordMessageImpression("message#3");
+    assertTrue(ActionManager.getInstance().shouldSuppressMessages());
+  }
+
+  @Test
+  public void testShouldSuppressMessagesDayLimit() {
+    ResponseHelper.seedResponse("/responses/local_caps_day_response.json");
+    Leanplum.start(mContext);
+    assertTrue(Leanplum.hasStarted());
+
+    ActionManager.getInstance().recordMessageImpression("message#1");
+    ActionManager.getInstance().recordMessageImpression("message#2");
+    assertFalse(ActionManager.getInstance().shouldSuppressMessages());
+
+    ActionManager.getInstance().recordMessageImpression("message#3");
+    assertTrue(ActionManager.getInstance().shouldSuppressMessages());
+
+    Clock.setInstance(new DayAheadClock());
+    assertFalse(ActionManager.getInstance().shouldSuppressMessages());
+  }
+
+  @Test
+  public void testShouldSuppressMessagesWeekLimit() {
+    ResponseHelper.seedResponse("/responses/local_caps_week_response.json");
+    Leanplum.start(mContext);
+    assertTrue(Leanplum.hasStarted());
+
+    ActionManager.getInstance().recordMessageImpression("message#1");
+    ActionManager.getInstance().recordMessageImpression("message#2");
+    assertFalse(ActionManager.getInstance().shouldSuppressMessages());
+
+    ActionManager.getInstance().recordMessageImpression("message#3");
+    assertTrue(ActionManager.getInstance().shouldSuppressMessages());
+
+    Clock.setInstance(new WeekAheadClock());
+    assertFalse(ActionManager.getInstance().shouldSuppressMessages());
+  }
+
 }

--- a/AndroidSDKTests/src/test/resources/responses/local_caps_day_response.json
+++ b/AndroidSDKTests/src/test/resources/responses/local_caps_day_response.json
@@ -1,0 +1,23 @@
+{
+  "response": [
+    {
+      "regions": {},
+      "fileAttributes": {},
+      "success": true,
+      "messages": {},
+      "vars": {
+        "intVariable": 100,
+        "stringVariable": "test_string"
+      },
+      "variants": [],
+      "localCaps": [
+        {
+          "channel": "IN_APP",
+          "limit": 3,
+          "type": "DAY"
+        }
+      ],
+      "token": "c2q5to0cTdiZWE2bdkKUQsTs0cQRVkfHkSGoPeqrQWc"
+    }
+  ]
+}

--- a/AndroidSDKTests/src/test/resources/responses/local_caps_response.json
+++ b/AndroidSDKTests/src/test/resources/responses/local_caps_response.json
@@ -1,0 +1,33 @@
+{
+  "response": [
+    {
+      "regions": {},
+      "fileAttributes": {},
+      "success": true,
+      "messages": {},
+      "vars": {
+        "intVariable": 100,
+        "stringVariable": "test_string"
+      },
+      "variants": [],
+      "localCaps": [
+        {
+          "channel": "IN_APP",
+          "limit": 1,
+          "type": "SESSION"
+        },
+        {
+          "channel": "IN_APP",
+          "limit": 2,
+          "type": "DAY"
+        },
+        {
+          "channel": "IN_APP",
+          "limit": 3,
+          "type": "WEEK"
+        }
+      ],
+      "token": "c2q5to0cTdiZWE2bdkKUQsTs0cQRVkfHkSGoPeqrQWc"
+    }
+  ]
+}

--- a/AndroidSDKTests/src/test/resources/responses/local_caps_session_response.json
+++ b/AndroidSDKTests/src/test/resources/responses/local_caps_session_response.json
@@ -1,0 +1,23 @@
+{
+  "response": [
+    {
+      "regions": {},
+      "fileAttributes": {},
+      "success": true,
+      "messages": {},
+      "vars": {
+        "intVariable": 100,
+        "stringVariable": "test_string"
+      },
+      "variants": [],
+      "localCaps": [
+        {
+          "channel": "IN_APP",
+          "limit": 3,
+          "type": "SESSION"
+        }
+      ],
+      "token": "c2q5to0cTdiZWE2bdkKUQsTs0cQRVkfHkSGoPeqrQWc"
+    }
+  ]
+}

--- a/AndroidSDKTests/src/test/resources/responses/local_caps_week_response.json
+++ b/AndroidSDKTests/src/test/resources/responses/local_caps_week_response.json
@@ -1,0 +1,23 @@
+{
+  "response": [
+    {
+      "regions": {},
+      "fileAttributes": {},
+      "success": true,
+      "messages": {},
+      "vars": {
+        "intVariable": 100,
+        "stringVariable": "test_string"
+      },
+      "variants": [],
+      "localCaps": [
+        {
+          "channel": "IN_APP",
+          "limit": 3,
+          "type": "WEEK"
+        }
+      ],
+      "token": "c2q5to0cTdiZWE2bdkKUQsTs0cQRVkfHkSGoPeqrQWc"
+    }
+  ]
+}


### PR DESCRIPTION
What              | Where/Who
------------------|----------------------------------------
JIRA Issue        | [SDK-423](https://leanplum.atlassian.net/browse/SDK-423)
People Involved   | @hborisoff 

Add functionality to support in-app message caps, configurable in dashboard.
You can set limit for in-app messages per day, week, and session.
Check [documentation](https://leanplum.atlassian.net/wiki/spaces/E2/pages/2061271098/Global+In-app+Message+caps) about all details of the changes.

`Clock.java` class was added to wrap usages of time interfaces and allow easier unit testing. Currently only `ActionManager` is updated to use it.