### PR TITLE
Integrate FCM 22.0.0.

### DIFF
--- a/AndroidSDKFcm/build.gradle
+++ b/AndroidSDKFcm/build.gradle
@@ -34,7 +34,7 @@ dependencies {
     api project(':AndroidSDKPush')
 
     // Provided dependencies are optional dependencies and will not show up in pom file.
-    compileOnly('com.google.firebase:firebase-messaging:[17.3.4, 21.1.0]') {
+    compileOnly('com.google.firebase:firebase-messaging:22.0.0') {
         exclude module: 'support-v4'
     }
 }

--- a/AndroidSDKFcm/src/main/java/com/leanplum/LeanplumFcmProvider.java
+++ b/AndroidSDKFcm/src/main/java/com/leanplum/LeanplumFcmProvider.java
@@ -25,8 +25,7 @@ import android.text.TextUtils;
 
 import com.google.android.gms.tasks.OnCompleteListener;
 import com.google.android.gms.tasks.Task;
-import com.google.firebase.iid.FirebaseInstanceId;
-import com.google.firebase.iid.InstanceIdResult;
+import com.google.firebase.messaging.FirebaseMessaging;
 import com.leanplum.internal.Constants;
 import com.leanplum.internal.Log;
 
@@ -58,17 +57,17 @@ class LeanplumFcmProvider extends LeanplumCloudMessagingProvider {
 
   @Override
   public void updateRegistrationId() {
-    FirebaseInstanceId.getInstance().getInstanceId()
-        .addOnCompleteListener(new OnCompleteListener<InstanceIdResult>() {
+    FirebaseMessaging.getInstance().getToken()
+        .addOnCompleteListener(new OnCompleteListener<String>() {
           @Override
-          public void onComplete(@NonNull Task<InstanceIdResult> task) {
+          public void onComplete(@NonNull Task<String> task) {
             if (!task.isSuccessful()) {
               Exception exc = task.getException();
-              Log.e("getInstanceId failed:\n" + Log.getStackTraceString(exc));
+              Log.e("getToken failed:\n" + Log.getStackTraceString(exc));
               return;
             }
-            // Get new Instance ID token
-            String tokenId = task.getResult().getToken();
+            // Get new Firebase Messaging token
+            String tokenId = task.getResult();
             if (!TextUtils.isEmpty(tokenId)) {
                 setRegistrationId(tokenId);
               }
@@ -79,7 +78,7 @@ class LeanplumFcmProvider extends LeanplumCloudMessagingProvider {
   @Override
   public void unregister() {
     try {
-      FirebaseInstanceId.getInstance().deleteInstanceId();
+      FirebaseMessaging.getInstance().deleteToken();
       Log.i("Application was unregistered from FCM.");
     } catch (Exception e) {
       Log.e("Failed to unregister from FCM.");


### PR DESCRIPTION
What              | Where/Who
------------------|----------------------------------------
JIRA Issue        | N/A
People Involved   | Just me

[Notes on PR descriptions](https://leanplum.atlassian.net/wiki/spaces/PR/pages/288424408/Creating+a+GitHub+Pull+Request)

## Background
`firebase-messaging` 22.0.0 deprecates the [`FirebaseInstanceId`](https://firebase.google.com/docs/reference/android/com/google/firebase/iid/FirebaseInstanceId) class, which is used by `LeanplumFcmProvider`. This causes a crash in apps that implement `firebase-messaging` 22.0.0 together with Leanplum 5.7.0. 
  
## Implementation
This PR implements `firebase-messaging` 22.0.0 by changing the references to `FirebaseInstanceId` in `LeanplumFcmProvider` to `FirebaseMessaging`.

## Testing steps
All tests should still pass, including `LeanplumPushServiceTest`. Moreover, this change successfully sets a push token for our device, visible on Leanplum's web client. We also receive push notifications as expected.  

## Is this change backwards-compatible?  
Unfortunately, this change is not backwards-compatible with versions of `firebase-messaging` before 22.0.0. Please let me know if you want to accommodate for that, and the preferred way of doing so. I will try to implement your suggestions.
