### PR TITLE
Fix NullPointerException from Leanplum.messageBodyFromContext

### DIFF
--- a/AndroidSDKCore/src/main/java/com/leanplum/Leanplum.java
+++ b/AndroidSDKCore/src/main/java/com/leanplum/Leanplum.java
@@ -1336,6 +1336,10 @@ public class Leanplum {
   @VisibleForTesting
   public static String messageBodyFromContext(ActionContext actionContext) {
     Object messageObject =  actionContext.getArgs().get("Message");
+    if (messageObject == null) {
+      return null;
+    }
+
     if (messageObject instanceof String) {
       return (String) messageObject;
     } else {


### PR DESCRIPTION
What              | Where/Who
------------------|----------------------------------------
People Involved   | @hborisoff 

`Leanplum.messageBodyFromContext` is reported to crash in some client apps.
This change fixes the `NullPointerException`.