### PR TITLE
Update to Robolectric 4.12.2

### DIFF
--- a/AndroidSDKTests/build.gradle
+++ b/AndroidSDKTests/build.gradle
@@ -73,12 +73,8 @@ dependencies {
 
     // Dependencies used for unit tests.
     testImplementation 'junit:junit:4.13'
-    testImplementation('org.robolectric:robolectric:4.7.3') {
-        exclude group: 'commons-logging', module: 'commons-logging'
-        exclude group: 'org.apache.httpcomponents', module: 'httpclient'
-    }
+    testImplementation 'org.robolectric:robolectric:4.12.2'
     testImplementation 'commons-io:commons-io:2.16.1'
-    testImplementation 'org.robolectric:shadows-play-services:3.3.2'
     testImplementation 'org.mockito:mockito-core:1.10.19'
     testImplementation 'org.powermock:powermock-module-junit4:1.6.5'
     testImplementation 'org.powermock:powermock-module-junit4-rule:1.6.5'

--- a/AndroidSDKTests/src/test/java/com/leanplum/LeanplumActionContextTest.java
+++ b/AndroidSDKTests/src/test/java/com/leanplum/LeanplumActionContextTest.java
@@ -36,8 +36,6 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.robolectric.RuntimeEnvironment;
 
-import java.io.InputStream;
-import java.lang.reflect.Method;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -51,7 +49,6 @@ import static org.mockito.Matchers.eq;
 import static org.mockito.Matchers.isNull;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
-import static org.powermock.api.mockito.PowerMockito.doReturn;
 import static org.powermock.api.mockito.PowerMockito.spy;
 import static org.powermock.api.mockito.PowerMockito.verifyStatic;
 
@@ -185,7 +182,7 @@ public class LeanplumActionContextTest extends AbstractTest {
 
         actionContext.muteFutureMessagesOfSameKind();
 
-        SharedPreferences preferences = RuntimeEnvironment.application.getSharedPreferences(
+        SharedPreferences preferences = RuntimeEnvironment.getApplication().getSharedPreferences(
             Defaults.MESSAGING_PREF_NAME, Context.MODE_PRIVATE);
         boolean muted = preferences.getBoolean(String.format(Constants.Defaults.MESSAGE_MUTED_KEY,
                 "messageId"), false);

--- a/AndroidSDKTests/src/test/java/com/leanplum/LeanplumCloudMessagingProviderTest.java
+++ b/AndroidSDKTests/src/test/java/com/leanplum/LeanplumCloudMessagingProviderTest.java
@@ -84,7 +84,7 @@ public class LeanplumCloudMessagingProviderTest {
   public void setUp() {
     spy(LeanplumCloudMessagingProvider.class);
 
-    this.context = RuntimeEnvironment.application;
+    this.context = RuntimeEnvironment.getApplication();
     assertNotNull(this.context);
     Leanplum.setApplicationContext(this.context);
   }
@@ -99,7 +99,7 @@ public class LeanplumCloudMessagingProviderTest {
   public void testOnRegistrationIdReceived() throws Exception {
     mockStatic(Leanplum.class);
     mockStatic(SharedPreferencesUtil.class);
-    when(Leanplum.class, "getContext").thenReturn(RuntimeEnvironment.application);
+    when(Leanplum.class, "getContext").thenReturn(context);
     String propertyName = "propertyName";
 
     LeanplumCloudMessagingProvider cloudMessagingProvider = new LeanplumCloudMessagingProvider() {

--- a/AndroidSDKTests/src/test/java/com/leanplum/LeanplumInflaterTest.java
+++ b/AndroidSDKTests/src/test/java/com/leanplum/LeanplumInflaterTest.java
@@ -40,7 +40,7 @@ public class LeanplumInflaterTest extends AbstractTest {
    */
   @Test
   public void testInflater() {
-    LeanplumInflater inflater = LeanplumInflater.from(RuntimeEnvironment.application.getApplicationContext());
+    LeanplumInflater inflater = LeanplumInflater.from(RuntimeEnvironment.getApplication().getApplicationContext());
     assertNotNull(inflater);
     assertNotNull(inflater.getLeanplumResources());
   }
@@ -50,7 +50,7 @@ public class LeanplumInflaterTest extends AbstractTest {
    */
   @Test
   public void testInflate() {
-    LeanplumInflater inflater = LeanplumInflater.from(RuntimeEnvironment.application.getApplicationContext());
+    LeanplumInflater inflater = LeanplumInflater.from(RuntimeEnvironment.getApplication().getApplicationContext());
     View root = inflater.inflate(R.layout.activity_main);
     assertNotNull(root);
   }

--- a/AndroidSDKTests/src/test/java/com/leanplum/LeanplumNotificationChannelTests.java
+++ b/AndroidSDKTests/src/test/java/com/leanplum/LeanplumNotificationChannelTests.java
@@ -171,8 +171,7 @@ public class LeanplumNotificationChannelTests extends AbstractTest {
     assertNotNull(notificationGroups);
 
     assertEquals(2, notificationChannels.size());
-    // Uncomment when robolectric fixes notification group deletion.
-    // assertEquals(2, notificationGroups.size());
+    assertEquals(2, notificationGroups.size());
   }
 
   @Test

--- a/AndroidSDKTests/src/test/java/com/leanplum/LeanplumPushServiceTest.java
+++ b/AndroidSDKTests/src/test/java/com/leanplum/LeanplumPushServiceTest.java
@@ -26,9 +26,7 @@ import android.app.NotificationManager;
 import android.content.Context;
 import android.content.Intent;
 import android.net.Uri;
-import android.os.Build;
 import android.os.Bundle;
-import android.text.TextUtils;
 import androidx.annotation.Nullable;
 import androidx.core.app.NotificationCompat;
 
@@ -60,7 +58,6 @@ import org.robolectric.annotation.Config;
 
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
-import java.lang.reflect.Modifier;
 import java.util.Map;
 import java.util.Queue;
 
@@ -68,20 +65,15 @@ import static junit.framework.Assert.assertEquals;
 import static junit.framework.Assert.assertFalse;
 import static junit.framework.Assert.assertNotNull;
 import static junit.framework.Assert.assertNull;
-import static junit.framework.Assert.assertSame;
 import static junit.framework.Assert.assertTrue;
 import static org.mockito.Matchers.any;
-import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.powermock.api.mockito.PowerMockito.doNothing;
 import static org.powermock.api.mockito.PowerMockito.mockStatic;
 import static org.powermock.api.mockito.PowerMockito.spy;
-import static org.powermock.api.mockito.PowerMockito.verifyPrivate;
-import static org.powermock.api.mockito.PowerMockito.verifyStatic;
 import static org.powermock.api.mockito.PowerMockito.when;
-import static org.powermock.api.mockito.PowerMockito.whenNew;
 import static org.robolectric.Shadows.shadowOf;
 
 /**
@@ -125,7 +117,7 @@ public class LeanplumPushServiceTest {
 
     when(Util.hasPlayServices()).thenReturn(true);
 
-    this.context = RuntimeEnvironment.application;
+    this.context = RuntimeEnvironment.getApplication();
     assertNotNull(this.context);
     Leanplum.setApplicationContext(this.context);
 
@@ -249,10 +241,10 @@ public class LeanplumPushServiceTest {
     bundle.putString("_lpm", "message_id");
     bundle.putString("title", "title_string");
     bundle.putString(Constants.Keys.PUSH_MESSAGE_TEXT, "message_text");
-    LeanplumPushService.handleNotification(RuntimeEnvironment.application.getApplicationContext(), bundle);
+    LeanplumPushService.handleNotification(context.getApplicationContext(), bundle);
 
     NotificationManager notificationManager = (NotificationManager)
-        RuntimeEnvironment.application.getSystemService(Context.NOTIFICATION_SERVICE);
+        context.getSystemService(Context.NOTIFICATION_SERVICE);
     assertEquals(1, shadowOf(notificationManager).size());
   }
 

--- a/AndroidSDKTests/src/test/java/com/leanplum/LeanplumTest.java
+++ b/AndroidSDKTests/src/test/java/com/leanplum/LeanplumTest.java
@@ -87,7 +87,6 @@ import static org.junit.Assert.fail;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyDouble;
 import static org.mockito.Matchers.anyInt;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.when;
@@ -845,7 +844,7 @@ public class LeanplumTest extends AbstractTest {
 
   @Test
   public void testAdvance() throws Exception {
-    setupSDK(RuntimeEnvironment.application, "/responses/simple_start_response.json");
+    setupSDK(RuntimeEnvironment.getApplication(), "/responses/simple_start_response.json");
 
     // Setup state values.
     final String stateName = "test_state_name";

--- a/AndroidSDKTests/src/test/java/com/leanplum/__setup/AbstractTest.java
+++ b/AndroidSDKTests/src/test/java/com/leanplum/__setup/AbstractTest.java
@@ -49,7 +49,6 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.runner.RunWith;
-import org.mockito.Mockito;
 import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.core.classloader.annotations.PrepareForTest;
@@ -58,7 +57,6 @@ import org.robolectric.RobolectricTestRunner;
 import org.robolectric.RuntimeEnvironment;
 import org.robolectric.annotation.Config;
 import org.robolectric.shadows.ShadowLog;
-import org.robolectric.shadows.ShadowLooper;
 import org.robolectric.util.ReflectionHelpers;
 
 import java.io.ByteArrayOutputStream;
@@ -85,10 +83,7 @@ import static org.powermock.api.mockito.PowerMockito.whenNew;
 @Config(
     sdk = 19,
     application = LeanplumTestApp.class,
-    packageName = "com.leanplum.tests",
-    shadows = {
-        ShadowLooper.class,
-    }
+    packageName = "com.leanplum.tests"
 )
 @PowerMockIgnore({
     "org.mockito.*",
@@ -135,7 +130,7 @@ public abstract class AbstractTest {
 
     ReflectionHelpers.setStaticField(LeanplumEventDataManager.class, "instance", null);
     // Get and set application context.
-    mContext = RuntimeEnvironment.application;
+    mContext = RuntimeEnvironment.getApplication();
     Leanplum.setApplicationContext(mContext);
 
     // Display logs in console.

--- a/AndroidSDKTests/src/test/java/com/leanplum/_whitebox/InAppMessagePrioritizationTest.java
+++ b/AndroidSDKTests/src/test/java/com/leanplum/_whitebox/InAppMessagePrioritizationTest.java
@@ -141,7 +141,7 @@ public class InAppMessagePrioritizationTest extends AbstractTest {
    */
   @Test
   public void testSingleMessage() throws Exception {
-    Assert.assertNotNull(RuntimeEnvironment.application); //Getting the application context
+    Assert.assertNotNull(RuntimeEnvironment.getApplication()); //Getting the application context
     InputStream inputStream = getClass().getResourceAsStream("/test_files/single_message.json");
     Assert.assertNotNull(inputStream);
     String jsonMessages = IOUtils.toString(inputStream);

--- a/AndroidSDKTests/src/test/java/com/leanplum/internal/AESCryptTest.java
+++ b/AndroidSDKTests/src/test/java/com/leanplum/internal/AESCryptTest.java
@@ -101,7 +101,7 @@ public class AESCryptTest {
   public void setUp() {
     Provider provider = new org.bouncycastle.jce.provider.BouncyCastleProvider();
     Security.addProvider(provider);
-    preferences = RuntimeEnvironment.application.getSharedPreferences("__leanplum__",
+    preferences = RuntimeEnvironment.getApplication().getSharedPreferences("__leanplum__",
         Context.MODE_PRIVATE);
   }
 

--- a/AndroidSDKTests/src/test/java/com/leanplum/internal/LeanplumEventDataManagerTest.java
+++ b/AndroidSDKTests/src/test/java/com/leanplum/internal/LeanplumEventDataManagerTest.java
@@ -60,7 +60,7 @@ public class LeanplumEventDataManagerTest {
    */
   @Before
   public void setUp() throws Exception {
-    this.mContext = RuntimeEnvironment.application;
+    this.mContext = RuntimeEnvironment.getApplication();
     assertNotNull(this.mContext);
     Leanplum.setApplicationContext(this.mContext);
 

--- a/AndroidSDKTests/src/test/java/com/leanplum/internal/RequestBatchFactoryTest.java
+++ b/AndroidSDKTests/src/test/java/com/leanplum/internal/RequestBatchFactoryTest.java
@@ -50,10 +50,7 @@ import org.robolectric.util.ReflectionHelpers;
 @RunWith(RobolectricTestRunner.class)
 @Config(
     sdk = 19,
-    application = LeanplumTestApp.class,
-    shadows = {
-        ShadowLooper.class,
-    }
+    application = LeanplumTestApp.class
 )
 @LooperMode(LooperMode.Mode.LEGACY)
 @PowerMockIgnore({
@@ -67,7 +64,7 @@ public class RequestBatchFactoryTest {
 
   @Before
   public void setUp() throws Exception {
-    Application context = RuntimeEnvironment.application;
+    Application context = RuntimeEnvironment.getApplication();
     assertNotNull(context);
 
     Leanplum.setApplicationContext(context);

--- a/AndroidSDKTests/src/test/java/com/leanplum/internal/RequestSenderTest.java
+++ b/AndroidSDKTests/src/test/java/com/leanplum/internal/RequestSenderTest.java
@@ -52,10 +52,7 @@ import java.util.concurrent.Semaphore;
 @RunWith(RobolectricTestRunner.class)
 @Config(
         sdk = 19,
-        application = LeanplumTestApp.class,
-        shadows = {
-                ShadowLooper.class,
-        }
+        application = LeanplumTestApp.class
 )
 @LooperMode(LooperMode.Mode.LEGACY)
 @PowerMockIgnore({
@@ -72,7 +69,7 @@ public class RequestSenderTest extends TestCase {
    */
   @Before
   public void setUp() throws Exception {
-    Application context = RuntimeEnvironment.application;
+    Application context = RuntimeEnvironment.getApplication();
     assertNotNull(context);
 
     Leanplum.setApplicationContext(context);

--- a/AndroidSDKTests/src/test/java/com/leanplum/internal/RequestUtilTest.java
+++ b/AndroidSDKTests/src/test/java/com/leanplum/internal/RequestUtilTest.java
@@ -39,7 +39,7 @@ public class RequestUtilTest extends TestCase {
      */
     @Before
     public void setUp() throws Exception {
-        Application context = RuntimeEnvironment.application;
+        Application context = RuntimeEnvironment.getApplication();
         assertNotNull(context);
         Leanplum.setApplicationContext(context);
 

--- a/AndroidSDKTests/src/test/java/com/leanplum/internal/SocketIOClientTest.java
+++ b/AndroidSDKTests/src/test/java/com/leanplum/internal/SocketIOClientTest.java
@@ -93,7 +93,7 @@ public class SocketIOClientTest {
    */
   @Test
   public void testUserAgentString() throws Exception {
-    Application context = RuntimeEnvironment.application;
+    Application context = RuntimeEnvironment.getApplication();
     Assert.assertNotNull(context);
     Leanplum.setApplicationContext(context);
 
@@ -134,7 +134,7 @@ public class SocketIOClientTest {
     when(Util.class, "getApplicationName", Matchers.any(Context.class)).thenReturn("app_name");
 
     // Test with a non-null Context.
-    doReturn(RuntimeEnvironment.application).when(Leanplum.class, "getContext");
+    doReturn(RuntimeEnvironment.getApplication()).when(Leanplum.class, "getContext");
     assertEquals("app_name/app_version(app_id; android; 1/s)",
         (String) userAgentStringMethod.invoke(socketIOClient));
 

--- a/AndroidSDKTests/src/test/java/com/leanplum/utils/BitmapUtilTest.java
+++ b/AndroidSDKTests/src/test/java/com/leanplum/utils/BitmapUtilTest.java
@@ -51,7 +51,6 @@ import static junit.framework.Assert.assertNotNull;
 import static junit.framework.Assert.assertNull;
 import static junit.framework.Assert.assertTrue;
 import static org.powermock.api.mockito.PowerMockito.spy;
-import static org.powermock.api.mockito.PowerMockito.when;
 
 /**
  * Tests for {@link BitmapUtil} class.
@@ -85,7 +84,7 @@ public class BitmapUtilTest {
   public void setUp() {
     spy(BitmapUtil.class);
 
-    this.context = RuntimeEnvironment.application;
+    this.context = RuntimeEnvironment.getApplication();
     assertNotNull(this.context);
     Leanplum.setApplicationContext(this.context);
   }


### PR DESCRIPTION
## Background

This PR updates Robolectric to version 4.12.2. This is the latest version to support API 19.

## Implementation

- Remove unnecessary shadows declaration in `@Config`.
- Replace deprecated `RuntimeEnvironment.application` with `RuntimeEnvironment.getApplication()`.
- Remove `org.robolectric:shadows-play-services` since it's not needed.
- Remove some unused imports.

## Testing steps

Ran tests locally successfully

## Is this change backwards-compatible?

Yes.