### PR TITLE
Allow file arguments with URL value

### DIFF
--- a/AndroidSDKCore/src/main/java/com/leanplum/internal/FileTransferManager.java
+++ b/AndroidSDKCore/src/main/java/com/leanplum/internal/FileTransferManager.java
@@ -122,13 +122,25 @@ public class FileTransferManager {
     String httpMethod = request.getHttpMethod();
     try {
       if (url == null) {
-        op = new NetworkOperation(
-            hostName,
-            servlet,
-            dict,
-            httpMethod,
-            APIConfig.getInstance().getApiSSL(),
-            Constants.NETWORK_TIMEOUT_SECONDS_FOR_DOWNLOADS);
+        // Download it directly if the argument is URL.
+        // Otherwise continue with the api request.
+        if (path != null && (path.startsWith("http://") || path.startsWith("https://"))) {
+          op = new NetworkOperation(
+              path,
+              httpMethod,
+              path.startsWith("https://"),
+              Constants.NETWORK_TIMEOUT_SECONDS_FOR_DOWNLOADS);
+
+        } else {
+          op = new NetworkOperation(
+              hostName,
+              servlet,
+              dict,
+              httpMethod,
+              APIConfig.getInstance().getApiSSL(),
+              Constants.NETWORK_TIMEOUT_SECONDS_FOR_DOWNLOADS);
+        }
+
       } else {
         op = new NetworkOperation(
             url,

--- a/AndroidSDKCore/src/main/java/com/leanplum/messagetemplates/options/RichHtmlOptions.java
+++ b/AndroidSDKCore/src/main/java/com/leanplum/messagetemplates/options/RichHtmlOptions.java
@@ -120,7 +120,7 @@ public class RichHtmlOptions {
 
   /**
    * Replace all keys with __file__ prefix to keys without __file__ prefix and replace value of
-   * those keys with local path to file. In case of URL it will leave the value unchanged.
+   * those keys with local path to file.
    *
    * @param map Map with arguments from ActionContext.
    * @param htmlTemplateName Name of file with HTML template.
@@ -143,18 +143,13 @@ public class RichHtmlOptions {
         if (filePath == null) {
           continue;
         }
-        if (filePath.startsWith("http://") || filePath.startsWith("https://")) {
-          map.put(key.replace(Values.FILE_PREFIX, ""), filePath);
-          map.remove(key);
-        } else {
-          File f = new File(filePath);
-          String localPath = "file://" + f.getAbsolutePath();
-          if (localPath.contains(Leanplum.getContext().getPackageName())) {
-            map.put(key.replace(Values.FILE_PREFIX, ""),
-                localPath.replace(" ", "%20"));
-          }
-          map.remove(key);
+        File f = new File(filePath);
+        String localPath = "file://" + f.getAbsolutePath();
+        if (localPath.contains(Leanplum.getContext().getPackageName())) {
+          map.put(key.replace(Values.FILE_PREFIX, ""),
+              localPath.replace(" ", "%20"));
         }
+        map.remove(key);
       }
     }
     return map;


### PR DESCRIPTION
What              | Where/Who
------------------|----------------------------------------
JIRA Issue        | [SDK-697](https://leanplum.atlassian.net/browse/SDK-697)
People Involved   | @hborisoff 

Reverting #492, the previous fix of SDK-697, because it was working only when preview the message.
New code will download file arguments that contain URLs and will save them in the file system using the URL as path, which is not the perfect solution, but it works. This is the same for iOS.
