### PR TITLE
Start CT as soon as config is available

### DIFF
--- a/AndroidSDKCore/src/main/java/com/leanplum/Leanplum.java
+++ b/AndroidSDKCore/src/main/java/com/leanplum/Leanplum.java
@@ -64,6 +64,7 @@ import com.leanplum.internal.Util.DeviceIdInfo;
 import com.leanplum.internal.VarCache;
 import com.leanplum.messagetemplates.MessageTemplates;
 import com.leanplum.migration.MigrationManager;
+import com.leanplum.migration.model.MigrationConfig;
 import com.leanplum.models.GeofenceEventType;
 import com.leanplum.utils.BuildUtil;
 import com.leanplum.utils.SharedPreferencesUtil;
@@ -237,6 +238,7 @@ public class Leanplum {
 
     Constants.isDevelopmentModeEnabled = true;
     APIConfig.getInstance().setAppId(appId, accessKey);
+    MigrationConfig.setAppId(appId);
   }
 
   /**
@@ -258,6 +260,7 @@ public class Leanplum {
 
     Constants.isDevelopmentModeEnabled = false;
     APIConfig.getInstance().setAppId(appId, accessKey);
+    MigrationConfig.setAppId(appId);
   }
 
   /**

--- a/AndroidSDKCore/src/main/java/com/leanplum/internal/APIConfig.java
+++ b/AndroidSDKCore/src/main/java/com/leanplum/internal/APIConfig.java
@@ -27,6 +27,7 @@ import android.text.TextUtils;
 import androidx.annotation.VisibleForTesting;
 import com.leanplum.Leanplum;
 import com.leanplum.internal.Constants.Defaults;
+import com.leanplum.internal.Constants.Params;
 import com.leanplum.utils.SharedPreferencesUtil;
 import java.util.Map;
 
@@ -103,6 +104,11 @@ public class APIConfig {
 
   private void load() {
     Context context = Leanplum.getContext();
+    if (context == null) {
+      Log.e("Leanplum context is null. Please call Leanplum.setApplicationContext(context) "
+          + "before anything else.");
+      return;
+    }
     SharedPreferences defaults = context.getSharedPreferences(
         Constants.Defaults.LEANPLUM, Context.MODE_PRIVATE);
 
@@ -131,6 +137,11 @@ public class APIConfig {
 
   public void save() {
     Context context = Leanplum.getContext();
+    if (context == null) {
+      Log.e("Leanplum context is null. Please call Leanplum.setApplicationContext(context) "
+          + "before anything else.");
+      return;
+    }
     SharedPreferences defaults = context.getSharedPreferences(
         Constants.Defaults.LEANPLUM, Context.MODE_PRIVATE);
     SharedPreferences.Editor editor = defaults.edit();

--- a/AndroidSDKCore/src/main/java/com/leanplum/migration/model/MigrationConfig.kt
+++ b/AndroidSDKCore/src/main/java/com/leanplum/migration/model/MigrationConfig.kt
@@ -56,6 +56,9 @@ object MigrationConfig {
   var trackGooglePlayPurchases = true
     private set
 
+  @JvmStatic
+  var appId: String? by StringPreferenceNullable(key = "app_id")
+
   fun update(data: ResponseData) {
     state = data.state
     hash = data.hash


### PR DESCRIPTION
What              | Where/Who
------------------|----------------------------------------
People Involved   | @hborisoff 

Start CT SDK as soon as the config data is available to mimic standalone CT SDK behaviour.

This is needed because in RN LP SDK if CT's push notification arrives it is not forwarded to CT, because the wrapper is not yet initialised, waiting for the LP.start to be initiated, but the LP.start is done by the JS code and not the Application.onCreate.
