### PR TITLE
Remove unnecessary actionDismissed calls

### DIFF
--- a/AndroidSDKCore/src/main/java/com/leanplum/messagetemplates/controllers/RichHtmlController.java
+++ b/AndroidSDKCore/src/main/java/com/leanplum/messagetemplates/controllers/RichHtmlController.java
@@ -317,10 +317,8 @@ public class RichHtmlController extends BaseController {
       if (!TextUtils.isEmpty(queryComponentsFromUrl) && actionContext != null) {
         if (url.contains(richOptions.getActionUrl())) {
           actionContext.runActionNamed(queryComponentsFromUrl);
-          actionContext.actionDismissed();
         } else {
           actionContext.runTrackedActionNamed(queryComponentsFromUrl);
-          actionContext.actionDismissed();
         }
       }
       return true;

--- a/AndroidSDKCore/src/main/java/com/leanplum/messagetemplates/options/BaseMessageOptions.java
+++ b/AndroidSDKCore/src/main/java/com/leanplum/messagetemplates/options/BaseMessageOptions.java
@@ -153,12 +153,10 @@ public abstract class BaseMessageOptions {
 
   public void accept() {
     context.runTrackedActionNamed(Args.ACCEPT_ACTION);
-    context.actionDismissed();
   }
 
   public void dismiss() {
     context.runActionNamed(Args.DISMISS_ACTION);
-    context.actionDismissed();
   }
 
   public static ActionArgs toArgs(Context currentContext) {

--- a/AndroidSDKCore/src/main/java/com/leanplum/messagetemplates/options/RichHtmlOptions.java
+++ b/AndroidSDKCore/src/main/java/com/leanplum/messagetemplates/options/RichHtmlOptions.java
@@ -375,6 +375,5 @@ public class RichHtmlOptions {
 
   public void dismiss() {
     actionContext.runActionNamed(Args.DISMISS_ACTION);
-    actionContext.actionDismissed();
   }
 }

--- a/AndroidSDKCore/src/main/java/com/leanplum/messagetemplates/options/WebInterstitialOptions.java
+++ b/AndroidSDKCore/src/main/java/com/leanplum/messagetemplates/options/WebInterstitialOptions.java
@@ -71,7 +71,6 @@ public class WebInterstitialOptions {
 
   public void dismiss() {
     actionContext.runActionNamed(Args.DISMISS_ACTION);
-    actionContext.actionDismissed();
   }
 
   public static ActionArgs toArgs() {


### PR DESCRIPTION
What              | Where/Who
------------------|----------------------------------------
People Involved   | @hborisoff

Remove unnecessary calls to `actionDismissed`, which will cause `currentAction` to be cleaned resulting of wrong sequence with chained actions.
`actionDismissed` will be called when the Android View is hidden, i.e. by `setOnDismissListener` in the cases different than Alert and Confirm.
