### PR TITLE
Validate and Hash CTID

### DIFF
--- a/AndroidSDKCore/build.gradle
+++ b/AndroidSDKCore/build.gradle
@@ -42,7 +42,7 @@ dependencies {
     api "androidx.legacy:legacy-support-v4:1.0.0"
     api "androidx.appcompat:appcompat:${APPCOMPAT_LIBRARY_VERSION}"
 
-    api "com.clevertap.android:clevertap-android-sdk:4.6.4"
+    api "com.clevertap.android:clevertap-android-sdk:4.6.5"
 }
 
 task generateJavadoc(type: Javadoc) {

--- a/AndroidSDKCore/src/main/java/com/clevertap/android/sdk/CTUtils.kt
+++ b/AndroidSDKCore/src/main/java/com/clevertap/android/sdk/CTUtils.kt
@@ -1,0 +1,29 @@
+package com.clevertap.android.sdk
+
+import android.annotation.SuppressLint
+import com.clevertap.android.sdk.task.CTExecutorFactory
+import com.clevertap.android.sdk.task.Task
+
+object CTUtils {
+
+  @SuppressLint("RestrictedApi")
+  fun ensureLocalDataStoreValue(key: String, cleverTapApi: CleverTapAPI) {
+    val value = cleverTapApi.coreState.localDataStore.getProfileValueForKey(key)
+    if (value == null) {
+      cleverTapApi.coreState.localDataStore.setProfileField(key, "")
+    }
+  }
+
+  @SuppressLint("RestrictedApi")
+  fun addMultiValueForKey(key: String, value: String, cleverTapApi: CleverTapAPI) {
+    CTExecutorFactory
+      .executors(cleverTapApi.coreState.config)
+      .postAsyncSafelyTask<Task<Void>>()
+      .execute("CTUtils") {
+        ensureLocalDataStoreValue(key, cleverTapApi)
+        cleverTapApi.addMultiValueForKey(key, value)
+        null
+      }
+  }
+
+}

--- a/AndroidSDKCore/src/main/java/com/leanplum/migration/MigrationConstants.kt
+++ b/AndroidSDKCore/src/main/java/com/leanplum/migration/MigrationConstants.kt
@@ -27,7 +27,7 @@ import com.leanplum.internal.Log
 object MigrationConstants {
   const val IDENTITY = "Identity"
   const val STATE_PREFIX = "state_"
-  const val DEVICES_USER_PROPERTY = "devices"
+  const val DEVICES_USER_PROPERTY = "lp_devices"
 
   const val CHARGED_EVENT_PARAM = "event"
   const val VALUE_PARAM = "value"

--- a/AndroidSDKCore/src/main/java/com/leanplum/migration/MigrationConstants.kt
+++ b/AndroidSDKCore/src/main/java/com/leanplum/migration/MigrationConstants.kt
@@ -27,6 +27,7 @@ import com.leanplum.internal.Log
 object MigrationConstants {
   const val IDENTITY = "Identity"
   const val STATE_PREFIX = "state_"
+  const val DEVICES_USER_PROPERTY = "devices"
 
   const val CHARGED_EVENT_PARAM = "event"
   const val VALUE_PARAM = "value"

--- a/AndroidSDKCore/src/main/java/com/leanplum/migration/MigrationConstants.kt
+++ b/AndroidSDKCore/src/main/java/com/leanplum/migration/MigrationConstants.kt
@@ -27,6 +27,7 @@ import com.leanplum.internal.Log
 object MigrationConstants {
   const val IDENTITY = "Identity"
   const val STATE_PREFIX = "state_"
+  const val ANONYMOUS_DEVICE_PROPERTY = "lp_device"
   const val DEVICES_USER_PROPERTY = "lp_devices"
 
   const val CHARGED_EVENT_PARAM = "event"

--- a/AndroidSDKCore/src/main/java/com/leanplum/migration/wrapper/CTWrapper.kt
+++ b/AndroidSDKCore/src/main/java/com/leanplum/migration/wrapper/CTWrapper.kt
@@ -25,9 +25,9 @@ import android.app.Application
 import android.content.Context
 import android.text.TextUtils
 import com.clevertap.android.sdk.ActivityLifecycleCallback
+import com.clevertap.android.sdk.CTUtils
 import com.clevertap.android.sdk.CleverTapAPI
 import com.clevertap.android.sdk.CleverTapInstanceConfig
-import com.clevertap.android.sdk.Utils
 import com.clevertap.android.sdk.pushnotification.PushConstants
 import com.clevertap.android.sdk.pushnotification.PushNotificationHandler
 import com.leanplum.callbacks.CleverTapInstanceCallback
@@ -56,7 +56,7 @@ internal class CTWrapper(
   private var instanceCallback: CleverTapInstanceCallback? = null
 
   private var identityManager = IdentityManager(deviceId, userId ?: deviceId)
-  private var firstTimeStart = identityManager.isStateUndefined()
+  private var firstTimeStart = identityManager.isFirstTimeStart()
 
   override fun launch(context: Context, callback: CleverTapInstanceCallback?) {
     instanceCallback = callback
@@ -155,13 +155,14 @@ internal class CTWrapper(
 
     Log.d("Wrapper: Leanplum.setUserId will call onUserLogin with $profile and __h$cleverTapId")
     cleverTapInstance?.onUserLogin(profile, cleverTapId)
-
-    setDevicesProperty()
+    cleverTapInstance?.setDevicesProperty()
   }
 
-  private fun setDevicesProperty() {
-    val deviceId = identityManager.getOriginalDeviceId()
-    cleverTapInstance?.addMultiValueForKey(MigrationConstants.DEVICES_USER_PROPERTY, deviceId)
+  private fun CleverTapAPI.setDevicesProperty() {
+    if (identityManager.isDeviceIdHashed()) {
+      val deviceId = identityManager.getOriginalDeviceId()
+      CTUtils.addMultiValueForKey(MigrationConstants.DEVICES_USER_PROPERTY, deviceId, this)
+    }
   }
 
   /**

--- a/AndroidSDKCore/src/main/java/com/leanplum/migration/wrapper/CTWrapper.kt
+++ b/AndroidSDKCore/src/main/java/com/leanplum/migration/wrapper/CTWrapper.kt
@@ -85,6 +85,7 @@ internal class CTWrapper(
       }
       if (identityManager.isAnonymous()) {
         Log.d("Wrapper: identity not set for anonymous user")
+        setAnonymousDeviceProperty()
       } else {
         Log.d("Wrapper: will call onUserLogin with $profile and __h$cleverTapId")
         onUserLogin(profile, cleverTapId)
@@ -158,9 +159,18 @@ internal class CTWrapper(
     cleverTapInstance?.setDevicesProperty()
   }
 
+  private fun CleverTapAPI.setAnonymousDeviceProperty() {
+    if (identityManager.isDeviceIdHashed()) {
+      val deviceId = identityManager.getOriginalDeviceId()
+      Log.d("Wrapper: property ${MigrationConstants.ANONYMOUS_DEVICE_PROPERTY} set $deviceId")
+      pushProfile(mapOf(MigrationConstants.ANONYMOUS_DEVICE_PROPERTY to deviceId))
+    }
+  }
+
   private fun CleverTapAPI.setDevicesProperty() {
     if (identityManager.isDeviceIdHashed()) {
       val deviceId = identityManager.getOriginalDeviceId()
+      Log.d("Wrapper: property ${MigrationConstants.DEVICES_USER_PROPERTY} add $deviceId")
       CTUtils.addMultiValueForKey(MigrationConstants.DEVICES_USER_PROPERTY, deviceId, this)
     }
   }

--- a/AndroidSDKCore/src/main/java/com/leanplum/migration/wrapper/IdentityManager.kt
+++ b/AndroidSDKCore/src/main/java/com/leanplum/migration/wrapper/IdentityManager.kt
@@ -25,11 +25,17 @@ import com.leanplum.internal.Log
 import com.leanplum.migration.MigrationConstants
 import com.leanplum.utils.StringPreference
 import com.leanplum.utils.StringPreferenceNullable
+import kotlin.properties.ReadWriteProperty
+
+private const val UNDEFINED = "undefined"
+private const val ANONYMOUS = "anonymous"
+private const val IDENTIFIED = "identified"
 
 /**
  * Scheme for migrating user profile is as follows:
  *   - anonymous is translated to <CTID=deviceId, Identity=null>
- *   - non-anonymous to <CTID=deviceId_userId, Identity=userId>
+ *   - non-anonymous to <CTID=deviceId_hash(userId), Identity=userId>
+ * Where deviceId is also hashed if it is longer than 50 characters or contains invalid symbols.
  *
  * When you login, but previous profile is anonymous, a merge should happen. CT SDK allows merges
  * only when the CTID remains the same, meaning that the merged profile would get the anonymous
@@ -42,7 +48,7 @@ import com.leanplum.utils.StringPreferenceNullable
  * 1. "undefined" state
  *
  * Wrapper hasn't been started even once, meaning that anonymous profile doesn't exist, so use the
- * "deviceId_userId" scheme.
+ * "deviceId_hash(userId)" scheme.
  *
  * 2. "anonymous" state
  *
@@ -51,22 +57,19 @@ import com.leanplum.utils.StringPreferenceNullable
  *
  * 3. "identified" state
  *
- * Wrapper has been started and previous user is not anonymous - use the "deviceId_userId" scheme.
+ * Wrapper has been started and previous user is not anonymous - use the "deviceId_hash(userId)"
+ * scheme.
  */
-internal class IdentityManager(
-  private val deviceId: String,
-  private var userId: String
+class IdentityManager(
+  deviceId: String,
+  userId: String,
+  stateDelegate: ReadWriteProperty<Any, String> = StringPreference("ct_login_state", UNDEFINED),
+  mergeUserDelegate: ReadWriteProperty<Any, String?> = StringPreferenceNullable("ct_anon_merge_userid"),
 ) {
 
-  companion object {
-    private const val UNDEFINED = "undefined"
-    private const val ANONYMOUS = "anonymous"
-    private const val IDENTIFIED = "identified"
-
-    private var anonymousMergeUserId: String? by StringPreferenceNullable("ct_anon_merge_userid")
-    private var state: String by StringPreference("ct_login_state", UNDEFINED)
-    fun isStateUndefined() = state == UNDEFINED
-  }
+  private val identity: LPIdentity = LPIdentity(deviceId = deviceId, userId = userId)
+  private var state: String by stateDelegate
+  private var anonymousMergeUserId: String? by mergeUserDelegate
 
   init {
     if (isAnonymous()) {
@@ -76,7 +79,9 @@ internal class IdentityManager(
     }
   }
 
-  fun isAnonymous() = userId == deviceId
+  fun isAnonymous() = identity.isAnonymous()
+
+  fun isStateUndefined() = state == UNDEFINED
 
   private fun loginAnonymously() {
     state = ANONYMOUS
@@ -87,31 +92,38 @@ internal class IdentityManager(
       state = IDENTIFIED
     }
     else if (state == ANONYMOUS) {
-      anonymousMergeUserId = userId
+      anonymousMergeUserId = identity.userId()
       Log.d("Wrapper: anonymous data will be merged to $anonymousMergeUserId")
       state = IDENTIFIED
     }
   }
 
   fun cleverTapId(): String {
-    return when (userId) {
-      deviceId -> deviceId
-      anonymousMergeUserId -> deviceId
-      else -> "${deviceId}_${userId}"
+    if (identity.isAnonymous()) {
+      return identity.deviceId()
+    } else if (identity.userId() == anonymousMergeUserId) {
+      return identity.deviceId()
+    } else {
+      return "${identity.deviceId()}_${identity.userId()}"
     }
   }
 
-  fun profile() = mapOf(MigrationConstants.IDENTITY to userId)
+  fun profile() = mapOf(MigrationConstants.IDENTITY to identity.originalUserId())
 
-  fun setUserId(userId: String) {
+  fun setUserId(userId: String): Boolean {
+    if (!identity.setUserId(userId)) {
+      // trying to set same userId
+      return false
+    }
+
     if (state == ANONYMOUS) {
-      anonymousMergeUserId = userId
+      anonymousMergeUserId = identity.userId()
       Log.d("Wrapper: anonymous data will be merged to $anonymousMergeUserId")
       state = IDENTIFIED
     }
-    this.userId = userId
+    return true;
   }
 
-  fun getUserId() = userId
+  fun getOriginalDeviceId() = identity.originalDeviceId()
 
 }

--- a/AndroidSDKCore/src/main/java/com/leanplum/migration/wrapper/IdentityManager.kt
+++ b/AndroidSDKCore/src/main/java/com/leanplum/migration/wrapper/IdentityManager.kt
@@ -69,9 +69,11 @@ class IdentityManager(
 
   private val identity: LPIdentity = LPIdentity(deviceId = deviceId, userId = userId)
   private var state: String by stateDelegate
+  private val startState: String
   private var anonymousMergeUserId: String? by mergeUserDelegate
 
   init {
+    startState = state
     if (isAnonymous()) {
       loginAnonymously()
     } else {
@@ -81,7 +83,7 @@ class IdentityManager(
 
   fun isAnonymous() = identity.isAnonymous()
 
-  fun isStateUndefined() = state == UNDEFINED
+  fun isFirstTimeStart() = startState == UNDEFINED
 
   private fun loginAnonymously() {
     state = ANONYMOUS
@@ -123,6 +125,8 @@ class IdentityManager(
     }
     return true;
   }
+
+  fun isDeviceIdHashed() = identity.originalDeviceId() != identity.deviceId()
 
   fun getOriginalDeviceId() = identity.originalDeviceId()
 

--- a/AndroidSDKCore/src/main/java/com/leanplum/migration/wrapper/LPIdentity.kt
+++ b/AndroidSDKCore/src/main/java/com/leanplum/migration/wrapper/LPIdentity.kt
@@ -1,0 +1,37 @@
+package com.leanplum.migration.wrapper
+
+import com.clevertap.android.sdk.Utils
+import com.leanplum.utils.HashUtil
+
+private const val DEVICE_ID_MAX_LENGTH = 50
+
+class LPIdentity(
+  private val deviceId: String,
+  private var userId: String
+) {
+
+  private var deviceIdHash: String? = null
+  private var userIdHash: String? = null
+
+  init {
+    if (deviceId.length > DEVICE_ID_MAX_LENGTH || !Utils.validateCTID(deviceId)) {
+      deviceIdHash = HashUtil.sha256_128(deviceId)
+    }
+    userIdHash = HashUtil.sha256_40(userId)
+  }
+
+  fun deviceId() = deviceIdHash ?: deviceId
+  fun originalDeviceId() = deviceId
+  fun userId() = userIdHash
+  fun originalUserId() = userId
+  fun isAnonymous() = userId == deviceId
+
+  fun setUserId(userId: String): Boolean {
+    if (this.userId == userId) {
+      return false
+    }
+    this.userId = userId
+    this.userIdHash = HashUtil.sha256_40(userId)
+    return true
+  }
+}

--- a/AndroidSDKCore/src/main/java/com/leanplum/migration/wrapper/LPIdentity.kt
+++ b/AndroidSDKCore/src/main/java/com/leanplum/migration/wrapper/LPIdentity.kt
@@ -15,7 +15,7 @@ class LPIdentity(
 
   init {
     if (deviceId.length > DEVICE_ID_MAX_LENGTH || !Utils.validateCTID(deviceId)) {
-      deviceIdHash = HashUtil.sha256_128(deviceId)
+      deviceIdHash = HashUtil.sha256_200(deviceId)
     }
     userIdHash = HashUtil.sha256_40(userId)
   }

--- a/AndroidSDKCore/src/main/java/com/leanplum/utils/HashUtil.kt
+++ b/AndroidSDKCore/src/main/java/com/leanplum/utils/HashUtil.kt
@@ -1,0 +1,31 @@
+package com.leanplum.utils
+
+import java.security.MessageDigest
+
+object HashUtil {
+
+  private fun ByteArray.toHex(limit: Int): String =
+    joinToString(separator = "", limit = limit, truncated = "") { eachByte ->
+      "%02x".format(eachByte)
+    }
+
+  /**
+   * Returns hexadecimal representation of sha256 on the input string.
+   */
+  fun sha256(text: String, limit: Int = 32): String {
+    return MessageDigest
+      .getInstance("SHA-256")
+      .digest(text.toByteArray(Charsets.UTF_8))
+      .toHex(limit)
+  }
+
+  /**
+   * Get first 10 symbols from hexadecimal representation of sha256.
+   */
+  fun sha256_40(text: String) = sha256(text, 5)
+
+  /**
+   * Get first 32 symbols from hexadecimal representation of sha256.
+   */
+  fun sha256_128(text: String) = sha256(text, 16)
+}

--- a/AndroidSDKCore/src/main/java/com/leanplum/utils/HashUtil.kt
+++ b/AndroidSDKCore/src/main/java/com/leanplum/utils/HashUtil.kt
@@ -25,7 +25,7 @@ object HashUtil {
   fun sha256_40(text: String) = sha256(text, 5)
 
   /**
-   * Get first 32 symbols from hexadecimal representation of sha256.
+   * Get first 50 symbols from hexadecimal representation of sha256.
    */
-  fun sha256_128(text: String) = sha256(text, 16)
+  fun sha256_200(text: String) = sha256(text, 25)
 }

--- a/AndroidSDKTests/src/test/java/com/leanplum/migration/wrapper/IdentityManagerTest.kt
+++ b/AndroidSDKTests/src/test/java/com/leanplum/migration/wrapper/IdentityManagerTest.kt
@@ -1,0 +1,251 @@
+package com.leanplum.migration.wrapper
+
+import android.util.Log
+import com.leanplum.utils.HashUtil
+import org.junit.Assert.*
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.powermock.core.classloader.annotations.PrepareForTest
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import kotlin.properties.Delegates
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [16])
+@PrepareForTest(
+  Log::class,
+)
+class IdentityManagerTest {
+  val userId = "userId"
+  val deviceId = "deviceId"
+
+  val userId2 = "userId2"
+
+  // 6ccb21214ffd60b0fc2c1607cf6a05be6a0fed9c74819eb6a92e1bd6717b28eb
+  val userId_sha = "6ccb21214f"
+  // c9430313f85740d3c62dd8bf8c8d275165e96f830e7b1e6ddf3a89ba17ee5cce
+  val userId2_sha = "c9430313f8"
+
+  var state: String? = null
+  var mergedUserId: String? = null
+
+  val totalIdLengthLimit = 61
+
+  @Before
+  fun setup() {
+    state = null
+    mergedUserId = null
+  }
+
+  private fun createIdentityManager(deviceId: String, userId: String): IdentityManager {
+    return IdentityManager(
+      deviceId = deviceId,
+      userId = userId,
+      stateDelegate = Delegates.observable("undefined") { _, _, new ->
+        state = new
+      },
+      mergeUserDelegate = Delegates.observable(null) { _, _, new ->
+        mergedUserId = new
+      }
+    )
+  }
+
+  @Test
+  fun testProfile() {
+    val anonymousManager = createIdentityManager(deviceId, deviceId)
+    assertEquals(mapOf("Identity" to deviceId), anonymousManager.profile())
+
+    val identifiedManager = IdentityManager(deviceId, userId)
+    assertEquals(mapOf("Identity" to userId), identifiedManager.profile())
+  }
+
+  @Test
+  fun testUserIdHash() {
+    val lpIdentity = LPIdentity(deviceId, userId)
+    assertEquals(userId_sha, lpIdentity.userId())
+  }
+
+  @Test
+  fun testAnonymous() {
+    val identityManager = createIdentityManager(deviceId, deviceId)
+    assertTrue(identityManager.isAnonymous())
+    assertEquals("anonymous", state)
+    assertEquals(deviceId, identityManager.cleverTapId())
+  }
+
+  @Test
+  fun testIdentified() {
+    val identityManager = createIdentityManager(deviceId, userId)
+    assertFalse(identityManager.isAnonymous())
+    assertEquals("identified", state)
+    assertEquals("${deviceId}_${userId_sha}", identityManager.cleverTapId())
+  }
+
+  @Test
+  fun testIdentifiedNewUser() {
+    val identityManager = createIdentityManager(deviceId, userId)
+
+    identityManager.setUserId(userId2)
+
+    assertFalse(identityManager.isAnonymous())
+    assertEquals("identified", state)
+    assertEquals(mergedUserId, null)
+    assertEquals("${deviceId}_${userId2_sha}", identityManager.cleverTapId())
+    assertEquals(mapOf("Identity" to userId2), identityManager.profile())
+  }
+
+  @Test
+  fun testAnonymousLogin() {
+    val identityManager = createIdentityManager(deviceId, deviceId)
+
+    identityManager.setUserId(userId)
+
+    assertFalse(identityManager.isAnonymous())
+    assertEquals("identified", state)
+    assertEquals(mergedUserId, userId_sha)
+    assertEquals(deviceId, identityManager.cleverTapId())
+    assertEquals(mapOf("Identity" to userId), identityManager.profile())
+  }
+
+  @Test
+  fun testAnonymousLoginNewUser() {
+    val identityManager = createIdentityManager(deviceId, deviceId)
+
+    identityManager.setUserId(userId)
+    identityManager.setUserId(userId2)
+
+    assertFalse(identityManager.isAnonymous())
+    assertEquals("identified", state)
+    assertEquals(mergedUserId, userId_sha)
+    assertEquals("${deviceId}_$userId2_sha", identityManager.cleverTapId())
+    assertEquals(mapOf("Identity" to userId2), identityManager.profile())
+  }
+
+  @Test
+  fun testAnonymousLoginBack() {
+    val identityManager = createIdentityManager(deviceId, deviceId)
+
+    identityManager.setUserId(userId)
+    identityManager.setUserId(userId2)
+    identityManager.setUserId(userId)
+
+    assertFalse(identityManager.isAnonymous())
+    assertEquals("identified", state)
+    assertEquals(deviceId, identityManager.cleverTapId())
+  }
+
+  // TODO testAnonymousLoginStart ?
+
+  @Test
+  fun testAnonymousLimitDeviceId() {
+    val deviceId = "1".repeat(50)
+    val identityManager = createIdentityManager(deviceId, deviceId)
+
+    assertEquals(deviceId, identityManager.cleverTapId())
+    assertTrue(identityManager.cleverTapId().length <= totalIdLengthLimit)
+  }
+
+  @Test
+  fun testIdentifiedLimitDeviceId() {
+    val deviceId = "1".repeat(50)
+    val identityManager = createIdentityManager(deviceId, userId)
+
+    assertEquals("${deviceId}_$userId_sha", identityManager.cleverTapId())
+    assertEquals(totalIdLengthLimit, identityManager.cleverTapId().length)
+  }
+
+  @Test
+  fun testAnonymousLongDeviceId() {
+    val deviceId = "1".repeat(51)
+    val identityManager = createIdentityManager(deviceId, deviceId)
+
+    val deviceId_sha = HashUtil.sha256_128(deviceId)
+
+    assertEquals(deviceId_sha, identityManager.cleverTapId())
+    assertTrue(identityManager.cleverTapId().length <= totalIdLengthLimit)
+  }
+
+  @Test
+  fun testIdentifiedLongDeviceId() {
+    val deviceId = "1".repeat(51)
+    val identityManager = createIdentityManager(deviceId, userId)
+
+    val deviceId_sha = HashUtil.sha256_128(deviceId)
+
+    assertEquals("${deviceId_sha}_$userId_sha", identityManager.cleverTapId())
+    assertTrue(identityManager.cleverTapId().length <= totalIdLengthLimit)
+  }
+
+  @Test
+  fun testIdentifiedLongerDeviceId() {
+    val deviceId = "1".repeat(100)
+    val identityManager = createIdentityManager(deviceId, userId)
+
+    val deviceId_sha = HashUtil.sha256_128(deviceId)
+
+    assertEquals("${deviceId_sha}_$userId_sha", identityManager.cleverTapId())
+    assertTrue(identityManager.cleverTapId().length <= totalIdLengthLimit)
+  }
+
+  @Test
+  fun testAnonymousInvalidDeviceId() {
+    val deviceId = "&".repeat(10)
+    val identityManager = createIdentityManager(deviceId, deviceId)
+
+    val deviceId_sha = HashUtil.sha256_128(deviceId)
+
+    assertEquals(deviceId_sha, identityManager.cleverTapId())
+    assertTrue(identityManager.cleverTapId().length <= totalIdLengthLimit)
+  }
+
+  @Test
+  fun testIdentifiedInvalidDeviceId() {
+    val deviceId = "&".repeat(10)
+    val identityManager = createIdentityManager(deviceId, userId)
+
+    val deviceId_sha = HashUtil.sha256_128(deviceId)
+
+    assertEquals("${deviceId_sha}_$userId_sha", identityManager.cleverTapId())
+    assertTrue(identityManager.cleverTapId().length <= totalIdLengthLimit)
+  }
+
+  @Test
+  fun testIdentifiedEmailUserId() {
+    val userId = "test@test.com"
+    val identityManager = createIdentityManager(deviceId, userId)
+
+    // f660ab912ec121d1b1e928a0bb4bc61b15f5ad44d5efdc4e1c92a25e99b8e44a
+    val userId_sha = "f660ab912e"
+
+    assertEquals("${deviceId}_$userId_sha", identityManager.cleverTapId())
+    assertTrue(identityManager.cleverTapId().length <= totalIdLengthLimit)
+  }
+
+  @Test
+  fun testInvalidDeviceIds() {
+    listOf(
+      // -\:\"fcea8952-0ae1-411d-b23c-50661050ded1\"
+      "-\\:\\\"fcea8952-0ae1-411d-b23c-50661050ded1\\\"",
+      // abd6039873\",4562412546555904
+      "abd6039873\\\",4562412546555904",
+      // !22113163828\""
+      "!22113163828\\\"\"",
+      // "22121327322\",4562412546555904<newline>117669683\""
+      "\"22121327322\\\",4562412546555904\"\n117669683\\\"\"",
+      // 117669683\""
+      "117669683\\\"\"",
+      "嘁脂Ήᔠ䦐ࠐ䤰†",
+      "{{device.hardware_id}}",
+      "116115935'2",
+      "9d29641dc261454239456122f13de042b3a0cc3f45d4c27e7ddc97b300eb11aa"
+    ).forEach { deviceId ->
+        val hash = HashUtil.sha256_128(deviceId)
+        val identityManager = createIdentityManager(deviceId, userId)
+
+        println(hash)
+        assertEquals("${hash}_$userId_sha", identityManager.cleverTapId())
+      }
+  }
+
+}

--- a/AndroidSDKTests/src/test/java/com/leanplum/utils/HashUtilTest.kt
+++ b/AndroidSDKTests/src/test/java/com/leanplum/utils/HashUtilTest.kt
@@ -1,0 +1,91 @@
+package com.leanplum.utils
+
+import org.junit.Assert
+import org.junit.Test
+
+class HashUtilTest {
+
+  @Test
+  fun testSha256Variants() {
+    Assert.assertEquals("982d9e3eb9", HashUtil.sha256_40("text"))
+    Assert.assertEquals("982d9e3eb996f559e633f4d194def376", HashUtil.sha256_128("text"))
+  }
+
+  @Test
+  fun testSha256Normal() {
+    val strings = listOf(
+      "9d29641dc261454239456122f13de042b3a0cc3f45d4c27e7ddc97b300eb11aa",
+      "test@test.com",
+      "2ed5184d449e4bbbeef008569a79943c0b3996b1",
+      "33a4878d89f77737",
+      "CB226263-54C6-4BA9-BA10-CC6D083F9559",
+      "032bc2fd2e59449c",
+      "744E9F39-EDF1-4460-9C23-DF2827007295",
+      "E3311F58_D7BC_4154_8705_C614332E38A1")
+
+    val hashes = listOf(
+      "68a971cf29b8b95159a66317a22ab8eaaadae7140b177dd91345d2809ed9b08b",
+      "f660ab912ec121d1b1e928a0bb4bc61b15f5ad44d5efdc4e1c92a25e99b8e44a",
+      "2849cfc7e464db9e0aafe689f3389de51cd35c44585d6d6183319194deb15c82",
+      "64780c16b0a8897d390cb31aa788bd6a8bbbe488cac93d1aff0578746cb70f4b",
+      "235fcc26fe5ce4c8f9a307c38aa99f5dbb59f838c81218051c38786ad4d5f162",
+      "2ae02aa4705cd42b311f460148491c049d1d1c9e88f04fc2d2653c5b92b2c454",
+      "239bcb0aedf9594a9aea2dc59a5e8aba3a5c23cc203890e44a61c4950dab3052",
+      "9aa07b6f47bb0e01f5e43037ac1d6fc0b0a779e141fef1db715d3ac9497206f6")
+
+    strings.forEachIndexed { idx, it ->
+      val hash = HashUtil.sha256(it)
+      Assert.assertEquals(hashes[idx], hash)
+
+      val hash40 = HashUtil.sha256_40(it)
+      Assert.assertEquals(10, hash40.length)
+      Assert.assertTrue(hash.startsWith(hash40))
+
+      val hash128 = HashUtil.sha256_128(it)
+      Assert.assertEquals(32, hash128.length)
+      Assert.assertTrue(hash.startsWith(hash128))
+    }
+  }
+
+  @Test
+  fun testSha256Complex() {
+    val strings = listOf(
+      // -\:\"fcea8952-0ae1-411d-b23c-50661050ded1\"
+      "-\\:\\\"fcea8952-0ae1-411d-b23c-50661050ded1\\\"",
+      // abd6039873\",4562412546555904
+      "abd6039873\\\",4562412546555904",
+      // !22113163828\""
+      "!22113163828\\\"\"",
+      // "22121327322\",4562412546555904<newline>117669683\""
+      "\"22121327322\\\",4562412546555904\"\n117669683\\\"\"",
+      // 117669683\""
+      "117669683\\\"\"",
+      "嘁脂Ήᔠ䦐ࠐ䤰†",
+      "{{device.hardware_id}}",
+      "116115935'2")
+
+    val hashes = listOf(
+      "9d68d70f279f830c1e313e813c4b8d672669a8f1a89e87fa268a9a6bc328b704",
+      "5b2efdf24962f9c2678f9bb7d30508f499e2be39b928be1986d1eb70190bf2b4",
+      "6ca78ed8e23d7851d1d72d90c3b69bcbbbb32dbc8d691d59690d8c444724c372",
+      "8bc024a346531a167229f3e431bbec8cba2d73a8d0b0eff6a490e960ace4ddc5",
+      "62f3106d53b24f8755c67b49404af3df416f1c889ccf8867bf8eb6fabee82748",
+      "5aafde83f3d6a6e8cb35a058976af376fd84311e07a03b03dd9c30dc7c90cc61",
+      "03b5c746e38ff7753d8f4854fdaee8cab68d451523e0c534eb00af653816fbc7",
+      "68b400b82ffcaea8f34f883c54753a88a09beac0f14518c9aa4d55f21fd103f2")
+
+    strings.forEachIndexed { idx, it ->
+      val hash = HashUtil.sha256(it)
+      Assert.assertEquals(hashes[idx], hash)
+
+      val hash40 = HashUtil.sha256_40(it)
+      Assert.assertEquals(10, hash40.length)
+      Assert.assertTrue(hash.startsWith(hash40))
+
+      val hash128 = HashUtil.sha256_128(it)
+      Assert.assertEquals(32, hash128.length)
+      Assert.assertTrue(hash.startsWith(hash128))
+    }
+  }
+
+}

--- a/AndroidSDKTests/src/test/java/com/leanplum/utils/HashUtilTest.kt
+++ b/AndroidSDKTests/src/test/java/com/leanplum/utils/HashUtilTest.kt
@@ -8,7 +8,7 @@ class HashUtilTest {
   @Test
   fun testSha256Variants() {
     Assert.assertEquals("982d9e3eb9", HashUtil.sha256_40("text"))
-    Assert.assertEquals("982d9e3eb996f559e633f4d194def376", HashUtil.sha256_128("text"))
+    Assert.assertEquals("982d9e3eb996f559e633f4d194def3761d909f5a3b647d1a85", HashUtil.sha256_200("text"))
   }
 
   @Test
@@ -41,9 +41,9 @@ class HashUtilTest {
       Assert.assertEquals(10, hash40.length)
       Assert.assertTrue(hash.startsWith(hash40))
 
-      val hash128 = HashUtil.sha256_128(it)
-      Assert.assertEquals(32, hash128.length)
-      Assert.assertTrue(hash.startsWith(hash128))
+      val hash200 = HashUtil.sha256_200(it)
+      Assert.assertEquals(50, hash200.length)
+      Assert.assertTrue(hash.startsWith(hash200))
     }
   }
 
@@ -82,9 +82,9 @@ class HashUtilTest {
       Assert.assertEquals(10, hash40.length)
       Assert.assertTrue(hash.startsWith(hash40))
 
-      val hash128 = HashUtil.sha256_128(it)
-      Assert.assertEquals(32, hash128.length)
-      Assert.assertTrue(hash.startsWith(hash128))
+      val hash200 = HashUtil.sha256_200(it)
+      Assert.assertEquals(50, hash200.length)
+      Assert.assertTrue(hash.startsWith(hash200))
     }
   }
 


### PR DESCRIPTION
What              | Where/Who
------------------|----------------------------------------
JIRA Issue        | [SDK-2353](https://wizrocket.atlassian.net/browse/SDK-2353)
People Involved   | @hborisoff 

Added `LPIdentity` containing both deviceId and userId, where methods `deviceId()` and `userId()` return valid strings for CleverTap.

New format:

- anonymous `<CTID=deviceId, Identity=null>`
- non-anonymous `<CTID=deviceId_userIdHash, Identity=userId>`
- if invalid deviceId `deviceId=deviceIdHash`

The userId Hash is generated using the first 10 chars of the userId SHA256 string (hex).

If the deviceId does not pass validation or is longer than 50 characters, we use the first 32 chars of the deviceId SHA256 string (hex).