### PR TITLE
Fix Open Action not working for push in RN

### DIFF
--- a/AndroidSDKPush/src/main/java/com/leanplum/LeanplumPushService.java
+++ b/AndroidSDKPush/src/main/java/com/leanplum/LeanplumPushService.java
@@ -38,6 +38,7 @@ import android.os.Bundle;
 import androidx.annotation.NonNull;
 import androidx.annotation.WorkerThread;
 import com.leanplum.LeanplumActivityHelper.NoTrampolinesLifecycleCallbacks;
+import com.leanplum.callbacks.StartCallback;
 import com.leanplum.callbacks.VariablesChangedCallback;
 import com.leanplum.internal.ActionManager;
 import com.leanplum.internal.Constants;
@@ -534,7 +535,7 @@ public class LeanplumPushService {
       context.startActivity(actionIntent);
     }
     // Post handles push notification.
-    performPushNotificationAction(notification);
+    performActionAfterIssuedStart(notification);
   }
 
   /**
@@ -569,7 +570,7 @@ public class LeanplumPushService {
         }
         return;
       }
-      performPushNotificationAction(notification);
+      performActionAfterIssuedStart(notification);
     }
   }
 
@@ -633,7 +634,13 @@ public class LeanplumPushService {
       Log.d("Could not post handle push notification, extras are null.");
       return;
     }
-    performPushNotificationAction(notification);
+    performActionAfterIssuedStart(notification);
+  }
+
+  private static void performActionAfterIssuedStart(@NonNull Bundle notification) {
+    LeanplumInternal.addStartIssuedHandler(() -> {
+      performPushNotificationAction(notification);
+    });
   }
 
   private static void performPushNotificationAction(@NonNull Bundle notification) {


### PR DESCRIPTION
What              | Where/Who
------------------|----------------------------------------
JIRA Issue        | [SDK-683](https://leanplum.atlassian.net/browse/SDK-683)
People Involved   | @hborisoff 

When testing push notification in React Native the Open Action was not executing if app was killed previously, because Java Script code runs later than the `Application.onCreate` code and this results in missing action handlers when the action was triggered.
Solution is to trigger the Open Action once `Leanplum.start` is issued.