### PR TITLE
Skip variables to be overriden when null is received

### DIFF
--- a/AndroidSDKCore/src/main/java/com/leanplum/Leanplum.java
+++ b/AndroidSDKCore/src/main/java/com/leanplum/Leanplum.java
@@ -990,7 +990,7 @@ public class Leanplum {
    * @param response The response containing content.
    */
   private static void applyContentInResponse(JSONObject response) {
-    Map<String, Object> values = JsonConverter.mapFromJsonOrDefault(
+    Map<String, Object> values = JsonConverter.mapFromJson(
         response.optJSONObject(Constants.Keys.VARS));
     Map<String, Object> messages = JsonConverter.mapFromJsonOrDefault(
         response.optJSONObject(Constants.Keys.MESSAGES));


### PR DESCRIPTION
What              | Where/Who
------------------|----------------------------------------
People Involved   | @hborisoff 

Null value is not permitted and should not be returned from server and value {} is used when not variables are defined.
Code won't allow variables to be replaced in case of server failure.