### PR TITLE
Push App Launched on first wrapper run

### DIFF
--- a/AndroidSDKCore/src/main/java/com/leanplum/migration/wrapper/CTWrapper.kt
+++ b/AndroidSDKCore/src/main/java/com/leanplum/migration/wrapper/CTWrapper.kt
@@ -100,6 +100,8 @@ internal class CTWrapper(
       Log.d("Wrapper: CleverTap instance created by Leanplum")
     }
     if (firstTimeStart) {
+      // Track App Launched event, because onResume of activity has been executed before first run
+      sendAppLaunchedEvent()
       // Send tokens in same session, because often a restart is needed for CT SDK to get them
       sendPushTokens(context)
     }
@@ -125,6 +127,13 @@ internal class CTWrapper(
 
   override fun removeInstanceCallback(callback: CleverTapInstanceCallback) {
     instanceCallbackList.remove(callback)
+  }
+
+  @SuppressLint("RestrictedApi")
+  private fun sendAppLaunchedEvent() {
+    cleverTapInstance?.coreState?.analyticsManager?.pushAppLaunchedEvent()?.also {
+      Log.d("Wrapper: app launched event sent")
+    }
   }
 
   private fun sendPushTokens(context: Context) {


### PR DESCRIPTION
What              | Where/Who
------------------|----------------------------------------
JIRA Issue        | [SDK-2959](https://wizrocket.atlassian.net/browse/SDK-2959)
People Involved   | @hborisoff 

Pushing App Launched event on the first run of the wrapper. Subsequent runs will track App Launched from the onResume of the activity in CT SDK.
It is possible that receiving a push notification, when client device is using the wrapper version, but hasn't started app even once, would trigger the migration and App Launched event will be tracked in that case too.