### PR TITLE
Support Android 13 and request notification permission

### DIFF
--- a/AndroidSDKCore/src/main/java/com/leanplum/messagetemplates/MessageTemplateConstants.java
+++ b/AndroidSDKCore/src/main/java/com/leanplum/messagetemplates/MessageTemplateConstants.java
@@ -15,7 +15,7 @@ public class MessageTemplateConstants {
     public static final String CANCEL_ACTION = "Cancel action";
     public static final String DISMISS_ACTION = "Dismiss action";
 
-    // Center popup/interstitial arguments.
+    // Center popup / interstitial / Push Pre-Permission arguments.
     public static final String TITLE_TEXT = "Title.Text";
     public static final String TITLE_COLOR = "Title.Color";
     public static final String MESSAGE_TEXT = "Message.Text";
@@ -23,6 +23,9 @@ public class MessageTemplateConstants {
     public static final String ACCEPT_BUTTON_TEXT = "Accept button.Text";
     public static final String ACCEPT_BUTTON_BACKGROUND_COLOR = "Accept button.Background color";
     public static final String ACCEPT_BUTTON_TEXT_COLOR = "Accept button.Text color";
+    public static final String CANCEL_BUTTON_TEXT = "Cancel button.Text";
+    public static final String CANCEL_BUTTON_BACKGROUND_COLOR = "Cancel button.Background color";
+    public static final String CANCEL_BUTTON_TEXT_COLOR = "Cancel button.Text color";
     public static final String BACKGROUND_IMAGE = "Background image";
     public static final String BACKGROUND_COLOR = "Background color";
     public static final String LAYOUT_WIDTH = "Layout.Width";
@@ -51,9 +54,11 @@ public class MessageTemplateConstants {
     public static final String CONFIRM_MESSAGE = "Confirmation message goes here.";
     public static final String POPUP_MESSAGE = "Popup message goes here.";
     public static final String INTERSTITIAL_MESSAGE = "Interstitial message goes here.";
+    public static final String PUSH_PRE_PERMISSION_MESSAGE = "Tap OK to receive important notifications from our app.";
     public static final String OK_TEXT = "OK";
     public static final String YES_TEXT = "Yes";
     public static final String NO_TEXT = "No";
+    public static final String MAYBE_LATER = "Maybe Later";
     public static final int CENTER_POPUP_WIDTH = 300;
     public static final int CENTER_POPUP_HEIGHT = 250;
     public static final int DEFAULT_HTML_HEIGHT = 0;

--- a/AndroidSDKCore/src/main/java/com/leanplum/messagetemplates/MessageTemplates.java
+++ b/AndroidSDKCore/src/main/java/com/leanplum/messagetemplates/MessageTemplates.java
@@ -34,6 +34,8 @@ import com.leanplum.internal.ActionManager;
 import com.leanplum.messagetemplates.actions.AlertMessage;
 import com.leanplum.messagetemplates.actions.CenterPopupMessage;
 import com.leanplum.messagetemplates.actions.InterstitialMessage;
+import com.leanplum.messagetemplates.actions.PushPrePermission;
+import com.leanplum.messagetemplates.actions.RegisterForPush;
 import com.leanplum.messagetemplates.actions.RichHtmlMessage;
 import com.leanplum.messagetemplates.actions.WebInterstitialMessage;
 import com.leanplum.messagetemplates.actions.ConfirmMessage;
@@ -136,5 +138,7 @@ public class MessageTemplates {
     registerTemplate(new InterstitialMessage(), context);
     registerTemplate(new WebInterstitialMessage(), context);
     registerTemplate(new RichHtmlMessage(), context);
+    registerAction(new RegisterForPush(), context);
+    registerTemplate(new PushPrePermission(), context);
   }
 }

--- a/AndroidSDKCore/src/main/java/com/leanplum/messagetemplates/actions/PushPrePermission.java
+++ b/AndroidSDKCore/src/main/java/com/leanplum/messagetemplates/actions/PushPrePermission.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2023, Leanplum, Inc. All rights reserved.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.leanplum.messagetemplates.actions;
+
+import android.app.Activity;
+import android.content.Context;
+import androidx.annotation.NonNull;
+import com.leanplum.ActionArgs;
+import com.leanplum.ActionContext;
+import com.leanplum.LeanplumActivityHelper;
+import com.leanplum.internal.Log;
+import com.leanplum.internal.OperationQueue;
+import com.leanplum.messagetemplates.MessageTemplate;
+import com.leanplum.messagetemplates.controllers.CenterPopupController;
+import com.leanplum.messagetemplates.options.PushPrePermissionOptions;
+import com.leanplum.utils.PushPermissionUtilKt;
+
+public class PushPrePermission implements MessageTemplate {
+  private static final String PUSH_ASK_TO_ASK = "Push Ask to Ask";
+
+  private CenterPopupController popup;
+
+  @NonNull
+  @Override
+  public String getName() {
+    return PUSH_ASK_TO_ASK;
+  }
+
+  @NonNull
+  @Override
+  public ActionArgs createActionArgs(@NonNull Context context) {
+    return PushPrePermissionOptions.toArgs(context);
+  }
+
+  @Override
+  public boolean present(@NonNull ActionContext context) {
+    Activity activity = LeanplumActivityHelper.getCurrentActivity();
+    if (activity == null || activity.isFinishing()) {
+      return false;
+    }
+
+    if (PushPermissionUtilKt.shouldShowPrePermission(activity)) {
+      showPrePermission(context, activity);
+      return true;
+    } else if (PushPermissionUtilKt.shouldShowRegisterForPush(activity)) {
+      showRegisterForPush(context, activity);
+      return true;
+    } else {
+      // nothing to do
+      Log.d("Will not show Push Pre-Permission dialog because:");
+      PushPermissionUtilKt.printDebugLog(activity);
+      return false;
+    }
+  }
+
+  private void showPrePermission(ActionContext context, Activity activity) {
+    PushPrePermissionOptions options = new PushPrePermissionOptions(context);
+    popup = new CenterPopupController(activity, options);
+    popup.setOnDismissListener(listener -> {
+      popup = null;
+      context.actionDismissed();
+    });
+    popup.show();
+  }
+
+  private void showRegisterForPush(ActionContext context, Activity activity) {
+    // Run after ActionManagerExecution code
+    OperationQueue.sharedInstance().addUiOperation(() -> {
+      context.actionDismissed();
+      // Flow of permission request will be shown on top of any other in-app
+      PushPermissionUtilKt.requestNativePermission(activity);
+    });
+  }
+
+  @Override
+  public boolean dismiss(@NonNull ActionContext context) {
+    if (popup != null) {
+      popup.dismiss();
+    }
+    return true;
+  }
+}

--- a/AndroidSDKCore/src/main/java/com/leanplum/messagetemplates/actions/RegisterForPush.java
+++ b/AndroidSDKCore/src/main/java/com/leanplum/messagetemplates/actions/RegisterForPush.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2023, Leanplum, Inc. All rights reserved.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.leanplum.messagetemplates.actions;
+
+import android.app.Activity;
+import android.content.Context;
+import androidx.annotation.NonNull;
+import com.leanplum.ActionArgs;
+import com.leanplum.ActionContext;
+import com.leanplum.LeanplumActivityHelper;
+import com.leanplum.internal.Log;
+import com.leanplum.internal.OperationQueue;
+import com.leanplum.messagetemplates.MessageTemplate;
+import com.leanplum.utils.PushPermissionUtilKt;
+
+public class RegisterForPush implements MessageTemplate {
+  private static final String REGISTER_FOR_PUSH = "Register For Push";
+
+  @NonNull
+  @Override
+  public String getName() {
+    return REGISTER_FOR_PUSH;
+  }
+
+  @NonNull
+  @Override
+  public ActionArgs createActionArgs(@NonNull Context context) {
+    return new ActionArgs();
+  }
+
+  @Override
+  public boolean present(@NonNull ActionContext context) {
+    Activity activity = LeanplumActivityHelper.getCurrentActivity();
+    if (activity == null || activity.isFinishing()) {
+      return false;
+    }
+
+    if (PushPermissionUtilKt.shouldShowRegisterForPush(activity)) {
+      showRegisterForPush(context, activity);
+      return true;
+    } else {
+      Log.d("Will not show Register For Push dialog because:");
+      PushPermissionUtilKt.printDebugLog(activity);
+      return false;
+    }
+  }
+
+  private void showRegisterForPush(ActionContext context, Activity activity) {
+    // Run after the other ActionManagerExecution code
+    OperationQueue.sharedInstance().addUiOperation(() -> {
+      context.actionDismissed();
+      // Flow of permission request will be shown on top of any other in-app
+      PushPermissionUtilKt.requestNativePermission(activity);
+    });
+  }
+
+  @Override
+  public boolean dismiss(@NonNull ActionContext context) {
+    // nothing to do
+    return true;
+  }
+}

--- a/AndroidSDKCore/src/main/java/com/leanplum/messagetemplates/controllers/BaseController.java
+++ b/AndroidSDKCore/src/main/java/com/leanplum/messagetemplates/controllers/BaseController.java
@@ -50,6 +50,8 @@ abstract class BaseController extends Dialog {
 
   protected boolean isClosing = false;
 
+  protected boolean hasDismissButton = false;
+
   protected BaseController(Activity activity) {
     super(activity, ViewUtils.getThemeId(activity));
     this.activity = activity;
@@ -62,7 +64,7 @@ abstract class BaseController extends Dialog {
     RelativeLayout messageView = createMessageView();
     contentView.addView(messageView);
 
-    if (hasDismissButton()) {
+    if (hasDismissButton) {
       CloseButton closeButton = createCloseButton(messageView);
       contentView.addView(closeButton);
     }
@@ -107,8 +109,6 @@ abstract class BaseController extends Dialog {
    * Creates and adds all message specific child views.
    */
   abstract void addMessageChildViews(RelativeLayout parent);
-
-  abstract boolean hasDismissButton();
 
   abstract boolean isFullscreen();
 

--- a/AndroidSDKCore/src/main/java/com/leanplum/messagetemplates/controllers/RichHtmlController.java
+++ b/AndroidSDKCore/src/main/java/com/leanplum/messagetemplates/controllers/RichHtmlController.java
@@ -71,11 +71,6 @@ public class RichHtmlController extends BaseController {
   }
 
   @Override
-  boolean hasDismissButton() {
-    return false;
-  }
-
-  @Override
   boolean isFullscreen() {
     return richOptions.isFullScreen();
   }
@@ -332,7 +327,7 @@ public class RichHtmlController extends BaseController {
     if (Build.VERSION.SDK_INT >= 17) {
       webViewSettings.setMediaPlaybackRequiresUserGesture(false);
     }
-    webViewSettings.setAppCacheEnabled(true);
+    webViewSettings.setCacheMode(WebSettings.LOAD_NO_CACHE);
     webViewSettings.setAllowFileAccess(true);
     webViewSettings.setJavaScriptEnabled(true);
     webViewSettings.setDomStorageEnabled(true);

--- a/AndroidSDKCore/src/main/java/com/leanplum/messagetemplates/controllers/WebInterstitialController.java
+++ b/AndroidSDKCore/src/main/java/com/leanplum/messagetemplates/controllers/WebInterstitialController.java
@@ -47,13 +47,9 @@ public class WebInterstitialController extends BaseController {
   public WebInterstitialController(Activity activity, @NonNull WebInterstitialOptions options) {
     super(activity);
     this.webOptions = options;
+    this.hasDismissButton = webOptions.hasDismissButton();
 
     init();
-  }
-
-  @Override
-  protected boolean hasDismissButton() {
-    return webOptions.hasDismissButton();
   }
 
   @Override

--- a/AndroidSDKCore/src/main/java/com/leanplum/messagetemplates/options/BaseMessageOptions.java
+++ b/AndroidSDKCore/src/main/java/com/leanplum/messagetemplates/options/BaseMessageOptions.java
@@ -52,6 +52,9 @@ public abstract class BaseMessageOptions {
   private String acceptButtonText;
   private int acceptButtonBackgroundColor;
   private int acceptButtonTextColor;
+  private String cancelButtonText;
+  private int cancelButtonBgColor;
+  private int cancelButtonTextColor;
 
   protected BaseMessageOptions(ActionContext context) {
     this.context = context;
@@ -73,6 +76,11 @@ public abstract class BaseMessageOptions {
         Args.ACCEPT_BUTTON_BACKGROUND_COLOR).intValue());
     setAcceptButtonTextColor(context.numberNamed(
         Args.ACCEPT_BUTTON_TEXT_COLOR).intValue());
+
+    // optional, used in Push Pre-Permission
+    cancelButtonText = context.stringNamed(Args.CANCEL_BUTTON_TEXT);
+    cancelButtonBgColor = context.numberNamed(Args.CANCEL_BUTTON_BACKGROUND_COLOR).intValue();
+    cancelButtonTextColor = context.numberNamed(Args.CANCEL_BUTTON_TEXT_COLOR).intValue();
   }
 
   public int getBackgroundColor() {
@@ -151,12 +159,36 @@ public abstract class BaseMessageOptions {
     this.acceptButtonTextColor = color;
   }
 
+  public String getCancelButtonText() {
+    return cancelButtonText;
+  }
+
+  public int getCancelButtonBgColor() {
+    return cancelButtonBgColor;
+  }
+
+  public int getCancelButtonTextColor() {
+    return cancelButtonTextColor;
+  }
+
+  public boolean hasCancelButtonNextToAccept() {
+    return cancelButtonText != null;
+  }
+
+  public void cancel() {
+    context.runTrackedActionNamed(Args.CANCEL_ACTION);
+  }
+
   public void accept() {
     context.runTrackedActionNamed(Args.ACCEPT_ACTION);
   }
 
   public void dismiss() {
     context.runActionNamed(Args.DISMISS_ACTION);
+  }
+
+  public boolean hasDismissButton() {
+    return true;
   }
 
   public static ActionArgs toArgs(Context currentContext) {
@@ -171,5 +203,24 @@ public abstract class BaseMessageOptions {
         .withColor(Args.ACCEPT_BUTTON_BACKGROUND_COLOR, Color.WHITE)
         .withColor(Args.ACCEPT_BUTTON_TEXT_COLOR, Color.argb(255, 0, 122, 255))
         .withAction(Args.ACCEPT_ACTION, null);
+  }
+
+  static ActionArgs createPushPrePermissionArgs(Context context) {
+    return new ActionArgs()
+        .with(Args.TITLE_TEXT, Util.getApplicationName(context))
+        .withColor(Args.TITLE_COLOR, Color.BLACK)
+        .with(Args.MESSAGE_TEXT, Values.PUSH_PRE_PERMISSION_MESSAGE) // replaced Values.POPUP_MESSAGE
+        .withColor(Args.MESSAGE_COLOR, Color.BLACK)
+        .withFile(Args.BACKGROUND_IMAGE, null)
+        .withColor(Args.BACKGROUND_COLOR, Color.WHITE)
+        .with(Args.ACCEPT_BUTTON_TEXT, Values.OK_TEXT)
+        .withColor(Args.ACCEPT_BUTTON_BACKGROUND_COLOR, Color.WHITE)
+        .withColor(Args.ACCEPT_BUTTON_TEXT_COLOR, Color.argb(255, 0, 122, 255))
+        // .withAction(Args.ACCEPT_ACTION, null) - accept action not available, will call native prompt
+        // new arguments
+        .withAction(Args.CANCEL_ACTION, null)
+        .with(Args.CANCEL_BUTTON_TEXT, Values.MAYBE_LATER)
+        .with(Args.CANCEL_BUTTON_BACKGROUND_COLOR, Color.WHITE)
+        .with(Args.CANCEL_BUTTON_TEXT_COLOR, Color.argb(255, 127, 127, 127)); // light grey
   }
 }

--- a/AndroidSDKCore/src/main/java/com/leanplum/messagetemplates/options/PushPrePermissionOptions.java
+++ b/AndroidSDKCore/src/main/java/com/leanplum/messagetemplates/options/PushPrePermissionOptions.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2023, Leanplum, Inc. All rights reserved.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.leanplum.messagetemplates.options;
+
+import android.app.Activity;
+import android.content.Context;
+import com.leanplum.ActionArgs;
+import com.leanplum.ActionContext;
+import com.leanplum.LeanplumActivityHelper;
+import com.leanplum.messagetemplates.MessageTemplateConstants;
+import com.leanplum.messagetemplates.MessageTemplateConstants.Args;
+import com.leanplum.utils.PushPermissionUtilKt;
+
+public class PushPrePermissionOptions extends CenterPopupOptions {
+
+  public PushPrePermissionOptions(ActionContext context) {
+    super(context);
+  }
+
+  /**
+   * Overrides the default accept action, because for PushPrePermission we want behavior similar to
+   * iOS, where the accept action is not added in arguments and it is set as a callback.
+   */
+  @Override
+  public void accept() {
+    Activity activity = LeanplumActivityHelper.getCurrentActivity();
+    if (activity == null || activity.isFinishing()) {
+      return;
+    }
+    PushPermissionUtilKt.requestNativePermission(activity);
+    super.accept(); // tracks accept event
+  }
+
+  @Override
+  public boolean hasDismissButton() {
+    return false;
+  }
+
+  public static ActionArgs toArgs(Context context) {
+    return BaseMessageOptions.createPushPrePermissionArgs(context)
+        .with(Args.LAYOUT_WIDTH, MessageTemplateConstants.Values.CENTER_POPUP_WIDTH)
+        .with(Args.LAYOUT_HEIGHT, MessageTemplateConstants.Values.CENTER_POPUP_HEIGHT);
+  }
+}

--- a/AndroidSDKCore/src/main/java/com/leanplum/utils/BuildUtil.java
+++ b/AndroidSDKCore/src/main/java/com/leanplum/utils/BuildUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021, Leanplum, Inc. All rights reserved.
+ * Copyright 2023, Leanplum, Inc. All rights reserved.
  *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
@@ -23,6 +23,7 @@ package com.leanplum.utils;
 import android.app.PendingIntent;
 import android.content.Context;
 import android.os.Build;
+import androidx.annotation.NonNull;
 
 /**
  * Utilities related to Build Version and target SDK.
@@ -40,6 +41,10 @@ public class BuildUtil {
    */
   public static boolean isNotificationChannelSupported(Context context) {
     return Build.VERSION.SDK_INT >= 26 && getTargetSdkVersion(context) >= 26;
+  }
+
+  public static boolean isPushPermissionSupported(@NonNull Context context) {
+    return Build.VERSION.SDK_INT >= 33 && getTargetSdkVersion(context) >= 33;
   }
 
   /**

--- a/AndroidSDKCore/src/main/java/com/leanplum/utils/PushPermissionUtil.kt
+++ b/AndroidSDKCore/src/main/java/com/leanplum/utils/PushPermissionUtil.kt
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2023, Leanplum, Inc. All rights reserved.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.leanplum.utils
+
+import android.Manifest
+import android.annotation.TargetApi
+import android.app.Activity
+import android.content.pm.PackageManager
+import androidx.core.app.ActivityCompat
+import androidx.core.app.NotificationManagerCompat
+import androidx.core.content.ContextCompat
+import com.leanplum.internal.Log
+
+/**
+ * Could be changed by client if code is already in use. Request code can be used in activity's
+ * onRequestPermissionsResult method to receive feedback whether the permission was granted or not.
+ */
+var pushPermissionRequestCode = 1233321
+
+@TargetApi(33)
+private fun isNotificationPermissionGranted(activity: Activity): Boolean {
+  val res = ContextCompat.checkSelfPermission(activity, Manifest.permission.POST_NOTIFICATIONS)
+  return res == PackageManager.PERMISSION_GRANTED
+}
+
+@TargetApi(33)
+fun shouldShowRegisterForPush(activity: Activity): Boolean {
+  return BuildUtil.isPushPermissionSupported(activity)
+      && !isNotificationPermissionGranted(activity)
+      && !NotificationManagerCompat.from(activity.applicationContext).areNotificationsEnabled()
+}
+
+@TargetApi(33)
+fun shouldShowPrePermission(activity: Activity): Boolean {
+  return shouldShowRegisterForPush(activity)
+      && ActivityCompat.shouldShowRequestPermissionRationale(activity, Manifest.permission.POST_NOTIFICATIONS)
+}
+
+@TargetApi(33)
+fun requestNativePermission(activity: Activity) {
+  activity.requestPermissions(
+    arrayOf(Manifest.permission.POST_NOTIFICATIONS),
+    pushPermissionRequestCode)
+}
+
+fun printDebugLog(activity: Activity) {
+  if (BuildUtil.isPushPermissionSupported(activity)) {
+    val permissionGranted = isNotificationPermissionGranted(activity)
+    val notificationsEnabled = NotificationManagerCompat
+      .from(activity.applicationContext)
+      .areNotificationsEnabled()
+    val shouldShowRequestPermissionRationale = ActivityCompat
+      .shouldShowRequestPermissionRationale(activity, Manifest.permission.POST_NOTIFICATIONS)
+
+    Log.d("Notification permission: granted=$permissionGranted " +
+        "notificationsEnabled=$notificationsEnabled " +
+        "shouldShowRequestPermissionRationale=$shouldShowRequestPermissionRationale")
+  } else {
+    Log.d("Notification permission: not supported by target or device version")
+  }
+}

--- a/AndroidSDKCore/src/main/res/values/ids.xml
+++ b/AndroidSDKCore/src/main/res/values/ids.xml
@@ -3,5 +3,7 @@
     <item name="container_view" type="id"/>
     <item name="close_button" type="id"/>
     <item name="title_view" type="id"/>
+    <item name="button_container" type="id"/>
     <item name="accept_button" type="id"/>
+    <item name="cancel_button" type="id"/>
 </resources>

--- a/AndroidSDKPush/src/main/AndroidManifest.xml
+++ b/AndroidSDKPush/src/main/AndroidManifest.xml
@@ -2,6 +2,9 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.leanplum.push">
 
+    <!-- New permission required by Android 13 to post notifications. -->
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS"/>
+
     <application>
         <receiver android:name="com.leanplum.LeanplumJobStartReceiver" />
         <!-- Leanplum Local Push Notification Service. -->

--- a/common-methods.gradle
+++ b/common-methods.gradle
@@ -1,6 +1,6 @@
 // Export methods by turning them into closures
 ext {
-    COMPILE_SDK_VERSION = 31
+    COMPILE_SDK_VERSION = 33
     APPCOMPAT_LIBRARY_VERSION = '1.2.0'
     CT_SDK_VERSION = '4.6.6'
     MIN_SDK_VERSION = 16


### PR DESCRIPTION
What              | Where/Who
------------------|----------------------------------------
JIRA Issue        | [SDK-1847](https://wizrocket.atlassian.net/browse/SDK-1847)
People Involved   | @hborisoff 

- Bumped compile SDK to 33.
- Added new message templates - `RegisterForPush`, `PushPrePermission`. First one is an action requesting the `POST_NOTIFICATIONS` permission, the second one is for a dialog with details why the permission is required.
- Added permission to post notifications in `leanplum-push` module's manifest.
- `PushPrePermission` is implemented similarly to `LPPushAskToAskMessageTemplate` in iOS, which is the reason to extend `AbstractPopupController` with functionality to hide the `Dismiss` button and to add a new `Cancel` button next to the `Accept` button.
- `webViewSettings.setAppCacheEnabled` is deprecated and replaced by `webViewSettings.setCacheMode`
- When requesting the `POST_NOTIFICATIONS` permission the developer could override `onRequestPermissionsResult` in his activity and gain access to the feedback whether the permission was granted by the user or not. Also the request code could be changed in `PushPermissionUtil.pushPermissionRequestCode`.

Check the internal [documentation](https://wizrocket.atlassian.net/wiki/spaces/PM/pages/3890806931/PRD+Leanplum+Android+Push+Primer+Pre-Permission) for a specification and resources on the feature.