### PR TITLE
Fix IAM Handler dismiss functionality

### DIFF
--- a/AndroidSDKCore/src/main/java/com/leanplum/actions/LeanplumActions.kt
+++ b/AndroidSDKCore/src/main/java/com/leanplum/actions/LeanplumActions.kt
@@ -93,8 +93,8 @@ class LeanplumActions {
      */
     @JvmStatic
     fun setQueuePaused(paused: Boolean) {
-      ActionManager.getInstance().isPaused = paused
       setContinueOnActivityResumed(!paused)
+      ActionManager.getInstance().isPaused = paused
     }
 
     /**

--- a/AndroidSDKCore/src/main/java/com/leanplum/actions/internal/ActionManagerExecution.kt
+++ b/AndroidSDKCore/src/main/java/com/leanplum/actions/internal/ActionManagerExecution.kt
@@ -100,7 +100,7 @@ fun ActionManager.dismissCurrentAction() {
 
 @UiThread
 private fun ActionManager.performActionsImpl() {
-  if (isPaused) return
+  if (isPaused || !isEnabled) return
 
   // do not continue if we have action running
   if (currentAction != null) {

--- a/AndroidSDKCore/src/main/java/com/leanplum/messagetemplates/actions/CenterPopupMessage.java
+++ b/AndroidSDKCore/src/main/java/com/leanplum/messagetemplates/actions/CenterPopupMessage.java
@@ -57,7 +57,10 @@ public class CenterPopupMessage implements MessageTemplate {
 
     CenterPopupOptions options = new CenterPopupOptions(context);
     popup = new CenterPopupController(activity, options);
-    popup.setOnDismissListener(listener -> popup = null);
+    popup.setOnDismissListener(listener -> {
+      popup = null;
+      context.actionDismissed();
+    });
     popup.show();
 
     return true;
@@ -66,9 +69,7 @@ public class CenterPopupMessage implements MessageTemplate {
   @Override
   public boolean dismiss(@NonNull ActionContext context) {
     if (popup != null) {
-      popup.setOnDismissListener(listener -> context.actionDismissed());
       popup.dismiss();
-      popup = null;
     }
     return true;
   }

--- a/AndroidSDKCore/src/main/java/com/leanplum/messagetemplates/actions/InterstitialMessage.java
+++ b/AndroidSDKCore/src/main/java/com/leanplum/messagetemplates/actions/InterstitialMessage.java
@@ -57,7 +57,10 @@ public class InterstitialMessage implements MessageTemplate {
 
     InterstitialOptions options = new InterstitialOptions(context);
     interstitial = new InterstitialController(activity, options);
-    interstitial.setOnDismissListener(listener -> interstitial = null);
+    interstitial.setOnDismissListener(listener -> {
+      interstitial = null;
+      context.actionDismissed();
+    });
     interstitial.show();
 
     return true;
@@ -66,9 +69,7 @@ public class InterstitialMessage implements MessageTemplate {
   @Override
   public boolean dismiss(@NonNull ActionContext context) {
     if (interstitial != null) {
-      interstitial.setOnDismissListener(listener -> context.actionDismissed());
       interstitial.dismiss();
-      interstitial = null;
     }
     return true;
   }

--- a/AndroidSDKCore/src/main/java/com/leanplum/messagetemplates/actions/RichHtmlMessage.java
+++ b/AndroidSDKCore/src/main/java/com/leanplum/messagetemplates/actions/RichHtmlMessage.java
@@ -64,7 +64,10 @@ public class RichHtmlMessage implements MessageTemplate {
 
       // Message is shown after html is rendered. Check handleOpenEvent(url) method.
       richHtml = new RichHtmlController(activity, richOptions);
-      richHtml.setOnDismissListener(listener -> richHtml = null);
+      richHtml.setOnDismissListener(listener -> {
+        richHtml = null;
+        context.actionDismissed();
+      });
       return true;
 
     } catch (Throwable t) {
@@ -76,9 +79,7 @@ public class RichHtmlMessage implements MessageTemplate {
   @Override
   public boolean dismiss(@NonNull ActionContext context) {
     if (richHtml != null) {
-      richHtml.setOnDismissListener(listener -> context.actionDismissed());
       richHtml.dismiss();
-      richHtml = null;
     }
     return true;
   }

--- a/AndroidSDKCore/src/main/java/com/leanplum/messagetemplates/actions/WebInterstitialMessage.java
+++ b/AndroidSDKCore/src/main/java/com/leanplum/messagetemplates/actions/WebInterstitialMessage.java
@@ -57,7 +57,10 @@ public class WebInterstitialMessage implements MessageTemplate {
 
     WebInterstitialOptions options = new WebInterstitialOptions(context);
     webInterstitial = new WebInterstitialController(activity, options);
-    webInterstitial.setOnDismissListener(listener -> webInterstitial = null);
+    webInterstitial.setOnDismissListener(listener -> {
+      webInterstitial = null;
+      context.actionDismissed();
+    });
     webInterstitial.show();
 
     return true;
@@ -66,9 +69,7 @@ public class WebInterstitialMessage implements MessageTemplate {
   @Override
   public boolean dismiss(@NonNull ActionContext context) {
     if (webInterstitial != null) {
-      webInterstitial.setOnDismissListener(listener -> context.actionDismissed());
       webInterstitial.dismiss();
-      webInterstitial = null;
     }
     return true;
   }


### PR DESCRIPTION
What              | Where/Who
------------------|----------------------------------------
People Involved   | @hborisoff 

In some cases reference to `Dialog` object was lost and `context.actionDismissed()` was never called, causing Queue to stuck.
Added check against Queue disabled state when `performActions` is called.