### PR TITLE
Download Robolectric dependency before unit tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,9 @@ env:
     - PATH=${ANDROID_HOME}:${ANDROID_HOME}/emulator:${TOOLS}:${TOOLS}/bin:${ANDROID_HOME}/platform-tools:${PATH}
     # If you want to run snapshot tests change value to 'true'. Build time will be increased by 6 minutes.
     - RUN_SNAPSHOT_TESTS=false
+    - ROBOLECTRIC_SDK8_URL=https://repo1.maven.org/maven2/org/robolectric/android-all/8.0.0_r4-robolectric-r1/android-all-8.0.0_r4-robolectric-r1
+    - ROBOLECTRIC_SDK8_DIR=$HOME/.m2/repository/org/robolectric/android-all/8.0.0_r4-robolectric-r1
+    - ROBOLECTRIC_SDK8_FILE=${ROBOLECTRIC_SDK8_DIR}/android-all-8.0.0_r4-robolectric-r1
 
 android:
   components:
@@ -30,12 +33,6 @@ licenses:
   - 'android-sdk-preview-license-.+'
   - 'android-sdk-license-.+'
   - 'google-gdk-license-.+'
-
-cache:
-  directories:
-  # cache is used for the Robolectric dependencies that are frequently failing to download
-  - .autoconf
-  - $HOME/.m2
 
 before_install:
   - curl -s "https://get.sdkman.io" | bash
@@ -64,6 +61,13 @@ before_script:
   - if [[ $RUN_SNAPSHOT_TESTS == true ]]; then emulator -verbose -avd test -no-accel -no-snapshot -no-window -no-audio -camera-back none -camera-front none -selinux permissive -qemu -m 2048 & fi;
 
 script:
+  # make sure Robolectric dependency is presented
+  - mkdir -p ${ROBOLECTRIC_SDK8_DIR}
+  - curl ${ROBOLECTRIC_SDK8_URL}.jar --output ${ROBOLECTRIC_SDK8_FILE}.jar
+  - curl ${ROBOLECTRIC_SDK8_URL}.jar.sha1 --output ${ROBOLECTRIC_SDK8_FILE}.jar.sha1
+  - curl ${ROBOLECTRIC_SDK8_URL}.pom --output ${ROBOLECTRIC_SDK8_FILE}.pom
+  - curl ${ROBOLECTRIC_SDK8_URL}.pom.sha1 --output ${ROBOLECTRIC_SDK8_FILE}.pom.sha1
+  - ls -la ${ROBOLECTRIC_SDK8_DIR}
   - ./gradlew assembleRelease testReleaseUnitTest
 
   # wait emulator to come alive and start snapshot tests


### PR DESCRIPTION
What              | Where/Who
------------------|----------------------------------------
People Involved   | @hborisoff 

There are issues when Robolectric dependency is being downloaded so fetching it before running tests.