### PR TITLE
Allow only one activity lifecycle callback

### DIFF
--- a/AndroidSDKCore/src/main/java/com/leanplum/LeanplumActivityHelper.java
+++ b/AndroidSDKCore/src/main/java/com/leanplum/LeanplumActivityHelper.java
@@ -200,6 +200,11 @@ public class LeanplumActivityHelper {
    * Enables lifecycle callbacks for Android devices with Android OS &gt;= 4.0
    */
   public static void enableLifecycleCallbacks(final Application app) {
+    if (registeredCallbacks) {
+      // callback is already registered
+      return;
+    }
+
     Leanplum.setApplicationContext(app.getApplicationContext());
 
     if (BuildUtil.shouldDisableTrampolines(app)) {

--- a/AndroidSDKPush/src/main/java/com/leanplum/internal/PushActionPersistence.kt
+++ b/AndroidSDKPush/src/main/java/com/leanplum/internal/PushActionPersistence.kt
@@ -51,8 +51,14 @@ private fun save(records: Map<String, Long>) {
 }
 
 fun recordOpenAction(occurrenceId: String) {
-    records[occurrenceId] = Clock.getInstance().currentTimeMillis()
-    save(records)
+    synchronized(records) {
+        records[occurrenceId] = Clock.getInstance().currentTimeMillis()
+        save(records)
+    }
 }
 
-fun isOpened(occurrenceId: String) = records.contains(occurrenceId)
+fun isOpened(occurrenceId: String): Boolean {
+    synchronized(records) {
+        return records.contains(occurrenceId)
+    }
+}


### PR DESCRIPTION
What              | Where/Who
------------------|----------------------------------------
JIRA Issue        | [SDK-2974](https://wizrocket.atlassian.net/browse/SDK-2974)
People Involved   | @hborisoff 

Allow only one activity lifecycle callback, because registering multiple callbacks by mistake is causing more than one `Push Opened` event to be tracked on clicking of a push notification.

Synchronized the access to `PushActionPersistence`, because it is accessed by a parallel operation.