### PR TITLE
Use identity keys in CT configuration

### DIFF
--- a/AndroidSDKCore/src/main/java/com/leanplum/internal/Constants.java
+++ b/AndroidSDKCore/src/main/java/com/leanplum/internal/Constants.java
@@ -167,6 +167,7 @@ public class Constants {
     public static final String CT_TOKEN = "token";
     public static final String CT_REGION_CODE = "regionCode";
     public static final String CT_ATTRIBUTE_MAPPINGS = "attributeMappings";
+    public static final String CT_IDENTITY_KEYS = "identityKeys";
     public static final String API_EVENTS_STATE = "events";
   }
 

--- a/AndroidSDKCore/src/main/java/com/leanplum/migration/ResponseHandler.kt
+++ b/AndroidSDKCore/src/main/java/com/leanplum/migration/ResponseHandler.kt
@@ -25,6 +25,7 @@ import com.leanplum.internal.Constants.Params
 import com.leanplum.internal.Log
 import com.leanplum.migration.model.MigrationState
 import com.leanplum.migration.model.ResponseData
+import org.json.JSONArray
 import org.json.JSONException
 import org.json.JSONObject
 
@@ -68,6 +69,7 @@ class ResponseHandler {
           var token: String? = null
           var regionCode: String? = null
           var attributeMappings: String? = null
+          var identityKeysCsv: String? = null
           json.optJSONObject(Params.CLEVERTAP)?.apply {
             accountId = optString(Params.CT_ACCOUNT_ID)
             token = optString(Params.CT_TOKEN)
@@ -75,8 +77,15 @@ class ResponseHandler {
             optJSONObject(Params.CT_ATTRIBUTE_MAPPINGS)?.let {
               attributeMappings = it.toString()
             }
+            optJSONArray(Params.CT_IDENTITY_KEYS)?.let {
+              val keys = mutableListOf<String>()
+              for (i in 0 until it.length()) {
+                keys += it.optString(i)
+              }
+              identityKeysCsv = keys.joinToString(separator = ",")
+            }
           }
-          ResponseData(state, hash, accountId, token, regionCode, attributeMappings)
+          ResponseData(state, hash, accountId, token, regionCode, attributeMappings, identityKeysCsv)
         } else {
           ResponseData(state, hash)
         }

--- a/AndroidSDKCore/src/main/java/com/leanplum/migration/model/MigrationConfig.kt
+++ b/AndroidSDKCore/src/main/java/com/leanplum/migration/model/MigrationConfig.kt
@@ -53,6 +53,16 @@ object MigrationConfig {
       return field
     }
 
+  private var identityKeysCsv: String? by StringPreferenceNullable(key = "ct_identity_keys")
+  var identityList: List<String>? = null
+    private set
+    get() {
+      if (field == null) {
+        field = identityKeysCsv?.split(",") ?: listOf("Identity")
+      }
+      return field
+    }
+
   var trackGooglePlayPurchases = true
     private set
 
@@ -67,6 +77,10 @@ object MigrationConfig {
     accountRegion = data.regionCode
     attributeMappings = data.attributeMappings.also {
       attributeMap = null
+    }
+    data.identityKeysCsv?.also { // remove question sign if you want a resettable value from server
+      identityKeysCsv = it
+      identityList = null
     }
   }
 

--- a/AndroidSDKCore/src/main/java/com/leanplum/migration/model/ResponseData.kt
+++ b/AndroidSDKCore/src/main/java/com/leanplum/migration/model/ResponseData.kt
@@ -28,4 +28,5 @@ data class ResponseData(
   val token: String? = null,
   val regionCode: String? = null,
   val attributeMappings: String? = null,
+  val identityKeysCsv: String? = null,
 )

--- a/AndroidSDKCore/src/main/java/com/leanplum/migration/wrapper/CTWrapper.kt
+++ b/AndroidSDKCore/src/main/java/com/leanplum/migration/wrapper/CTWrapper.kt
@@ -21,6 +21,7 @@
 
 package com.leanplum.migration.wrapper
 
+import android.annotation.SuppressLint
 import android.app.Application
 import android.content.Context
 import android.text.TextUtils
@@ -44,6 +45,7 @@ internal class CTWrapper(
   private val accountId: String,
   private val accountToken: String,
   private val accountRegion: String,
+  private val identityList: List<String>?,
   deviceId: String,
   userId: String?
 ) : IWrapper by StaticMethodsWrapper {
@@ -58,6 +60,7 @@ internal class CTWrapper(
   private var identityManager = IdentityManager(deviceId, userId ?: deviceId)
   private var firstTimeStart = identityManager.isFirstTimeStart()
 
+  @SuppressLint("WrongConstant")
   override fun launch(context: Context, callbacks: List<CleverTapInstanceCallback>) {
     instanceCallbackList.addAll(callbacks)
 
@@ -72,6 +75,9 @@ internal class CTWrapper(
       enableCustomCleverTapId = true
       debugLevel = ctLevel // set instance log level
       setLogLevel(lpLevel) // set static log level, arg needs to be Leanplum's level
+      identityList?.also { // setting IdentityKeys
+        setIdentityKeys(*it.toTypedArray())
+      }
     }
 
     val cleverTapId = identityManager.cleverTapId()

--- a/AndroidSDKCore/src/main/java/com/leanplum/migration/wrapper/WrapperFactory.kt
+++ b/AndroidSDKCore/src/main/java/com/leanplum/migration/wrapper/WrapperFactory.kt
@@ -59,7 +59,9 @@ internal object WrapperFactory {
       return StaticMethodsWrapper
     }
 
-    return CTWrapper(account, token, region, deviceId, userId).apply {
+    val identityList = MigrationConfig.identityList
+
+    return CTWrapper(account, token, region, identityList, deviceId, userId).apply {
       val timeToLaunch = measureTimeMillis {
         launch(context, callbacks)
       }


### PR DESCRIPTION
What              | Where/Who
------------------|----------------------------------------
JIRA Issue        | [SDK-2683](https://wizrocket.atlassian.net/browse/SDK-2683)
People Involved   | @hborisoff 

Identity keys are received with migration config and set in the CleverTap configuration.
Example of JSON containing identity keys:
```
{
    "ct" : {
        "accountId" : "accId",
        "attributeMappings" : ...,
        "identityKeys" : ["Identity", "Phone", "Email"]
    };
    ...
}
```
When value is not received in the migration config the current value is not reset, a new value must be received from server to replace the already saved.

Default value is "Identity".