### PR TITLE
Allow changing of Device ID multiple times

### DIFF
--- a/AndroidSDKCore/src/main/java/com/leanplum/internal/APIConfig.java
+++ b/AndroidSDKCore/src/main/java/com/leanplum/internal/APIConfig.java
@@ -129,7 +129,7 @@ public class APIConfig {
     }
   }
 
-  private void save() {
+  public void save() {
     Context context = Leanplum.getContext();
     SharedPreferences defaults = context.getSharedPreferences(
         Constants.Defaults.LEANPLUM, Context.MODE_PRIVATE);


### PR DESCRIPTION
What              | Where/Who
------------------|----------------------------------------
JIRA Issue        | [SDK-732](https://leanplum.atlassian.net/browse/SDK-732)
People Involved   | @hborisoff 

Allow switching Device ID after Leanplum has started using `Leanplum.forceNewDeviceId(String)`.
In opposite to the other method `Leanplum.setDeviceId(String)` this one allows for multiple changes. The push tokens are also moved to the new device and push notifications are possible immediately.

