### PR TITLE
Add handler for runActionNamed

### DIFF
--- a/AndroidSDKCore/src/main/java/com/leanplum/messagetemplates/controllers/AbstractPopupController.java
+++ b/AndroidSDKCore/src/main/java/com/leanplum/messagetemplates/controllers/AbstractPopupController.java
@@ -63,6 +63,11 @@ abstract class AbstractPopupController extends BaseController {
   }
 
   @Override
+  protected void runDismissAction() {
+    options.dismiss();
+  }
+
+  @Override
   void addMessageChildViews(RelativeLayout parent) {
     ImageView image = createBackgroundImageView(activity);
     parent.addView(image);

--- a/AndroidSDKCore/src/main/java/com/leanplum/messagetemplates/controllers/BaseController.java
+++ b/AndroidSDKCore/src/main/java/com/leanplum/messagetemplates/controllers/BaseController.java
@@ -117,6 +117,17 @@ abstract class BaseController extends Dialog {
    */
   abstract void applyWindowDecoration();
 
+  /**
+   * Calls ActionContext.runActionNamed for dismiss action.
+   */
+  protected abstract void runDismissAction();
+
+  @Override
+  public void onBackPressed() {
+    runDismissAction();
+    super.onBackPressed();
+  }
+
   @Override
   public void cancel() {
     if (isClosing) {
@@ -158,7 +169,10 @@ abstract class BaseController extends Dialog {
       closeLayout.setMargins(0, -SizeUtil.dp7, -SizeUtil.dp7, 0);
     }
     closeButton.setLayoutParams(closeLayout);
-    closeButton.setOnClickListener(clickedView -> cancel());
+    closeButton.setOnClickListener(clickedView -> {
+      runDismissAction();
+      cancel();
+    });
     return closeButton;
   }
 

--- a/AndroidSDKCore/src/main/java/com/leanplum/messagetemplates/controllers/RichHtmlController.java
+++ b/AndroidSDKCore/src/main/java/com/leanplum/messagetemplates/controllers/RichHtmlController.java
@@ -80,6 +80,14 @@ public class RichHtmlController extends BaseController {
   }
 
   @Override
+  protected void runDismissAction() {
+    // need to check state, because touches from banner sometimes trigger more than 1 action
+    if (!isClosing) {
+      richOptions.dismiss();
+    }
+  }
+
+  @Override
   protected void applyWindowDecoration() {
     if (isFullscreen())
       return;
@@ -242,6 +250,7 @@ public class RichHtmlController extends BaseController {
 
   private boolean handleCloseEvent(String url) {
     if (url.contains(richOptions.getCloseUrl())) {
+      runDismissAction();
       cancel();
       String queryComponentsFromUrl = queryComponentsFromUrl(url, "result");
       if (!TextUtils.isEmpty(queryComponentsFromUrl)) {
@@ -411,6 +420,7 @@ public class RichHtmlController extends BaseController {
 
       if (ev.getY() < top || ev.getY() > bottom || ev.getX() < left || ev.getX() > right) {
         if (richOptions.isHtmlTabOutsideToClose()) {
+          runDismissAction();
           cancel();
         }
         activity.dispatchTouchEvent(ev);

--- a/AndroidSDKCore/src/main/java/com/leanplum/messagetemplates/controllers/WebInterstitialController.java
+++ b/AndroidSDKCore/src/main/java/com/leanplum/messagetemplates/controllers/WebInterstitialController.java
@@ -57,6 +57,11 @@ public class WebInterstitialController extends BaseController {
   }
 
   @Override
+  protected void runDismissAction() {
+    webOptions.dismiss();
+  }
+
+  @Override
   boolean isFullscreen() {
     return true;
   }
@@ -106,6 +111,7 @@ public class WebInterstitialController extends BaseController {
 
   private boolean handleCloseEvent(String url) {
     if (url.contains(webOptions.getCloseUrl())) {
+      runDismissAction();
       cancel();
       String[] urlComponents = url.split("\\?");
       if (urlComponents.length > 1) {

--- a/AndroidSDKCore/src/main/java/com/leanplum/messagetemplates/options/BaseMessageOptions.java
+++ b/AndroidSDKCore/src/main/java/com/leanplum/messagetemplates/options/BaseMessageOptions.java
@@ -155,6 +155,10 @@ public abstract class BaseMessageOptions {
     context.runTrackedActionNamed(Args.ACCEPT_ACTION);
   }
 
+  public void dismiss() {
+    context.runActionNamed(Args.DISMISS_ACTION);
+  }
+
   public static ActionArgs toArgs(Context currentContext) {
     return new ActionArgs()
         .with(Args.TITLE_TEXT, Util.getApplicationName(currentContext))

--- a/AndroidSDKCore/src/main/java/com/leanplum/messagetemplates/options/RichHtmlOptions.java
+++ b/AndroidSDKCore/src/main/java/com/leanplum/messagetemplates/options/RichHtmlOptions.java
@@ -372,4 +372,8 @@ public class RichHtmlOptions {
     String templateName = getActionContext().getArgs().get(Values.HTML_TEMPLATE_PREFIX).toString();
     return templateName.toLowerCase().contains("banner") && !isHtmlTabOutsideToClose();
   }
+
+  public void dismiss() {
+    actionContext.runActionNamed(Args.DISMISS_ACTION);
+  }
 }

--- a/AndroidSDKCore/src/main/java/com/leanplum/messagetemplates/options/WebInterstitialOptions.java
+++ b/AndroidSDKCore/src/main/java/com/leanplum/messagetemplates/options/WebInterstitialOptions.java
@@ -36,11 +36,13 @@ public class WebInterstitialOptions {
   private String url;
   private String closeUrl;
   private boolean hasDismissButton;
+  private ActionContext actionContext;
 
   public WebInterstitialOptions(ActionContext context) {
     this.setUrl(context.stringNamed(Args.URL));
     this.setHasDismissButton(context.booleanNamed(Args.HAS_DISMISS_BUTTON));
     this.setCloseUrl(context.stringNamed(Args.CLOSE_URL));
+    this.actionContext = context;
   }
 
   public String getUrl() {
@@ -65,6 +67,10 @@ public class WebInterstitialOptions {
 
   private void setCloseUrl(String closeUrl) {
     this.closeUrl = closeUrl;
+  }
+
+  public void dismiss() {
+    actionContext.runActionNamed(Args.DISMISS_ACTION);
   }
 
   public static ActionArgs toArgs() {


### PR DESCRIPTION
What              | Where/Who
------------------|----------------------------------------
JIRA Issue        | [SDK-455](https://leanplum.atlassian.net/browse/SDK-445)
People Involved   | @hborisoff 

This change enables callback to be invoked when in-app message actions are run.
For example - `Accept action`, `Select button 1 action`.

Added `Dismiss action` to be run for some of the in-app templates, where appropriate.

Example usage:

```
Leanplum.onAction("Center Popup", new ActionCallback() {
    @Override
    public boolean onResponse(ActionContext context) {
        context.setActionNamedHandler(new ActionCallback() {
            @Override
            public boolean onResponse(ActionContext context) {
                String actionName = context.actionName(); // "Accept action"
                String parentActionName = context.getParentContext().actionName(); // "Center Popup"
                return true;
            }
        });
        return true;
    }
});
```
