### PR TITLE
Android 12 trampoline restrictions

### DIFF
--- a/AndroidSDKCore/src/main/java/com/leanplum/internal/ActionManager.java
+++ b/AndroidSDKCore/src/main/java/com/leanplum/internal/ActionManager.java
@@ -31,6 +31,7 @@ import com.leanplum.ActionContext.ContextualValues;
 import com.leanplum.Leanplum;
 import com.leanplum.LocationManager;
 import com.leanplum.callbacks.ActionCallback;
+import com.leanplum.internal.Constants.Defaults;
 import com.leanplum.utils.SharedPreferencesUtil;
 
 import java.util.HashMap;
@@ -58,7 +59,6 @@ public class ActionManager {
   public static final String HELD_BACK_ACTION_NAME = "__held_back";
   private static final String LEANPLUM_LOCAL_PUSH_HELPER =
       "com.leanplum.internal.LeanplumLocalPushHelper";
-  private static final String PREFERENCES_NAME = "__leanplum_messaging__";
   private static LocationManager locationManager;
   private static boolean loggedLocationManagerFailure = false;
 
@@ -157,7 +157,7 @@ public class ActionManager {
           // Get existing eta and clear notification from preferences.
           Context context = Leanplum.getContext();
           SharedPreferences preferences = context.getSharedPreferences(
-              PREFERENCES_NAME, Context.MODE_PRIVATE);
+              Defaults.MESSAGING_PREF_NAME, Context.MODE_PRIVATE);
           String preferencesKey = String.format(Constants.Defaults.LOCAL_NOTIFICATION_KEY,
               messageId);
           long existingEta = preferences.getLong(preferencesKey, 0L);
@@ -193,7 +193,7 @@ public class ActionManager {
     }
     Context context = Leanplum.getContext();
     SharedPreferences preferences = context.getSharedPreferences(
-        PREFERENCES_NAME, Context.MODE_PRIVATE);
+        Defaults.MESSAGING_PREF_NAME, Context.MODE_PRIVATE);
     String savedValue = preferences.getString(
         String.format(Constants.Defaults.MESSAGE_IMPRESSION_OCCURRENCES_KEY, messageId),
         "{}");
@@ -205,7 +205,7 @@ public class ActionManager {
   public void saveMessageImpressionOccurrences(Map<String, Number> occurrences, String messageId) {
     Context context = Leanplum.getContext();
     SharedPreferences preferences = context.getSharedPreferences(
-        PREFERENCES_NAME, Context.MODE_PRIVATE);
+        Defaults.MESSAGING_PREF_NAME, Context.MODE_PRIVATE);
     SharedPreferences.Editor editor = preferences.edit();
     editor.putString(
         String.format(Constants.Defaults.MESSAGE_IMPRESSION_OCCURRENCES_KEY, messageId),
@@ -221,7 +221,7 @@ public class ActionManager {
     }
     Context context = Leanplum.getContext();
     SharedPreferences preferences = context.getSharedPreferences(
-        PREFERENCES_NAME, Context.MODE_PRIVATE);
+        Defaults.MESSAGING_PREF_NAME, Context.MODE_PRIVATE);
     int savedValue = preferences.getInt(
         String.format(Constants.Defaults.MESSAGE_TRIGGER_OCCURRENCES_KEY, messageId), 0);
     messageTriggerOccurrences.put(messageId, savedValue);
@@ -231,7 +231,7 @@ public class ActionManager {
   public void saveMessageTriggerOccurrences(int occurrences, String messageId) {
     Context context = Leanplum.getContext();
     SharedPreferences preferences = context.getSharedPreferences(
-        PREFERENCES_NAME, Context.MODE_PRIVATE);
+        Defaults.MESSAGING_PREF_NAME, Context.MODE_PRIVATE);
     SharedPreferences.Editor editor = preferences.edit();
     editor.putInt(
         String.format(Constants.Defaults.MESSAGE_TRIGGER_OCCURRENCES_KEY, messageId), occurrences);
@@ -246,7 +246,7 @@ public class ActionManager {
     // 1. Must not be muted.
     Context context = Leanplum.getContext();
     SharedPreferences preferences = context.getSharedPreferences(
-        PREFERENCES_NAME, Context.MODE_PRIVATE);
+        Defaults.MESSAGING_PREF_NAME, Context.MODE_PRIVATE);
     if (preferences.getBoolean(
         String.format(Constants.Defaults.MESSAGE_MUTED_KEY, messageId), false)) {
       return result;
@@ -558,7 +558,7 @@ public class ActionManager {
     if (messageId != null) {
       Context context = Leanplum.getContext();
       SharedPreferences preferences = context.getSharedPreferences(
-          PREFERENCES_NAME, Context.MODE_PRIVATE);
+          Defaults.MESSAGING_PREF_NAME, Context.MODE_PRIVATE);
       SharedPreferences.Editor editor = preferences.edit();
       editor.putBoolean(
           String.format(Constants.Defaults.MESSAGE_MUTED_KEY, messageId),
@@ -661,7 +661,7 @@ public class ActionManager {
 
     Context context = Leanplum.getContext();
     SharedPreferences prefs =
-        context.getSharedPreferences(PREFERENCES_NAME, Context.MODE_PRIVATE);
+        context.getSharedPreferences(Defaults.MESSAGING_PREF_NAME, Context.MODE_PRIVATE);
     Map<String, ?> all = prefs.getAll();
 
     int occurrenceCount = 0;

--- a/AndroidSDKCore/src/main/java/com/leanplum/internal/Clock.java
+++ b/AndroidSDKCore/src/main/java/com/leanplum/internal/Clock.java
@@ -29,6 +29,8 @@ import java.util.Date;
  * mock in unit tests.
  */
 public abstract class Clock {
+  public static final long DAY_MILLIS = 24 * 60 * 60 * 1000;
+  public static final long MONTH_MILLIS = 30 * DAY_MILLIS;
 
   public static final Clock SYSTEM = new Clock() {
     @Override
@@ -68,4 +70,13 @@ public abstract class Clock {
    */
   @NonNull
   abstract Date newDate();
+
+  /**
+   * Checks if time is not from more than 30 days ago.
+   *
+   * @return True if elapsed time is less than a month.
+   */
+  public boolean lessThanMonthAgo(long timeInMillis) {
+    return currentTimeMillis() - timeInMillis < MONTH_MILLIS;
+  }
 }

--- a/AndroidSDKCore/src/main/java/com/leanplum/internal/Constants.java
+++ b/AndroidSDKCore/src/main/java/com/leanplum/internal/Constants.java
@@ -79,6 +79,7 @@ public class Constants {
     public static final String TOKEN_KEY = "__leanplum_token";
     public static final String MESSAGES_KEY = "__leanplum_messages";
     public static final String REGIONS_KEY = "regions";
+    public static final String MESSAGING_PREF_NAME = "__leanplum_messaging__";
     public static final String MESSAGE_TRIGGER_OCCURRENCES_KEY =
         "__leanplum_message_trigger_occurrences_%s";
     public static final String MESSAGE_IMPRESSION_OCCURRENCES_KEY =
@@ -193,6 +194,7 @@ public class Constants {
     public static final String PUSH_MESSAGE_SILENT_TRACK = "lp_silent_track";
     public static final String PUSH_SENT_TIME = "lp_sent_time";
     public static final String PUSH_OCCURRENCE_ID = "lp_occurrence_id";
+    public static final String LOCAL_PUSH_OCCURRENCE_ID = "internal_occurrence_id";
     public static final String REGION = "region";
     public static final String REGION_STATE = "regionState";
     public static final String REGIONS = "regions";

--- a/AndroidSDKCore/src/main/java/com/leanplum/utils/BuildUtil.java
+++ b/AndroidSDKCore/src/main/java/com/leanplum/utils/BuildUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017, Leanplum, Inc. All rights reserved.
+ * Copyright 2021, Leanplum, Inc. All rights reserved.
  *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
@@ -40,6 +40,18 @@ public class BuildUtil {
    */
   public static boolean isNotificationChannelSupported(Context context) {
     return Build.VERSION.SDK_INT >= 26 && getTargetSdkVersion(context) >= 26;
+  }
+
+  /**
+   * Checks whether notification trampolines are not supported.
+   * Targeting Android 12 means you cannot use a service or broadcast receiver as a trampoline to
+   * start an activity. The activity must be started immediately when notification is clicked.
+   *
+   * @param context The application context.
+   * @return True if notification trampolines are not supported.
+   */
+  public static boolean shouldDisableTrampolines(Context context) {
+    return Build.VERSION.SDK_INT >= 31 && getTargetSdkVersion(context) >= 31;
   }
 
   /**

--- a/AndroidSDKPush/src/main/java/com/leanplum/LeanplumLocalPushListenerService.java
+++ b/AndroidSDKPush/src/main/java/com/leanplum/LeanplumLocalPushListenerService.java
@@ -29,8 +29,10 @@ import androidx.annotation.NonNull;
 import androidx.core.app.JobIntentService;
 
 import com.leanplum.internal.Constants;
+import com.leanplum.internal.Constants.Keys;
 import com.leanplum.internal.Log;
 import com.leanplum.internal.Util;
+import java.util.UUID;
 
 /**
  * Listener Service for local push notifications.
@@ -51,6 +53,7 @@ public class LeanplumLocalPushListenerService extends JobIntentService {
         Intent intent = new Intent();
         intent.putExtra(LeanplumJobStartReceiver.LP_EXTRA_SERVICE_CLASS, LP_CLASS_NAME);
         intent.putExtra(LeanplumJobStartReceiver.LP_EXTRA_JOB_ID, LP_JOB_ID);
+        intent.putExtra(Keys.LOCAL_PUSH_OCCURRENCE_ID, UUID.randomUUID().toString());
         intent.setClass(context, LeanplumJobStartReceiver.class);
         return intent;
     }

--- a/AndroidSDKPush/src/main/java/com/leanplum/LeanplumPushService.java
+++ b/AndroidSDKPush/src/main/java/com/leanplum/LeanplumPushService.java
@@ -36,6 +36,8 @@ import android.net.Uri;
 import android.os.Bundle;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.WorkerThread;
+import com.leanplum.LeanplumActivityHelper.NoTrampolinesLifecycleCallbacks;
 import com.leanplum.callbacks.VariablesChangedCallback;
 import com.leanplum.internal.ActionManager;
 import com.leanplum.internal.Constants;
@@ -44,6 +46,8 @@ import com.leanplum.internal.Constants.Params;
 import com.leanplum.internal.JsonConverter;
 import com.leanplum.internal.LeanplumInternal;
 import com.leanplum.internal.Log;
+import com.leanplum.internal.OperationQueue;
+import com.leanplum.internal.PushActionPersistenceKt;
 import com.leanplum.internal.Request.RequestType;
 import com.leanplum.internal.RequestBuilder;
 import com.leanplum.internal.Request;
@@ -52,6 +56,7 @@ import com.leanplum.internal.Util;
 import com.leanplum.internal.VarCache;
 import com.leanplum.utils.BuildUtil;
 
+import java.util.UUID;
 import org.json.JSONException;
 import org.json.JSONObject;
 
@@ -322,11 +327,7 @@ public class LeanplumPushService {
       return;
     }
 
-    Intent intent = new Intent(context, LeanplumPushReceiver.class);
-    intent.addCategory("lpAction");
-    intent.putExtras(message);
-    PendingIntent contentIntent = PendingIntent.getBroadcast(context.getApplicationContext(),
-        new Random().nextInt(), intent, BuildUtil.createIntentFlags(0));
+    PendingIntent contentIntent = createContentIntent(context, message);
 
     String title = Util.getApplicationName(context.getApplicationContext());
     if (message.getString("title") != null) {
@@ -433,6 +434,77 @@ public class LeanplumPushService {
     }
   }
 
+  /**
+   * Creates the notification's content intent for this message.
+   */
+  private static PendingIntent createContentIntent(Context context, Bundle message) {
+    PendingIntent contentIntent;
+
+    if (BuildUtil.shouldDisableTrampolines(context)) {
+      Intent intent = createActivityIntent(context, message);
+      contentIntent = PendingIntent.getActivity(
+          context,
+          new Random().nextInt(),
+          intent,
+          BuildUtil.createIntentFlags(PendingIntent.FLAG_UPDATE_CURRENT));
+    } else {
+      Intent intent = createBroadcastIntent(context, message);
+      contentIntent = PendingIntent.getBroadcast(
+          context.getApplicationContext(),
+          new Random().nextInt(),
+          intent,
+          BuildUtil.createIntentFlags(0));
+    }
+    return contentIntent;
+  }
+
+  /**
+   * Creates intent object for LeanplumPushReceiver which will forward execution to either client
+   * or Leanplum code.
+   */
+  private static Intent createBroadcastIntent(Context context, Bundle message) {
+    Intent intent = new Intent(context, LeanplumPushReceiver.class);
+    intent.addCategory("lpAction");
+    intent.putExtras(message);
+    return intent;
+  }
+
+  /**
+   * Creates intent object to start activity based on the message payload.
+   */
+  @TargetApi(31)
+  private static Intent createActivityIntent(Context context, Bundle message) {
+
+    // 'Open URL'
+    String action = message.getString(Keys.PUSH_MESSAGE_ACTION);
+    if (action != null && action.contains(OPEN_URL)) {
+      Intent deepLinkIntent = getDeepLinkIntent(message);
+      if (deepLinkIntent != null) {
+        resolveIntentActivity(context, deepLinkIntent);
+        String messageId = LeanplumPushService.getMessageId(message);
+        if (messageId != null) {
+          deepLinkIntent.putExtras(message); // payload will be used to track the open event
+        }
+        return deepLinkIntent;
+      }
+    }
+
+    // 'Open App'
+    Intent actionIntent = getActionIntent(context);
+    if (actionIntent == null) {
+      return null;
+    }
+    actionIntent.putExtras(message);
+    actionIntent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP | Intent.FLAG_ACTIVITY_NEW_TASK);
+
+    // 'Chain to message'
+
+    // In this case handling of push Open Action will be run from activity lifecycle callbacks and
+    // will call onActivityNotificationClick(context, bundle)
+
+    return actionIntent;
+  }
+
   static void openNotification(Context context, Intent intent) {
     // Pre handles push notification.
     Bundle notification = preHandlePushNotification(context, intent);
@@ -474,6 +546,42 @@ public class LeanplumPushService {
     }
     // Post handles push notification.
     performPushNotificationAction(notification);
+  }
+
+  /**
+   * Called by reflection from {@link NoTrampolinesLifecycleCallbacks} to track events and perform
+   * push notification action.
+   */
+  static void onActivityNotificationClick(@NonNull Bundle notification) {
+    String occurrenceId;
+    if (notification.containsKey(Keys.PUSH_OCCURRENCE_ID)) {
+      occurrenceId = (String) notification.get(Keys.PUSH_OCCURRENCE_ID);
+    } else if (notification.containsKey(Keys.LOCAL_PUSH_OCCURRENCE_ID)){
+      occurrenceId = (String) notification.get(Keys.LOCAL_PUSH_OCCURRENCE_ID);
+    } else {
+      Log.i("Skipping execution of Open Action because occurrenceId is missing.");
+      return;
+    }
+
+    if (PushActionPersistenceKt.isOpened(occurrenceId)) {
+      Log.i("Open Action from activity intent is already executed.");
+    } else {
+      Log.d("Executing Open Action from push notification.");
+      PushActionPersistenceKt.recordOpenAction(occurrenceId);
+      PushTracking.trackOpen(notification);
+
+      if (getDeepLinkIntent(notification) != null) {
+        // track Open event
+        String messageId = LeanplumPushService.getMessageId(notification);
+        if (messageId != null) {
+          ActionContext actionContext = new ActionContext(
+              ActionManager.PUSH_NOTIFICATION_ACTION_NAME, null, messageId);
+          actionContext.track(OPEN_ACTION, 0.0, null);
+        }
+        return;
+      }
+      performPushNotificationAction(notification);
+    }
   }
 
   /**

--- a/AndroidSDKPush/src/main/java/com/leanplum/internal/LeanplumLocalPushHelper.java
+++ b/AndroidSDKPush/src/main/java/com/leanplum/internal/LeanplumLocalPushHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, Leanplum, Inc. All rights reserved.
+ * Copyright 2021, Leanplum, Inc. All rights reserved.
  *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
@@ -43,7 +43,6 @@ import java.util.Map;
  * @author Anna Orlova
  */
 class LeanplumLocalPushHelper {
-  private static final String PREFERENCES_NAME = "__leanplum_messaging__";
 
   /**
    * Schedule local push notification. This method will call by reflection from AndroidSDKCore.
@@ -63,7 +62,7 @@ class LeanplumLocalPushHelper {
       // If there's already one scheduled before the eta, discard this.
       // Otherwise, discard the scheduled one.
       SharedPreferences preferences = context.getSharedPreferences(
-          PREFERENCES_NAME, Context.MODE_PRIVATE);
+          Constants.Defaults.MESSAGING_PREF_NAME, Context.MODE_PRIVATE);
       long existingEta = preferences.getLong(String.format(
           Constants.Defaults.LOCAL_NOTIFICATION_KEY, messageId), 0L);
       if (existingEta > 0L && existingEta > System.currentTimeMillis()) {

--- a/AndroidSDKPush/src/main/java/com/leanplum/internal/PushActionPersistence.kt
+++ b/AndroidSDKPush/src/main/java/com/leanplum/internal/PushActionPersistence.kt
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2021, Leanplum, Inc. All rights reserved.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.leanplum.internal
+
+import android.content.Context
+import com.leanplum.Leanplum
+import com.leanplum.internal.Constants.Defaults
+
+private const val PREF_KEY = "__leanplum_push_open_actions"
+
+private val records: MutableMap<String, Long> by lazy {
+    val saved = load()
+    val youngerThanMonth = saved.filterValues { Clock.getInstance().lessThanMonthAgo(it) }
+
+    if (youngerThanMonth.size < saved.size) {
+        save(youngerThanMonth)
+    }
+    youngerThanMonth as MutableMap<String, Long>
+}
+
+private fun load(): Map<String, Long> {
+    val context = Leanplum.getContext() ?: return mutableMapOf()
+    val prefs = context.getSharedPreferences(Defaults.MESSAGING_PREF_NAME, Context.MODE_PRIVATE)
+    val savedValue = prefs.getString(PREF_KEY, "{}")
+    return CollectionUtil.uncheckedCast(JsonConverter.fromJson(savedValue))
+}
+
+private fun save(records: Map<String, Long>) {
+    val context = Leanplum.getContext() ?: return
+    val prefs = context.getSharedPreferences(Defaults.MESSAGING_PREF_NAME, Context.MODE_PRIVATE)
+    prefs.edit().putString(PREF_KEY, JsonConverter.toJson(records)).apply()
+}
+
+fun recordOpenAction(occurrenceId: String) {
+    records[occurrenceId] = Clock.getInstance().currentTimeMillis()
+    save(records)
+}
+
+fun isOpened(occurrenceId: String) = records.contains(occurrenceId)

--- a/AndroidSDKTests/src/test/java/com/leanplum/LeanplumActionContextTest.java
+++ b/AndroidSDKTests/src/test/java/com/leanplum/LeanplumActionContextTest.java
@@ -26,6 +26,7 @@ import android.content.SharedPreferences;
 import com.google.common.collect.ImmutableMap;
 import com.leanplum.__setup.AbstractTest;
 import com.leanplum.internal.Constants;
+import com.leanplum.internal.Constants.Defaults;
 import com.leanplum.internal.JsonConverter;
 import com.leanplum.internal.LeanplumInternal;
 import com.leanplum.internal.Log;
@@ -241,7 +242,7 @@ public class LeanplumActionContextTest extends AbstractTest {
         actionContext.muteFutureMessagesOfSameKind();
 
         SharedPreferences preferences = RuntimeEnvironment.application.getSharedPreferences(
-                "__leanplum_messaging__", Context.MODE_PRIVATE);
+            Defaults.MESSAGING_PREF_NAME, Context.MODE_PRIVATE);
         boolean muted = preferences.getBoolean(String.format(Constants.Defaults.MESSAGE_MUTED_KEY,
                 "messageId"), false);
         assertTrue(muted);


### PR DESCRIPTION
What              | Where/Who
------------------|----------------------------------------
JIRA Issue        | [SDK-491](https://leanplum.atlassian.net/browse/SDK-491)
People Involved   | @hborisoff 


## Background
This change makes the SDK compliant with [Android 12 trampoline](https://developer.android.com/about/versions/12/behavior-changes-12#notification-trampolines) restrictions.

Until now a click on notification is handled in `LeanplumPushReceiver` which decides what to do next and what activity should be started. With version 12 notifications must start activity directly. This results in a change in the `LeanplumPushService.handleNotification` to assign the correct activity to the notification intent and bypass the `LeanplumPushReceiver`.

If we bypass the receiver we can't make the correct tracking of the `Push Opened` and `Open` events and also we can't run the `Open Action` of the message. To solve it the message is attached as an extra in the notification intent and it is processed in the `ActivityLifecycleCallbacks` object.

Important to note is that if `Open Action` of the push notification is `Open URL` which opens another app this will result in not tracking the `Push Opened` and `Open` events because we can't get feedback when the user clicks the notification.

Another important note is that when main activity is set as `singleTop` the client must call `setIntent(intent)` inside `Activity.onNewIntent` method to allow the lifecycle callback to work properly.

Check the docs[TODO link] for further details about the implementation.
