### PR TITLE
Fix possible issue with multiple open events

### DIFF
--- a/AndroidSDKPush/src/main/java/com/leanplum/LeanplumPushService.java
+++ b/AndroidSDKPush/src/main/java/com/leanplum/LeanplumPushService.java
@@ -700,11 +700,12 @@ public class LeanplumPushService {
         resolveIntentActivity(context, deepLinkIntent);
         String messageId = LeanplumPushService.getMessageId(notification);
         if (messageId != null) {
-          ActionContext actionContext = new ActionContext(
-              ActionManager.PUSH_NOTIFICATION_ACTION_NAME, null, messageId);
-          actionContext.track(OPEN_ACTION, 0.0, null);
           try {
             context.startActivity(deepLinkIntent);
+            // track event only after successful activity start
+            ActionContext actionContext = new ActionContext(
+                ActionManager.PUSH_NOTIFICATION_ACTION_NAME, null, messageId);
+            actionContext.track(OPEN_ACTION, 0.0, null);
           }  catch (ActivityNotFoundException e) {
             return false;
           }


### PR DESCRIPTION
What              | Where/Who
------------------|----------------------------------------
JIRA Issue        | [SDK-2191](https://wizrocket.atlassian.net/browse/SDK-2191)
People Involved   | @hborisoff 

Fixing possible issue related to multiple tracks for the open event of push notification's payload when it is Open URL and running on Android 11 or older.

When [ActivityNotFound](https://github.com/Leanplum/Leanplum-Android-SDK/blob/master/AndroidSDKPush/src/main/java/com/leanplum/LeanplumPushService.java#L703-L710) exception is thrown  it would track the open event but continues in LeanplumPushService.openNotification and would open the deep link using other way and tracking a second open event.