### PR TITLE
Allow multiple CT instance callbacks

### DIFF
--- a/AndroidSDKCore/src/main/java/com/leanplum/Leanplum.java
+++ b/AndroidSDKCore/src/main/java/com/leanplum/Leanplum.java
@@ -27,7 +27,6 @@ import android.text.TextUtils;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
-import com.clevertap.android.sdk.CleverTapAPI;
 import com.leanplum.ActionContext.ContextualValues;
 import com.leanplum.actions.internal.ActionDefinition;
 import com.leanplum.actions.internal.ActionManagerDefinitionKt;
@@ -2401,12 +2400,23 @@ public class Leanplum {
   }
 
   /**
-   * Sets callback object to be notified when CleverTapAPI instance is created.
+   * Adds a callback object to be notified when CleverTapAPI instance is created.
    * Use this callback to initialise any CleverTap state.
    *
-   * @param callback Null value will remove the callback.
+   * Remove callback with {@link #removeCleverTapInstanceCallback(CleverTapInstanceCallback)}.
+   *
+   * @param callback Your callback instance.
    */
-  public static void onCleverTapInstanceInitialized(@Nullable CleverTapInstanceCallback callback) {
-    MigrationManager.setCleverTapInstanceCallback(callback);
+  public static void addCleverTapInstanceCallback(@NonNull CleverTapInstanceCallback callback) {
+    MigrationManager.addCleverTapInstanceCallback(callback);
+  }
+
+  /**
+   * Removes the callback for the CleverTap instance.
+   *
+   * @param callback Callback to remove.
+   */
+  public static void removeCleverTapInstanceCallback(@NonNull CleverTapInstanceCallback callback) {
+    MigrationManager.removeCleverTapInstanceCallback(callback);
   }
 }

--- a/AndroidSDKCore/src/main/java/com/leanplum/actions/internal/ActionManagerDefinition.kt
+++ b/AndroidSDKCore/src/main/java/com/leanplum/actions/internal/ActionManagerDefinition.kt
@@ -107,8 +107,9 @@ private fun areActionDefinitionsEqual(a: Map<String, Any?>?, b: Map<String, Any?
     if (value == null || b[key] == null) {
       return false
     }
-    val aItem = value as Map<String, Any>
-    val bItem = b[key] as Map<String, Any>
+
+    val aItem = value as Map<*, *>
+    val bItem = b[key] as Map<*, *>
 
     val aKind = aItem["kind"]
     val aValues = aItem["values"]

--- a/AndroidSDKCore/src/main/java/com/leanplum/migration/MigrationManager.kt
+++ b/AndroidSDKCore/src/main/java/com/leanplum/migration/MigrationManager.kt
@@ -42,12 +42,25 @@ object MigrationManager {
     @Synchronized get
     private set
 
+  /**
+   * List is kept the same as the one in IWrapper instance, because if wrapper state is changed it
+   * would still continue to work.
+   */
+  private val instanceCallbackList: MutableList<CleverTapInstanceCallback> = mutableListOf()
+
   @JvmStatic
-  var cleverTapInstanceCallback: CleverTapInstanceCallback? = null
-    set(value) {
-      field = value
-      wrapper.setInstanceCallback(value)
-    }
+  @Synchronized
+  fun addCleverTapInstanceCallback(callback: CleverTapInstanceCallback) {
+    instanceCallbackList.add(callback)
+    wrapper.addInstanceCallback(callback)
+  }
+
+  @JvmStatic
+  @Synchronized
+  fun removeCleverTapInstanceCallback(callback: CleverTapInstanceCallback) {
+    instanceCallbackList.remove(callback)
+    wrapper.removeInstanceCallback(callback)
+  }
 
   @JvmStatic
   @Synchronized
@@ -60,7 +73,7 @@ object MigrationManager {
     if (getState().useCleverTap()
       && (wrapper == NullWrapper || wrapper == StaticMethodsWrapper)
     ) {
-      wrapper = WrapperFactory.createWrapper(cleverTapInstanceCallback)
+      wrapper = WrapperFactory.createWrapper(instanceCallbackList)
     } else if (wrapper != NullWrapper && !getState().useCleverTap()) {
       wrapper = NullWrapper
     }

--- a/AndroidSDKCore/src/main/java/com/leanplum/migration/wrapper/IWrapper.kt
+++ b/AndroidSDKCore/src/main/java/com/leanplum/migration/wrapper/IWrapper.kt
@@ -36,9 +36,11 @@ interface IWrapper {
 
   val miPushHandler: MiPushMigrationHandler? get() = null
 
-  fun launch(context: Context, callback: CleverTapInstanceCallback?) = Unit
+  fun launch(context: Context, callbacks: List<CleverTapInstanceCallback>) = Unit
 
-  fun setInstanceCallback(callback: CleverTapInstanceCallback?) = Unit
+  fun addInstanceCallback(callback: CleverTapInstanceCallback) = Unit
+
+  fun removeInstanceCallback(callback: CleverTapInstanceCallback) = Unit
 
   fun setUserId(userId: String?) = Unit
 

--- a/AndroidSDKCore/src/main/java/com/leanplum/migration/wrapper/WrapperFactory.kt
+++ b/AndroidSDKCore/src/main/java/com/leanplum/migration/wrapper/WrapperFactory.kt
@@ -34,7 +34,7 @@ import kotlin.system.measureTimeMillis
 
 internal object WrapperFactory {
 
-  fun createWrapper(callback: CleverTapInstanceCallback?): IWrapper {
+  fun createWrapper(callbacks: List<CleverTapInstanceCallback>): IWrapper {
     val account = MigrationConfig.accountId
     val token = MigrationConfig.accountToken
     val region = MigrationConfig.accountRegion
@@ -61,7 +61,7 @@ internal object WrapperFactory {
 
     return CTWrapper(account, token, region, deviceId, userId).apply {
       val timeToLaunch = measureTimeMillis {
-        launch(context, callback)
+        launch(context, callbacks)
       }
       Log.d("Wrapper: launch took $timeToLaunch millis")
     }


### PR DESCRIPTION
What              | Where/Who
------------------|----------------------------------------
People Involved   | @hborisoff 

## Background
In some cases we need several instance callbacks, for example when adding callback in RN JS code and we want to add another callback in RN Android native code.

Fixed minor warning message in ActionManagerDefinition.