### PR TITLE
Skip HMS classes for consumers' proguard

### DIFF
--- a/AndroidSDKHms/consumer-proguard-rules.pro
+++ b/AndroidSDKHms/consumer-proguard-rules.pro
@@ -5,3 +5,6 @@
 
 -keep class com.leanplum.** { *; }
 -dontwarn com.leanplum.**
+
+-keep class com.huawei.updatesdk.**{*;}
+-keep class com.huawei.hms.**{*;}


### PR DESCRIPTION
What              | Where/Who
------------------|----------------------------------------
People Involved   | @hborisoff 

When HMS library was bumped to `com.huawei.hms:push:6.3.0.304` push notifications on the Huawei channel stopped working for Rondo app. These couple lines exclude HMS classes for client's Proguard configuration and pushes now arrive.
