### PR TITLE
Fix App Launched event in CT

### DIFF
--- a/AndroidSDKCore/src/main/java/com/leanplum/Leanplum.java
+++ b/AndroidSDKCore/src/main/java/com/leanplum/Leanplum.java
@@ -657,6 +657,8 @@ public class Leanplum {
             }
       });
 
+      MigrationManager.updateWrapper(); // create CT object to track App Launched correctly
+
       // Reduce latency by running the rest of the start call in a background thread.
       OperationQueue.sharedInstance().addParallelOperation(new Runnable() {
         @Override
@@ -751,6 +753,9 @@ public class Leanplum {
       }
     }
     APIConfig.getInstance().setUserId(userId);
+
+    // If wrapper has already been initialised it would update it with correct userId.
+    MigrationManager.getWrapper().setUserId(userId);
 
     String locale = Util.getLocale();
     if (!TextUtils.isEmpty(customLocale)) {

--- a/AndroidSDKCore/src/main/java/com/leanplum/migration/wrapper/WrapperFactory.kt
+++ b/AndroidSDKCore/src/main/java/com/leanplum/migration/wrapper/WrapperFactory.kt
@@ -23,9 +23,10 @@ package com.leanplum.migration.wrapper
 
 import com.leanplum.Leanplum
 import com.leanplum.callbacks.CleverTapInstanceCallback
-import com.leanplum.internal.Constants
 import com.leanplum.internal.LeanplumInternal
+import com.leanplum.internal.Log
 import com.leanplum.migration.model.MigrationConfig
+import kotlin.system.measureTimeMillis
 
 internal object WrapperFactory {
 
@@ -51,7 +52,10 @@ internal object WrapperFactory {
     }
 
     return CTWrapper(account, token, region, deviceId, userId).apply {
-      launch(context, callback)
+      val timeToLaunch = measureTimeMillis {
+        launch(context, callback)
+      }
+      Log.d("Wrapper: launch took $timeToLaunch millis")
     }
   }
 


### PR DESCRIPTION
What              | Where/Who
------------------|----------------------------------------
People Involved   | @hborisoff 

## Background

There was a race condition when running the LP.start and creating the first activity of the application, because LP.start is starting a second thread to offload some of the heavy work. For that reason the wrapper is created in the same thread that the LP.start was called.
If you call LP.start(userId) with different userId the wrapper must be updated to comply with that. Previously this wasn't needed, because the wrapper factory uses the userId from APIConfig.