### PR TITLE
Configurable API endpoint

### DIFF
--- a/AndroidSDKCore/src/main/java/com/leanplum/Leanplum.java
+++ b/AndroidSDKCore/src/main/java/com/leanplum/Leanplum.java
@@ -56,6 +56,7 @@ import com.leanplum.internal.RequestBuilder;
 import com.leanplum.internal.RequestSender;
 import com.leanplum.internal.RequestSenderTimer;
 import com.leanplum.internal.RequestUtil;
+import com.leanplum.internal.Socket;
 import com.leanplum.internal.Util;
 import com.leanplum.internal.Util.DeviceIdInfo;
 import com.leanplum.internal.VarCache;
@@ -124,25 +125,23 @@ public class Leanplum {
   }
 
   /**
-   * Optional. Sets the API server. The API path is of the form http[s]://hostname/servletName
+   * Optional. Sets the API server. The API path is of the form http[s]://hostName/apiPath
    *
    * @param hostName The name of the API host, such as www.leanplum.com
-   * @param servletName The name of the API servlet, such as api
+   * @param apiPath The name of the API servlet, such as api
    * @param ssl Whether to use SSL
    */
-  public static void setApiConnectionSettings(String hostName, String servletName, boolean ssl) {
+  public static void setApiConnectionSettings(String hostName, String apiPath, boolean ssl) {
     if (TextUtils.isEmpty(hostName)) {
-      Log.i("setApiConnectionSettings - Empty hostname parameter provided.");
+      Log.i("setApiConnectionSettings - Empty hostName parameter provided.");
       return;
     }
-    if (TextUtils.isEmpty(servletName)) {
-      Log.i("setApiConnectionSettings - Empty servletName parameter provided.");
+    if (TextUtils.isEmpty(apiPath)) {
+      Log.i("setApiConnectionSettings - Empty apiPath parameter provided.");
       return;
     }
 
-    Constants.API_HOST_NAME = hostName;
-    Constants.API_SERVLET = servletName;
-    Constants.API_SSL = ssl;
+    APIConfig.getInstance().setApiConfig(hostName, apiPath, ssl);
   }
 
   /**
@@ -161,8 +160,11 @@ public class Leanplum {
       return;
     }
 
-    Constants.SOCKET_HOST = hostName;
-    Constants.SOCKET_PORT = port;
+    String currentSocketHost = APIConfig.getInstance().getSocketHost();
+    if (!hostName.equals(currentSocketHost)) {
+      APIConfig.getInstance().setSocketConfig(hostName, port);
+      LeanplumInternal.connectDevelopmentServer();
+    }
   }
 
   /**
@@ -582,7 +584,7 @@ public class Leanplum {
         LeanplumInternal.getUserAttributeChanges().add(validAttributes);
       }
 
-      APIConfig.getInstance().loadToken();
+      APIConfig.getInstance(); // load prefs
       VarCache.setSilent(true);
       VarCache.loadDiffs();
       VarCache.setSilent(false);
@@ -825,7 +827,6 @@ public class Leanplum {
 
         String token = response.optString(Constants.Keys.TOKEN, null);
         APIConfig.getInstance().setToken(token);
-        APIConfig.getInstance().saveToken();
 
         applyContentInResponse(response);
 

--- a/AndroidSDKCore/src/main/java/com/leanplum/internal/APIConfig.java
+++ b/AndroidSDKCore/src/main/java/com/leanplum/internal/APIConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, Leanplum, Inc. All rights reserved.
+ * Copyright 2022, Leanplum, Inc. All rights reserved.
  *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
@@ -26,22 +26,33 @@ import android.content.SharedPreferences;
 import android.text.TextUtils;
 import androidx.annotation.VisibleForTesting;
 import com.leanplum.Leanplum;
+import com.leanplum.internal.Constants.Defaults;
 import com.leanplum.utils.SharedPreferencesUtil;
 import java.util.Map;
 
 public class APIConfig {
   private static final APIConfig INSTANCE = new APIConfig();
 
+  // non persistable data
   private String appId;
   private String accessKey;
   private String deviceId;
   private String userId;
+
+  // persistable data
+
   // The token is saved primarily for legacy SharedPreferences decryption. This could
   // likely be removed in the future.
   private String token;
+  private String apiHost = "api.leanplum.com";
+  private String apiPath = "api";
+  private boolean apiSSL = true;
+  private String socketHost = "dev.leanplum.com";
+  private int socketPort = 443;
 
   @VisibleForTesting
   APIConfig() {
+    load();
   }
 
   public static APIConfig getInstance() {
@@ -55,10 +66,6 @@ public class APIConfig {
     if (!TextUtils.isEmpty(accessKey)) {
       this.accessKey = accessKey.trim();
     }
-  }
-
-  public void loadToken(String token) {
-    this.token = token;
   }
 
   public String appId() {
@@ -91,25 +98,50 @@ public class APIConfig {
 
   public void setToken(String token) {
     this.token = token;
+    save();
   }
 
-  public void loadToken() {
+  private void load() {
     Context context = Leanplum.getContext();
     SharedPreferences defaults = context.getSharedPreferences(
         Constants.Defaults.LEANPLUM, Context.MODE_PRIVATE);
+
     String token = defaults.getString(Constants.Defaults.TOKEN_KEY, null);
-    if (token == null) {
-      return;
+    if (token != null) {
+      this.token = token;
     }
-    setToken(token);
+    String apiHost = defaults.getString(Defaults.API_HOST_KEY, null);
+    if (apiHost != null) {
+      this.apiHost = apiHost;
+    }
+    String apiPath = defaults.getString(Defaults.API_PATH_KEY, null);
+    if (apiPath != null) {
+      this.apiPath = apiPath;
+    }
+    this.apiSSL = defaults.getBoolean(Defaults.API_SSL_KEY, true);
+    String socketHost = defaults.getString(Defaults.SOCKET_HOST_KEY, null);
+    if (socketHost != null) {
+      this.socketHost = socketHost;
+    }
+    int socketPort = defaults.getInt(Defaults.SOCKET_PORT_KEY, 0);
+    if (socketPort != 0) {
+      this.socketPort = socketPort;
+    }
   }
 
-  public void saveToken() {
+  private void save() {
     Context context = Leanplum.getContext();
     SharedPreferences defaults = context.getSharedPreferences(
         Constants.Defaults.LEANPLUM, Context.MODE_PRIVATE);
     SharedPreferences.Editor editor = defaults.edit();
-    editor.putString(Constants.Defaults.TOKEN_KEY, APIConfig.getInstance().token());
+
+    editor.putString(Defaults.TOKEN_KEY, this.token);
+    editor.putString(Defaults.API_HOST_KEY, this.apiHost);
+    editor.putString(Defaults.API_PATH_KEY, this.apiPath);
+    editor.putBoolean(Defaults.API_SSL_KEY, this.apiSSL);
+    editor.putString(Defaults.SOCKET_HOST_KEY, this.socketHost);
+    editor.putInt(Defaults.SOCKET_PORT_KEY, this.socketPort);
+
     SharedPreferencesUtil.commitChanges(editor);
   }
 
@@ -123,5 +155,44 @@ public class APIConfig {
     dict.put(Constants.Params.CLIENT_KEY, accessKey);
     dict.put(Constants.Params.CLIENT, Constants.CLIENT);
     return true;
+  }
+
+  public void setApiConfig(String apiHost, String apiPath, boolean apiSSL) {
+    if (!TextUtils.isEmpty(apiHost)) {
+      this.apiHost = apiHost;
+    }
+    if (!TextUtils.isEmpty(apiPath)) {
+      this.apiPath = apiPath;
+    }
+    this.apiSSL = apiSSL;
+    save();
+  }
+
+  public void setSocketConfig(String socketHost, int socketPort) {
+    if (!TextUtils.isEmpty(socketHost)) {
+      this.socketHost = socketHost;
+      this.socketPort = socketPort;
+      save();
+    }
+  }
+
+  public String getApiHost() {
+    return this.apiHost;
+  }
+
+  public String getApiPath() {
+    return this.apiPath;
+  }
+
+  public String getSocketHost() {
+    return this.socketHost;
+  }
+
+  public int getSocketPort() {
+    return this.socketPort;
+  }
+
+  public boolean getApiSSL() {
+    return this.apiSSL;
   }
 }

--- a/AndroidSDKCore/src/main/java/com/leanplum/internal/Constants.java
+++ b/AndroidSDKCore/src/main/java/com/leanplum/internal/Constants.java
@@ -29,11 +29,6 @@ import com.leanplum.core.BuildConfig;
  * @author Andrew First.
  */
 public class Constants {
-  public static String API_HOST_NAME = "api.leanplum.com";
-  public static String API_SERVLET = "api";
-  public static boolean API_SSL = true;
-  public static String SOCKET_HOST = "dev.leanplum.com";
-  public static int SOCKET_PORT = 443;
   public static int NETWORK_TIMEOUT_SECONDS = 10;
   public static int NETWORK_TIMEOUT_SECONDS_FOR_DOWNLOADS = 10;
   public static String LEANPLUM_VERSION = BuildConfig.SDK_VERSION;
@@ -76,6 +71,11 @@ public class Constants {
     public static final String VARIABLES_SIGN_KEY = "__leanplum_variables_signature";
     public static final String ATTRIBUTES_KEY = "__leanplum_attributes";
     public static final String TOKEN_KEY = "__leanplum_token";
+    public static final String API_HOST_KEY = "__leanplum_api_host";
+    public static final String API_PATH_KEY = "__leanplum_api_path";
+    public static final String API_SSL_KEY = "__leanplum_api_ssl";
+    public static final String SOCKET_HOST_KEY = "__leanplum_socket_host";
+    public static final String SOCKET_PORT_KEY = "__leanplum_socket_port";
     public static final String MESSAGES_KEY = "__leanplum_messages";
     public static final String REGIONS_KEY = "regions";
     public static final String MESSAGING_PREF_NAME = "__leanplum_messaging__";
@@ -155,6 +155,9 @@ public class Constants {
     public static final String VERSION_NAME = "versionName";
     public static final String REQUEST_ID = "reqId";
     public static final String STACK_TRACE = "stackTrace";
+    public static final String API_HOST = "apiHost";
+    public static final String API_PATH = "apiPath";
+    public static final String DEV_SERVER_HOST = "devServerHost";
   }
 
   public static class Keys {

--- a/AndroidSDKCore/src/main/java/com/leanplum/internal/FileTransferManager.java
+++ b/AndroidSDKCore/src/main/java/com/leanplum/internal/FileTransferManager.java
@@ -99,7 +99,9 @@ public class FileTransferManager {
       @Override
       public void run() {
         try {
-          downloadHelper(request, Constants.API_HOST_NAME, Constants.API_SERVLET, path, url, dict);
+          String apiHost = APIConfig.getInstance().getApiHost();
+          String apiPath = APIConfig.getInstance().getApiPath();
+          downloadHelper(request, apiHost, apiPath, path, url, dict);
         } catch (Throwable t) {
           Log.exception(t);
         }
@@ -125,7 +127,7 @@ public class FileTransferManager {
             servlet,
             dict,
             httpMethod,
-            Constants.API_SSL,
+            APIConfig.getInstance().getApiSSL(),
             Constants.NETWORK_TIMEOUT_SECONDS_FOR_DOWNLOADS);
       } else {
         op = new NetworkOperation(
@@ -251,10 +253,10 @@ public class FileTransferManager {
 
           try {
             op = new UploadOperation(
-                Constants.API_HOST_NAME,
-                Constants.API_SERVLET,
+                APIConfig.getInstance().getApiHost(),
+                APIConfig.getInstance().getApiPath(),
                 request.getHttpMethod(),
-                Constants.API_SSL,
+                APIConfig.getInstance().getApiSSL(),
                 60);
 
             if (op.uploadFiles(filesToUpload, streams, dict)) {

--- a/AndroidSDKCore/src/main/java/com/leanplum/internal/LeanplumInternal.java
+++ b/AndroidSDKCore/src/main/java/com/leanplum/internal/LeanplumInternal.java
@@ -583,12 +583,28 @@ public class LeanplumInternal {
         if (!success) {
           return;
         }
-        if (Constants.isDevelopmentModeEnabled && !Constants.isNoop()) {
-          Socket.getInstance();
-        }
         maybePerformActions(new String[] {"start", "resume"}, null,
             LeanplumMessageMatchFilter.LEANPLUM_ACTION_FILTER_ALL, null, null);
         recordAttributeChanges();
+      }
+    });
+
+    connectDevelopmentServer();
+  }
+
+  public static void connectDevelopmentServer() {
+    Leanplum.addStartResponseHandler(new StartCallback() {
+      @Override
+      public void onResponse(boolean success) {
+        if (!success) {
+          return;
+        }
+        if (!inForeground) {
+          return;
+        }
+        if (Constants.isDevelopmentModeEnabled && !Constants.isNoop()) {
+          Socket.connectSocket();
+        }
       }
     });
   }

--- a/AndroidSDKCore/src/main/java/com/leanplum/internal/RequestSender.java
+++ b/AndroidSDKCore/src/main/java/com/leanplum/internal/RequestSender.java
@@ -130,17 +130,23 @@ public class RequestSender {
     try {
       try {
         op = new NetworkOperation(
-            Constants.API_HOST_NAME,
-            Constants.API_SERVLET,
+            APIConfig.getInstance().getApiHost(),
+            APIConfig.getInstance().getApiPath(),
             multiRequestArgs,
             RequestBuilder.POST,
-            Constants.API_SSL,
+            APIConfig.getInstance().getApiSSL(),
             Constants.NETWORK_TIMEOUT_SECONDS);
 
         JSONObject responseBody = op.getJsonResponse();
         int statusCode = op.getResponseCode();
 
         if (statusCode >= 200 && statusCode <= 299) {
+          if (RequestUtil.updateApiConfig(responseBody)) {
+            // API config is changed and we need to send requests again
+            sendRequests();
+            return;
+          }
+
           // Parse response body and trigger callbacks
           invokeCallbacks(responseBody);
 

--- a/AndroidSDKCore/src/main/java/com/leanplum/internal/Socket.java
+++ b/AndroidSDKCore/src/main/java/com/leanplum/internal/Socket.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016, Leanplum, Inc. All rights reserved.
+ * Copyright 2022, Leanplum, Inc. All rights reserved.
  *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
@@ -25,11 +25,13 @@ import android.app.Activity;
 import android.app.AlertDialog;
 import android.content.DialogInterface;
 
+import android.text.TextUtils;
 import com.leanplum.ActionContext;
 import com.leanplum.Leanplum;
 import com.leanplum.LeanplumActivityHelper;
 import com.leanplum.callbacks.VariablesChangedCallback;
 
+import java.io.IOException;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -37,7 +39,6 @@ import org.json.JSONObject;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.Collections;
-import java.util.List;
 import java.util.Map;
 import java.util.Timer;
 import java.util.TimerTask;
@@ -59,18 +60,82 @@ public class Socket {
   private static final String EVENT_REGISTER_DEVICE = "registerDevice";
   private static final String EVENT_APPLY_VARS = "applyVars";
 
-  private static Socket instance = new Socket();
-  private SocketIOClient sio;
+  private static Socket instance;
+  private static boolean requestNewConnection;
+
+  private volatile SocketIOClient sio;
+  private Timer reconnectTimer;
   private boolean authSent;
   private boolean connected = false;
   private boolean connecting = false;
+
+  private String socketHost;
+  private int socketPort;
 
   public Socket() {
     createSocketClient();
   }
 
-  public static Socket getInstance() {
-    return instance;
+  /**
+   * Start socket, if it hasn't been, or reconnect it in case of a host or port change.
+   */
+  public static synchronized void connectSocket() {
+    if (instance == null) {
+      instance = new Socket();
+    } else {
+      // Reconnect socket if host or port are changed
+
+      String newHost = APIConfig.getInstance().getSocketHost();
+      int newPort = APIConfig.getInstance().getSocketPort();
+
+      String currentHost = instance.socketHost;
+      int currentPort = instance.socketPort;
+
+      boolean reconnect = false;
+      if (!TextUtils.isEmpty(currentHost) && !currentHost.equals(newHost)) {
+        reconnect = true;
+      }
+      if (currentPort != 0 && currentPort != newPort) {
+        reconnect = true;
+      }
+
+      if (reconnect) {
+        reconnectSocket();
+      }
+    }
+  }
+
+  private static synchronized void reconnectSocket() {
+    if (instance != null) {
+      if (instance.connecting) {
+        // wait until connected, then disconnect
+        requestNewConnection = true;
+      } else {
+        // already connected, no problem to disconnect
+        instance.disconnect();
+        instance = new Socket();
+        requestNewConnection = false;
+      }
+    }
+  }
+
+  /**
+   * For testing purposes only.
+   *
+   * Before disconnecting make sure connection process is done.
+   */
+  public static synchronized void disconnectSocket() {
+    if (instance != null) {
+      instance.disconnect();
+      instance = null;
+    }
+  }
+
+  private void updateConnectionStatus(boolean flag) {
+    connecting = flag;
+    if (!connecting && requestNewConnection) {
+      reconnectSocket();
+    }
   }
 
   private void createSocketClient() {
@@ -80,27 +145,29 @@ public class Socket {
         Log.e("Development socket error", error);
 
         // if error happens during connecting, reset flag
-        connecting = false;
+        updateConnectionStatus(false);
       }
 
       @Override
       public void onDisconnect(int code, String reason) {
         Log.d("Disconnected from development server");
         connected = false;
-        connecting = false;
+        updateConnectionStatus(false);
         authSent = false;
       }
 
       @Override
       public void onConnect() {
         if (!authSent) {
-          Log.d("Connected to development server");
+          Log.d("Connected to development server " + socketHost + ":" + socketPort);
           try {
             Map<String, String> args = Util.newMap(
                 Constants.Params.APP_ID, APIConfig.getInstance().appId(),
                 Constants.Params.DEVICE_ID, APIConfig.getInstance().deviceId());
             try {
-              sio.emit("auth", new JSONArray(Collections.singletonList(new JSONObject(args))));
+              if (sio != null) {
+                sio.emit("auth", new JSONArray(Collections.singletonList(new JSONObject(args))));
+              }
             } catch (JSONException e) {
               e.printStackTrace();
             }
@@ -109,7 +176,7 @@ public class Socket {
           }
           authSent = true;
           connected = true;
-          connecting = false;
+          updateConnectionStatus(false);
         }
       }
 
@@ -145,13 +212,15 @@ public class Socket {
     };
 
     try {
-      sio = new SocketIOClient(new URI("https://" + Constants.SOCKET_HOST + ":" +
-          Constants.SOCKET_PORT), socketIOClientHandler);
+      socketHost = APIConfig.getInstance().getSocketHost();
+      socketPort = APIConfig.getInstance().getSocketPort();
+      URI socketUri = new URI("https://" + socketHost + ":" + socketPort);
+      sio = new SocketIOClient(socketUri, socketIOClientHandler);
     } catch (URISyntaxException e) {
       Log.e(e.getMessage());
     }
     connect();
-    Timer reconnectTimer = new Timer();
+    reconnectTimer = new Timer();
     reconnectTimer.schedule(new TimerTask() {
       @Override
       public void run() {
@@ -168,8 +237,25 @@ public class Socket {
    * Connect to the remote socket.
    */
   private void connect() {
-    connecting = true;
-    sio.connect();
+    updateConnectionStatus(true);
+    if (sio != null) {
+      sio.connect();
+    }
+  }
+
+  private void disconnect() {
+    try {
+      if (reconnectTimer != null) {
+        reconnectTimer.cancel();
+        reconnectTimer = null;
+      }
+      if (sio != null) {
+        sio.disconnect();
+        sio = null;
+      }
+    } catch (IOException e) {
+      Log.e("Disconnect error", e);
+    }
   }
 
   /**
@@ -190,8 +276,10 @@ public class Socket {
   public <T> void sendEvent(String eventName, Map<String, T> data) {
     try {
       Log.d("Sending event: %s with data: %s over socket", eventName, data);
-      sio.emit(eventName,
-          new JSONArray(Collections.singletonList(JsonConverter.mapToJsonObject(data))));
+      if (sio != null) {
+        sio.emit(eventName,
+            new JSONArray(Collections.singletonList(JsonConverter.mapToJsonObject(data))));
+      }
     } catch (JSONException e) {
       Log.d("Failed to create JSON data object: " + e.getMessage());
     }

--- a/AndroidSDKCore/src/main/java/com/leanplum/internal/SocketIOClient.java
+++ b/AndroidSDKCore/src/main/java/com/leanplum/internal/SocketIOClient.java
@@ -214,6 +214,7 @@ class SocketIOClient {
   }
 
   public void disconnect() throws IOException {
+    Log.d("SocketIOClient.disconnect()");
     cleanup();
   }
 

--- a/AndroidSDKTests/src/test/java/com/leanplum/internal/ChangeHostTest.java
+++ b/AndroidSDKTests/src/test/java/com/leanplum/internal/ChangeHostTest.java
@@ -1,0 +1,91 @@
+package com.leanplum.internal;
+
+import static org.mockito.Matchers.anyBoolean;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Matchers.eq;
+import static org.powermock.api.mockito.PowerMockito.verifyStatic;
+
+import com.leanplum.Leanplum;
+import com.leanplum.__setup.AbstractTest;
+import com.leanplum._whitebox.utilities.ImmediateRequestSender;
+import java.lang.reflect.Field;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+public class ChangeHostTest extends AbstractTest {
+
+   @Before
+   public void setUp() throws Exception {
+      // Timer will call sendRequests because of the shadow operation queue
+      // Replacing timer instance to prevent it
+      RequestSenderTimer spiedTimer = Mockito.spy(RequestSenderTimer.get());
+      Mockito.doNothing().when(spiedTimer).start();
+      Field instance = RequestSenderTimer.class.getDeclaredField("INSTANCE");
+      instance.setAccessible(true);
+      instance.set(instance, spiedTimer);
+   }
+
+   @After
+   public void tearDown() throws Exception {
+      Field instance = RequestSenderTimer.class.getDeclaredField("INSTANCE");
+      instance.setAccessible(true);
+      instance.set(instance, new RequestSenderTimer());
+
+      RequestSender.setInstance(new RequestSender());
+   }
+
+   @Test
+   public void testApiHostResponse() throws Exception {
+      RequestSender sender = Mockito.spy(ImmediateRequestSender.class);
+      RequestSender.setInstance(sender);
+
+      setupSDK(Leanplum.getContext(), "/responses/change_host_response.json");
+
+      // verify number of calls
+      verifyStatic(Mockito.times(2));
+      Leanplum.setApiConnectionSettings(anyString(), anyString(), anyBoolean());
+      verifyStatic(Mockito.times(2));
+      Leanplum.setSocketConnectionSettings(anyString(), eq(443));
+
+      // default case from setup method
+      verifyStatic(Mockito.times(1));
+      Leanplum.setApiConnectionSettings("www.leanplum.com", "api", true);
+      verifyStatic(Mockito.times(1));
+      Leanplum.setSocketConnectionSettings("dev.leanplum.com", 443);
+
+      // changed config from request
+      verifyStatic(Mockito.times(1));
+      Leanplum.setApiConnectionSettings("api2.leanplum.com", "new-api", true);
+      verifyStatic(Mockito.times(1));
+      Leanplum.setSocketConnectionSettings("dev2.leanplum.com", 443);
+
+      // verify sendRequests called for second time recursively
+      Mockito.verify(sender, Mockito.times(2)).sendRequests();
+   }
+
+   @Test
+   public void testSameConfigResponse() throws Exception {
+      RequestSender sender = Mockito.spy(ImmediateRequestSender.class);
+      RequestSender.setInstance(sender);
+
+      // response file contains the default config, that is used in the setup method
+      setupSDK(Leanplum.getContext(), "/responses/change_host_loop_response.json");
+
+      // verify number of calls
+      verifyStatic(Mockito.times(1));
+      Leanplum.setApiConnectionSettings(anyString(), anyString(), eq(true));
+      verifyStatic(Mockito.times(1));
+      Leanplum.setSocketConnectionSettings(anyString(), eq(443));
+
+      // default case from setup method
+      verifyStatic(Mockito.times(1));
+      Leanplum.setApiConnectionSettings("www.leanplum.com", "api", true);
+      verifyStatic(Mockito.times(1));
+      Leanplum.setSocketConnectionSettings("dev.leanplum.com", 443);
+
+      // verify sendRequests called only once
+      Mockito.verify(sender, Mockito.times(1)).sendRequests();
+   }
+}

--- a/AndroidSDKTests/src/test/java/com/leanplum/internal/LeanplumInternalTest.java
+++ b/AndroidSDKTests/src/test/java/com/leanplum/internal/LeanplumInternalTest.java
@@ -91,12 +91,11 @@ public class LeanplumInternalTest {
     when(LeanplumInternal.class, "isStartSuccessful").thenReturn(false);
     LeanplumInternal.moveToForeground();
     verifyStatic(never());
-    Socket.getInstance();
+    Socket.connectSocket();
 
     // Test for successful connection to Leanplum.
     when(LeanplumInternal.class, "isStartSuccessful").thenReturn(true);
     assertTrue(LeanplumInternal.isStartSuccessful());
-    when(Socket.getInstance()).thenReturn(null);
     Field inForegroundField = LeanplumInternal.class.getDeclaredField("inForeground");
     assertNotNull(inForegroundField);
     inForegroundField.setAccessible(true);
@@ -113,6 +112,6 @@ public class LeanplumInternalTest {
 
     LeanplumInternal.moveToForeground();
     verifyStatic();
-    Socket.getInstance();
+    Socket.connectSocket();
   }
 }

--- a/AndroidSDKTests/src/test/java/com/leanplum/internal/SocketIOClientTest.java
+++ b/AndroidSDKTests/src/test/java/com/leanplum/internal/SocketIOClientTest.java
@@ -20,12 +20,14 @@
  */
 package com.leanplum.internal;
 
+import android.app.Application;
 import android.content.Context;
 
 import com.leanplum.Leanplum;
 import com.leanplum.__setup.LeanplumTestApp;
 
 import org.json.JSONArray;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -91,9 +93,14 @@ public class SocketIOClientTest {
    */
   @Test
   public void testUserAgentString() throws Exception {
+    Application context = RuntimeEnvironment.application;
+    Assert.assertNotNull(context);
+    Leanplum.setApplicationContext(context);
+
     mockStatic(Util.class);
     mockStatic(APIConfig.class);
     spy(Leanplum.class);
+
     SocketIOClient socketIOClient = new SocketIOClient(new URI(""), new SocketIOClient.Handler() {
       @Override
       public void onConnect() {

--- a/AndroidSDKTests/src/test/resources/responses/change_host_loop_response.json
+++ b/AndroidSDKTests/src/test/resources/responses/change_host_loop_response.json
@@ -1,0 +1,13 @@
+{
+  "response": [
+    {
+      "success": false,
+      "apiHost": "www.leanplum.com",
+      "apiPath": "api",
+      "devServerHost": "dev.leanplum.com",
+      "error": {
+        "message": "App endpoint configuration mismatch."
+      }
+    }
+  ]
+}

--- a/AndroidSDKTests/src/test/resources/responses/change_host_response.json
+++ b/AndroidSDKTests/src/test/resources/responses/change_host_response.json
@@ -1,0 +1,13 @@
+{
+  "response": [
+    {
+      "success": false,
+      "apiHost": "api2.leanplum.com",
+      "apiPath": "new-api",
+      "devServerHost": "dev2.leanplum.com",
+      "error": {
+        "message": "App endpoint configuration mismatch."
+      }
+    }
+  ]
+}


### PR DESCRIPTION
What              | Where/Who
------------------|----------------------------------------
JIRA Issue        | [SDK-665](https://leanplum.atlassian.net/browse/SDK-665)
People Involved   | @hborisoff 

## Background
Change API and Dev server endpoints based on API response.
HTTP status will be 200 OK and success false. Example of response:
```
{
  "response": [
    {
      "success": false,
      "apiHost": "api2.leanplum.com",
      "apiPath": "new-api",
      "devServerHost": "dev2.leanplum.com",
      "error": {
        "message": "App endpoint configuration mismatch."
      }
    }
  ]
}
```

## Implementation
`RequestSender.sendRequests` checks if the response returns a new API config, then changes the hosts and retries the request. Callbacks will be executed by the subsequent request.

Socket layer is modified to allow disconnecting of old socket and connecting a new one. Important to note is that you need to wait until socket is connected to disconnect it successfully.

New API and Dev server configs are saved in shared preferences from `APIConfig`.

## Testing steps
Added couple of unit tests in `ChangeHostTest.java`.
Most modifications are tested manually.
