### PR TITLE
Validate advertising id

### DIFF
--- a/AndroidSDKCore/src/main/java/com/leanplum/internal/Constants.java
+++ b/AndroidSDKCore/src/main/java/com/leanplum/internal/Constants.java
@@ -43,6 +43,7 @@ public class Constants {
   public static final String LEANPLUM_PACKAGE_IDENTIFIER = BuildConfig.LEANPLUM_PACKAGE_IDENTIFIER;
   static final String INVALID_MAC_ADDRESS = "02:00:00:00:00:00";
   static final String INVALID_MAC_ADDRESS_HASH = "0f607264fc6318a92b9e13c65db7cd3c";
+  static final String INVALID_UUID = "00000000-0000-0000-0000-000000000000";
 
   /**
    * From very old versions of the SDK, leading zeros were stripped from the mac address.

--- a/AndroidSDKCore/src/main/java/com/leanplum/internal/Util.java
+++ b/AndroidSDKCore/src/main/java/com/leanplum/internal/Util.java
@@ -259,6 +259,10 @@ public class Util {
       Log.d(logPrefix + "(sentinel): " + userId);
       return false;
     }
+    if (Constants.INVALID_UUID.equals(userId)) {
+      Log.d(logPrefix + "(zero uuid): " + userId);
+      return false;
+    }
     if (userId.length() > Constants.MAX_USER_ID_LENGTH) {
       Log.d(logPrefix + "(too long): " + userId);
       return false;
@@ -279,7 +283,8 @@ public class Util {
     if (deviceId == null || deviceId.isEmpty() ||
         Constants.INVALID_ANDROID_ID.equals(deviceId) ||
         Constants.INVALID_MAC_ADDRESS_HASH.equals(deviceId) ||
-        Constants.OLD_INVALID_MAC_ADDRESS_HASH.equals(deviceId)) {
+        Constants.OLD_INVALID_MAC_ADDRESS_HASH.equals(deviceId) ||
+        Constants.INVALID_UUID.equals(deviceId)) {
       Log.d(logPrefix + "(sentinel): " + deviceId);
       return false;
     }


### PR DESCRIPTION
What              | Where/Who
------------------|----------------------------------------
JIRA Issue        | [SDK-604](https://leanplum.atlassian.net/browse/SDK-604)
People Involved   | @hborisoff 

Validate advertising ID for zero value.
Check [documentation](https://developers.google.com/android/reference/com/google/android/gms/ads/identifier/AdvertisingIdClient.Info#public-string-getid) when such value is possible.

Saved value of device ID or user ID will be repaired if is invalid UUID.
