### PR TITLE
Enable user for onRequestPermissionResult feedback

### DIFF
--- a/AndroidSDKCore/src/main/java/com/leanplum/utils/IntPreference.kt
+++ b/AndroidSDKCore/src/main/java/com/leanplum/utils/IntPreference.kt
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2023, Leanplum, Inc. All rights reserved.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.leanplum.utils
+
+import com.leanplum.Leanplum
+import kotlin.properties.ReadWriteProperty
+import kotlin.reflect.KProperty
+
+internal class IntPreference(
+  private val key: String,
+  private val defaultValue: Int
+) : ReadWriteProperty<Nothing?, Int> {
+
+  override fun getValue(thisRef: Nothing?, property: KProperty<*>): Int {
+    val prefs = Leanplum.getContext()?.getLeanplumPrefs() ?: return defaultValue
+    return prefs.getInt(key, defaultValue)
+  }
+
+  override fun setValue(thisRef: Nothing?, property: KProperty<*>, value: Int) {
+    val prefs = Leanplum.getContext()?.getLeanplumPrefs() ?: return
+    prefs.edit().putInt(key, value).apply()
+  }
+}

--- a/AndroidSDKCore/src/main/java/com/leanplum/utils/PushPermissionUtil.kt
+++ b/AndroidSDKCore/src/main/java/com/leanplum/utils/PushPermissionUtil.kt
@@ -24,17 +24,61 @@ package com.leanplum.utils
 import android.Manifest
 import android.annotation.TargetApi
 import android.app.Activity
+import android.content.Context
 import android.content.pm.PackageManager
 import androidx.core.app.ActivityCompat
 import androidx.core.app.NotificationManagerCompat
 import androidx.core.content.ContextCompat
+import com.leanplum.Leanplum
 import com.leanplum.internal.Log
+
+private const val DECLINE_LIMIT = 2
 
 /**
  * Could be changed by client if code is already in use. Request code can be used in activity's
- * onRequestPermissionsResult method to receive feedback whether the permission was granted or not.
+ * [onRequestPermissionResult] method to receive feedback whether the permission was granted or not.
  */
 var pushPermissionRequestCode = 1233321
+
+/**
+ * Decline count is tracked only when [onRequestPermissionResult] is invoked by client.
+ *
+ * Setting value of 2 would disable asking for push permission permanently.
+ * Setting value of 0 would ask for push permission again.
+ */
+var declineCount: Int by IntPreference(key = "push_permission_decline_count", defaultValue = 0)
+
+/**
+ * Invoke method from your activity's onRequestPermissionResult to allow Leanplum SDK to track the
+ * number of consecutive declines of the POST_NOTIFICATIONS permission. When two consecutive
+ * declines happen none of the permission dialogs will be shown again and user would have to
+ * manually allow notifications. Note that dismissing the native dialog without clicking on Allow or
+ * Don't Allow does count as a decline from OS API.
+ */
+fun onRequestPermissionResult(requestCode: Int,
+                              permissions: Array<String>,
+                              grantResults: IntArray
+) {
+  val context: Context? = Leanplum.getContext()
+  if (context == null || !BuildUtil.isPushPermissionSupported(context)) {
+    return
+  }
+
+  if (requestCode != pushPermissionRequestCode || permissions.size != grantResults.size) {
+    return
+  }
+
+  for (i in permissions.indices) {
+    if (permissions[i] == Manifest.permission.POST_NOTIFICATIONS) {
+      if (grantResults[i] == PackageManager.PERMISSION_GRANTED) {
+        declineCount = 0
+      } else {
+        declineCount++
+      }
+      break
+    }
+  }
+}
 
 @TargetApi(33)
 private fun isNotificationPermissionGranted(activity: Activity): Boolean {
@@ -53,13 +97,17 @@ fun shouldShowRegisterForPush(activity: Activity): Boolean {
 fun shouldShowPrePermission(activity: Activity): Boolean {
   return shouldShowRegisterForPush(activity)
       && ActivityCompat.shouldShowRequestPermissionRationale(activity, Manifest.permission.POST_NOTIFICATIONS)
+      && declineCount < DECLINE_LIMIT
 }
 
 @TargetApi(33)
 fun requestNativePermission(activity: Activity) {
-  activity.requestPermissions(
-    arrayOf(Manifest.permission.POST_NOTIFICATIONS),
-    pushPermissionRequestCode)
+  if (declineCount < DECLINE_LIMIT) {
+    activity.requestPermissions(
+      arrayOf(Manifest.permission.POST_NOTIFICATIONS),
+      pushPermissionRequestCode
+    )
+  }
 }
 
 fun printDebugLog(activity: Activity) {
@@ -73,7 +121,8 @@ fun printDebugLog(activity: Activity) {
 
     Log.d("Notification permission: granted=$permissionGranted " +
         "notificationsEnabled=$notificationsEnabled " +
-        "shouldShowRequestPermissionRationale=$shouldShowRequestPermissionRationale")
+        "shouldShowRequestPermissionRationale=$shouldShowRequestPermissionRationale " +
+        "declineCount=$declineCount")
   } else {
     Log.d("Notification permission: not supported by target or device version")
   }


### PR DESCRIPTION
What              | Where/Who
------------------|----------------------------------------
JIRA Issue        | [SDK-2828](https://wizrocket.atlassian.net/browse/SDK-2828)
People Involved   | @hborisoff 

## Background
A client reported that his activity `onPause` and `onResume` are getting executed when the `Push Pre-Permission` inapp is triggered even if the permission has been declined twice in a row.
The cause of the issue is the code that is requesting the permission, because the Leanplum SDK doesn't know whether the permission has been declined, neither the Android SDK provides such method. The only possible solution is to ask the user for input on his `onRequestPermissionResult`.

If user dismisses the native dialog without clicking `Allow` or `Don't Allow` button the system will return `PERMISSION_DENIED` in the `onRequestPermissionResult`.

User can call `PushPermissionUtilKt.onRequestPermissionResult` from his implementation of `onRequestPermissionResult` to give feedback in the SDK. He can also reset the `declineCounter` or directly set it as `2` to disable the permission request.