### PR TITLE
[external] use debug logs instead of info logs

### DIFF
--- a/AndroidSDKCore/src/main/java/com/leanplum/internal/ActionManager.java
+++ b/AndroidSDKCore/src/main/java/com/leanplum/internal/ActionManager.java
@@ -659,7 +659,7 @@ public class ActionManager {
    * @param value True to enable adding actions to queue and false otherwise.
    */
   public void setEnabled(boolean value) {
-    Log.i("[ActionManager] isEnabled: " + value);
+    Log.d("[ActionManager] isEnabled: " + value);
     enabled = value;
     if (enabled) {
       ActionManagerExecutionKt.performActions(ActionManager.getInstance());
@@ -680,7 +680,7 @@ public class ActionManager {
    * @param value True to pause queue, false otherwise.
    */
   public void setPaused(boolean value) {
-    Log.i("[ActionManager] isPaused: " + value);
+    Log.d("[ActionManager] isPaused: " + value);
     paused = value;
     if (!paused) {
       ActionManagerExecutionKt.performActions(ActionManager.getInstance());


### PR DESCRIPTION



## Background
- `ActionManager.java` class shows less important logs that floods the `info` filter. setting the log as `debug` will allow this log to show up only when `verbose` filter is enabled

## Implementation
- replaced `Log.i` with `Log.d`

## Testing steps
- create a sample app and integrate LeanPlum SDK.
- launch it on a physical device or emulator
- log will show up as debug logs instead.

## Is this change backwards-compatible?
- yes
