### PR TITLE
Skip proguard for CT's BuildConfig

### DIFF
--- a/AndroidSDKCore/consumer-proguard-rules.pro
+++ b/AndroidSDKCore/consumer-proguard-rules.pro
@@ -9,3 +9,6 @@
 # Keep bytebuddy classes.
 -keep class net.bytebuddy.** { *; }
 -dontwarn net.bytebuddy.**
+
+# Reflection is used to get CT version in runtime
+-keep class com.clevertap.android.sdk.BuildConfig { *; }


### PR DESCRIPTION
What              | Where/Who
------------------|----------------------------------------
People Involved   | @hborisoff 

Add proguard exclusion rule for CT's BuildConfig, which is accessed by reflection from Leanplum SDK.
