### PR TITLE
Fix concurrency exception for the action definitions.

### DIFF
--- a/AndroidSDKCore/src/main/java/com/leanplum/internal/VarCache.java
+++ b/AndroidSDKCore/src/main/java/com/leanplum/internal/VarCache.java
@@ -577,7 +577,7 @@ public class VarCache {
         Map<String, Object> actionArgs = CollectionUtil.uncheckedCast(messageConfig.get(Constants
             .Keys.VARS));
         Map<String, Object> actionDefinitions =
-            ActionManagerDefinitionKt.getActionDefinitionMaps(ActionManager.getInstance());
+            ActionManager.getInstance().getDefinitions().getActionDefinitionMaps();
         Map<String, Object> defaultArgs = Util.multiIndex(actionDefinitions,
             newConfig.get(Constants.Params.ACTION), "values");
         Map<String, Object> vars = CollectionUtil.uncheckedCast(mergeHelper(defaultArgs,
@@ -666,7 +666,7 @@ public class VarCache {
       changed = true;
     }
     Map<String, Object> actionDefinitions =
-        ActionManagerDefinitionKt.getActionDefinitionMaps(ActionManager.getInstance());
+        ActionManager.getInstance().getDefinitions().getActionDefinitionMaps();
 
     boolean areLocalAndServerDefinitionsEqual =
         ActionManagerDefinitionKt.areLocalAndServerDefinitionsEqual(ActionManager.getInstance());
@@ -901,7 +901,7 @@ public class VarCache {
     fileStreams.clear();
     valuesFromClient.clear();
     defaultKinds.clear();
-    ActionManager.getInstance().getDefinitions().getActionDefinitions().clear();
+    ActionManager.getInstance().getDefinitions().clear();
     diffs.clear();
     messageDiffs.clear();
     regions.clear();

--- a/AndroidSDKTests/src/test/java/com/leanplum/actions/internal/ActionManagerExecutionTest.kt
+++ b/AndroidSDKTests/src/test/java/com/leanplum/actions/internal/ActionManagerExecutionTest.kt
@@ -41,7 +41,7 @@ class ActionManagerExecutionTest : AbstractTest() {
     ActionManager.getInstance().currentAction = null
     ActionManager.getInstance().messageDisplayController = null
     ActionManager.getInstance().messageDisplayListener = null
-    ActionManager.getInstance().definitions.actionDefinitions.clear()
+    ActionManager.getInstance().definitions.clear()
     ActionManager.getInstance().scheduler = ActionScheduler()
     LeanplumActions.setDismissOnPushOpened(true)
   }


### PR DESCRIPTION
What              | Where/Who
------------------|----------------------------------------
JIRA Issue        | [SDK-2477](https://wizrocket.atlassian.net/browse/SDK-2477)
People Involved   | @hborisoff 

A concurrency issue when defining actions from a background thread was [reported](https://github.com/Leanplum/Leanplum-Android-SDK/issues/533). This change synhronizes access to shared data.