### PR TITLE
Add `setLocale` method

### DIFF
--- a/AndroidSDKCore/src/main/java/com/leanplum/Leanplum.java
+++ b/AndroidSDKCore/src/main/java/com/leanplum/Leanplum.java
@@ -111,6 +111,7 @@ public class Leanplum {
   private static LeanplumDeviceIdMode deviceIdMode = LeanplumDeviceIdMode.MD5_MAC_ADDRESS;
   private static String customDeviceId;
   private static String customAppVersion = null;
+  private static String customLocale = null;
   private static boolean userSpecifiedDeviceId;
   private static boolean locationCollectionEnabled = true;
   private static volatile boolean pushDeliveryTrackingEnabled = true;
@@ -326,6 +327,18 @@ public class Leanplum {
 
     customDeviceId = deviceId;
     userSpecifiedDeviceId = true;
+  }
+
+  /**
+   * Sets a custom locale.
+   * Must be called before Leanplum.start().
+   */
+  public static void setLocale(String locale) {
+    if (TextUtils.isEmpty(locale)) {
+      Log.i("setLocale - Empty locale parameter provided.");
+    }
+
+    customLocale = locale;
   }
 
   /**
@@ -666,6 +679,11 @@ public class Leanplum {
       versionName = "";
     }
 
+    String locale = Util.getLocale();
+    if (!TextUtils.isEmpty(customLocale)) {
+      locale = customLocale;
+    }
+
     TimeZone localTimeZone = TimeZone.getDefault();
     Date now = new Date();
     int timezoneOffsetSeconds = localTimeZone.getOffset(now.getTime()) / 1000;
@@ -698,7 +716,7 @@ public class Leanplum {
     }
     params.put(Constants.Keys.TIMEZONE, localTimeZone.getID());
     params.put(Constants.Keys.TIMEZONE_OFFSET_SECONDS, Integer.toString(timezoneOffsetSeconds));
-    params.put(Constants.Keys.LOCALE, Util.getLocale());
+    params.put(Constants.Keys.LOCALE, locale);
     params.put(Constants.Keys.COUNTRY, Constants.Values.DETECT);
     params.put(Constants.Keys.REGION, Constants.Values.DETECT);
     params.put(Constants.Keys.CITY, Constants.Values.DETECT);

--- a/AndroidSDKCore/src/main/java/com/leanplum/Leanplum.java
+++ b/AndroidSDKCore/src/main/java/com/leanplum/Leanplum.java
@@ -330,8 +330,7 @@ public class Leanplum {
   }
 
   /**
-   * Sets a custom locale.
-   * Must be called before Leanplum.start().
+   * Sets a custom locale. You should call this before {@link Leanplum#start}.
    */
   public static void setLocale(String locale) {
     if (TextUtils.isEmpty(locale)) {


### PR DESCRIPTION
Introduce `setLocale(locale: String)` in order to set a custom locale string.

Problem with this approach is that `setLocale(...)` needs to be called before `Leanplum.start(...)` method.